### PR TITLE
feat: add RAG semantic search, file watcher, and smart search routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .cartog.db
+.fastembed_cache/
 .ruff_cache/
 __pycache__/
 benchmarks/results/*.jsonl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,21 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -22,6 +30,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -74,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -85,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,9 +122,27 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -122,10 +160,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -140,11 +193,16 @@ dependencies = [
  "anyhow",
  "clap",
  "criterion",
+ "ctrlc",
+ "fastembed",
+ "notify",
+ "notify-debouncer-mini",
  "rmcp",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
+ "sqlite-vec",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -165,6 +223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +246,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -268,6 +341,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,7 +424,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -315,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -360,13 +490,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -385,12 +550,73 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -402,6 +628,50 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -417,6 +687,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,16 +736,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastembed"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4339d45a80579ab8305616a501eacdbf18fb0f7def7fa6e4c0b75941416d5b0"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -539,6 +934,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,12 +1009,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -578,6 +1050,151 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ureq 2.12.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -604,10 +1221,188 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -617,7 +1412,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -631,6 +1426,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -652,16 +1456,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -675,10 +1516,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matchers"
@@ -690,10 +1565,170 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa5a66d07ed97dce782be94dcf5ab4d1b457f4243f7566c7557f15cabc8c799"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -701,7 +1736,25 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -712,6 +1765,27 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -726,10 +1800,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq 3.2.0",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq 3.2.0",
+]
 
 [[package]]
 name = "paste"
@@ -738,10 +1908,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -778,6 +1969,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +2030,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +2081,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +2099,26 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -865,12 +2171,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rmcp"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2faf35b7d3c4b7f8c21c45bb014011b32a0ce6444bf6094da04daab01a8c3c34"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "paste",
@@ -891,7 +2254,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9720d9d2a943779f1dc3d47fa9072c7eeffaff4e1a82f67eb9f7ea52696091"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -904,12 +2267,60 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -919,12 +2330,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -952,6 +2389,35 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1008,6 +2474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +2512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +2528,60 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec77b84fb8dd5f0f8def127226db83b5d1152c5bf367f09af03998b76ba554a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -1058,6 +2596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +2610,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1098,6 +2696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,14 +2716,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1130,6 +2775,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +2806,51 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1283,6 +2993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +3009,119 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1329,6 +3158,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +3201,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1374,6 +3250,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,13 +3307,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1434,6 +3416,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,11 +3446,284 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1474,6 +3740,66 @@ name = "zerocopy-derive"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,19 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 walkdir = "2"
 sha2 = "0.10"
+notify = "7"
+notify-debouncer-mini = "0.5"
+ctrlc = "3"
 anyhow = "1"
 rmcp = { version = "0.5", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+# RAG pipeline: semantic code search (ONNX Runtime via fastembed)
+# default-features=false drops image-models (image embedding support we don't use)
+fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-native-tls", "hf-hub-native-tls"] }
+sqlite-vec = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Julien Rollin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check check-rust check-fixtures check-py check-ts check-go check-rs check-rb bench bench-criterion
+.PHONY: check check-rust check-fixtures check-py check-ts check-go check-rs check-rb bench bench-criterion bench-rag
 
 # --- Full integrity check ---
 
@@ -47,3 +47,8 @@ bench: ## Run shell benchmark suite (all scenarios, all fixtures)
 
 bench-criterion: ## Run Rust criterion benchmarks (query latency)
 	cargo bench --bench queries
+
+bench-rag: ## Run RAG relevancy benchmarks (in-memory + shell scenario 13)
+	cargo test --test rag_relevancy -- --nocapture
+	cargo build --release
+	CARTOG=$(CURDIR)/target/release/cartog ./benchmarks/run.sh --scenario 13

--- a/README.md
+++ b/README.md
@@ -9,32 +9,52 @@
 
 **Map your codebase. Navigate by graph, not grep.**
 
-Your AI coding agent wastes context re-discovering code structure with grep and cat on every task. cartog pre-computes the code graph — symbols, calls, imports, inheritance — so agents query structure in 2-3 calls instead of 6+, using 6x fewer tokens with complete coverage.
+cartog gives your AI coding agent a pre-computed code graph — symbols, calls, imports, inheritance — so it queries structure in 1-2 calls instead of 6+. Everything runs locally: no API calls, no cloud, no data leaves your machine.
 
-## Benchmarks
+## Why cartog
 
-Measured across 12 scenarios, 5 languages ([full benchmark suite](benchmarks/)):
-
-| | grep/cat | cartog | Improvement |
-|---|---:|---:|---|
-| **Tokens per query** | ~1,700 | ~280 | **83% fewer tokens** |
-| **Recall** (completeness) | 78% | 97% | **finds what grep misses** |
-| **Query latency** | n/a (multi-step) | 8-450 us | **instant** |
+| | grep/cat workflow | cartog |
+|---|---|---|
+| **Tokens per query** | ~1,700 | ~280 (**83% fewer**) |
+| **Recall** (completeness) | 78% | 97% |
+| **Query latency** | multi-step | 8-450 us |
+| **Privacy** | n/a | **100% local** — no remote calls |
+| **Transitive analysis** | impossible | `impact --depth 3` traces callers-of-callers |
 
 Where cartog shines most: tracing call chains (88% token reduction, 35% grep recall vs 100% cartog), finding callers (95% reduction), and type references (93% reduction).
+
+Measured across 13 scenarios, 5 languages ([full benchmark suite](benchmarks/)).
+
+### What you get immediately
+
+- **Single binary, self-contained** — `cargo install cartog` and you're done. No language server, no Docker, no config.
+- **100% offline** — tree-sitter parsing + SQLite storage + ONNX embeddings. Your code never leaves your machine, ever.
+- **Smart search routing** — keyword search (sub-ms, symbol names) and semantic search (natural language queries) work together. Run both in parallel when unsure.
+- **Live index** — `cartog watch` auto re-indexes on file changes. Your agent always queries fresh data.
+- **MCP server** — `cartog serve` exposes 11 tools over stdio. Plug into Claude Code, Cursor, Windsurf, Zed, or any MCP-compatible agent.
 
 ![cartog demo](docs/demo.gif)
 
 ## Quick Start
 
 ```bash
-cargo install cartog        # or download a pre-built binary (see below)
+cargo install cartog
 cd your-project
 cartog index .               # build the graph (~95ms for 4k LOC, incremental)
-cartog search validate       # find symbols by name
+cartog search validate       # find symbols by name (sub-millisecond)
 cartog refs validate_token   # who calls/imports/references this?
 cartog impact validate_token # what breaks if I change this?
 ```
+
+### Add semantic search (optional, still fully local)
+
+```bash
+cartog rag setup             # download embedding + re-ranker models (~50MB, one-time)
+cartog rag index .           # embed all symbols into sqlite-vec
+cartog rag search "authentication token validation"   # natural language queries
+```
+
+Models are downloaded once to `~/.cache/cartog/models/` and run locally via ONNX Runtime. No API keys, no network calls at query time.
 
 ## Install
 
@@ -68,12 +88,44 @@ sudo mv cartog /usr/local/bin/
 # Windows (x86_64) — download .zip from releases page
 ```
 
+## Search: Keyword, Semantic, or Both
+
+cartog offers two search modes that complement each other:
+
+| Query type | Command | Speed | Best for |
+|---|---|---|---|
+| Symbol name / partial name | `cartog search parse` | sub-ms | You know the name: `validate_token`, `AuthService` |
+| Natural language / concept | `cartog rag search "error handling"` | ~150-500ms | You know the behavior, not the name |
+| Broad keyword, unsure | Run both in parallel | sub-ms + ~300ms | `auth`, `config` — catch names + semantics |
+
+**Narrowing pattern**: `cartog search parse` returns 30 hits? Narrow with `cartog rag search "parse JSON response body"` to pinpoint the right ones.
+
+```bash
+# Direct keyword search — fast, exact
+cartog search validate_token
+cartog search parse --kind function --limit 10
+
+# Semantic search — natural language, conceptual
+cartog rag search "database connection pooling"
+cartog rag search "error handling" --kind function
+
+# Both in parallel when unsure
+cartog search auth & cartog rag search "authentication and authorization"
+```
+
 ## Commands
 
 ```bash
-cartog index .                              # Build the graph
+# Index
+cartog index .                              # Build the graph (incremental)
+cartog index . --force                      # Re-index all files
+
+# Search
 cartog search validate                      # Find symbols by partial name
 cartog search validate --kind function      # Filter by kind
+cartog rag search "token validation"        # Semantic search (natural language)
+
+# Navigate
 cartog outline src/auth/tokens.py           # File structure without reading it
 cartog refs validate_token                  # Who references this? (calls, imports, inherits, types)
 cartog refs validate_token --kind calls     # Filter: only call sites
@@ -82,6 +134,15 @@ cartog impact SessionManager --depth 3      # What breaks if I change this?
 cartog hierarchy BaseService                # Inheritance tree
 cartog deps src/routes/auth.py              # File-level imports
 cartog stats                                # Index summary
+
+# Watch (auto re-index on file changes)
+cartog watch .                              # Watch for changes, re-index automatically
+cartog watch . --rag                        # Also re-embed symbols (deferred)
+
+# MCP Server
+cartog serve                                # MCP server over stdio (11 tools)
+cartog serve --watch                        # With background file watcher
+cartog serve --watch --rag                  # Watcher + deferred RAG embedding
 ```
 
 All commands support `--json` for structured output.
@@ -144,22 +205,30 @@ graph LR
     A["Source files<br/>(py, ts, rs, go, rb)"] -->|tree-sitter| B["Symbols + Edges"]
     B -->|write| C[".cartog.db<br/>(SQLite)"]
     C -->|query| D["search / refs / impact<br/>outline / callees / hierarchy"]
+    C -->|embed locally| E["ONNX embeddings<br/>(sqlite-vec)"]
+    E -->|query| F["rag search<br/>(FTS5 + vector KNN + reranker)"]
 ```
 
 1. **Index** — walks your project, parses each file with tree-sitter, extracts symbols (functions, classes, methods, imports, variables) and edges (calls, imports, inherits, raises, type references)
 2. **Store** — writes everything to a local `.cartog.db` SQLite file
 3. **Resolve** — links edges by name with scope-aware heuristic matching (same file > same directory > unique project match)
-4. **Query** — instant lookups against the pre-computed graph
+4. **Embed** (optional) — generates vector embeddings locally with ONNX Runtime (`BAAI/bge-small-en-v1.5`), stored in sqlite-vec
+5. **Query** — instant lookups against the pre-computed graph, hybrid FTS5 + vector search with RRF merge and cross-encoder re-ranking
 
-Re-indexing is incremental: only files with changed content hashes are re-parsed.
+Re-indexing is incremental: only files with changed content hashes are re-parsed. `cartog watch` automates this on file changes.
+
+**Everything runs on your machine.** No API keys. No cloud endpoints. No telemetry. Your code stays local.
 
 ## MCP Server
 
-cartog can run as an [MCP](https://modelcontextprotocol.io/) server, exposing all 9 tools over stdio with zero context cost.
+cartog runs as an [MCP](https://modelcontextprotocol.io/) server, exposing 11 tools (9 core + 2 RAG) over stdio.
 
 ```bash
 # Claude Code
 claude mcp add cartog -- cartog serve
+
+# With live re-indexing
+claude mcp add cartog -- cartog serve --watch --rag
 
 # Cursor — add to .cursor/mcp.json
 # Windsurf — add to ~/.codeium/windsurf/mcp_config.json
@@ -174,7 +243,7 @@ Common config (JSON):
   "mcpServers": {
     "cartog": {
       "command": "cartog",
-      "args": ["serve"]
+      "args": ["serve", "--watch", "--rag"]
     }
   }
 }
@@ -196,13 +265,26 @@ Or install manually:
 cp -r skills/cartog ~/.claude/skills/
 ```
 
-The skill teaches your AI agent to use cartog for code navigation instead of grep/cat. See [Claude Code Integration](docs/claude-code.md) for details.
+The skill teaches your AI agent **when and how** to use cartog — including smart search routing (keyword vs semantic vs parallel), refactoring workflows, and when to fall back to grep. See [Claude Code Integration](docs/claude-code.md) for details.
+
+## Privacy
+
+cartog is designed for air-gapped and privacy-conscious environments:
+
+- **Parsing**: tree-sitter runs in-process, no external calls
+- **Storage**: SQLite file in your project directory (`.cartog.db`)
+- **Embeddings**: ONNX Runtime inference, models cached locally (`~/.cache/cartog/models/`)
+- **Re-ranking**: cross-encoder runs locally via ONNX, no API
+- **MCP server**: communicates over stdio only, no network sockets
+- **No telemetry**, no analytics, no phone-home of any kind
+
+Your code never leaves your machine. Not during indexing, not during search, not ever.
 
 ## Supported Languages
 
 | Language | Extensions | Symbols | Edges |
 |----------|-----------|---------|-------|
-| Python | .py | functions, classes, methods, imports, variables | calls, imports, inherits, raises, type refs |
+| Python | .py, .pyi | functions, classes, methods, imports, variables | calls, imports, inherits, raises, type refs |
 | TypeScript | .ts, .tsx | functions, classes, methods, imports, variables | calls, imports, inherits, type refs, new |
 | JavaScript | .js, .jsx, .mjs, .cjs | functions, classes, methods, imports, variables | calls, imports, inherits, new |
 | Rust | .rs | functions, structs, traits, impls, imports | calls, imports, inherits (trait impl), type refs |
@@ -230,8 +312,9 @@ Query latency (criterion benchmarks on the same fixture):
 ## Design Trade-offs
 
 - **Structural, not semantic** — name-based resolution (~90% accuracy), not full type analysis. Good enough for navigation; LSP can be layered on later.
-- **Zero dependencies** — single binary + SQLite file. No language server, no embedding model, no graph DB.
+- **Self-contained** — single binary, all dependencies compiled in. No language server, no cloud service, no separate database process.
 - **Incremental** — SHA256 hash per file, only re-indexes what changed.
+- **Local-first** — embedding models run via ONNX Runtime on your CPU. Slower than API calls, but your code stays private.
 
 ## Documentation
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -40,11 +40,12 @@ All fixtures model the same domain (auth service, tokens, routes, middleware, da
 | 10 | "High-fanout: who uses get_logger?" | `refs` (precise call sites) vs grep (every mention) |
 | 11 | "Deep call chain (5+ hops)" | Sequential `callees` x6 vs 6 grep rounds with noise |
 | 12 | "Deep impact at depth 5" | `impact --depth 5` (transitive BFS) vs flat grep |
+| 13 | "Find authentication logic" | `rag search` (FTS5 + vector KNN + reranker) vs grep keywords |
 
 ## Usage
 
 ```bash
-# Run all scenarios (01-12) across all 5 languages
+# Run all scenarios (01-13) across all 5 languages
 ./benchmarks/run.sh
 
 # Run single scenario

--- a/benchmarks/ground_truth/webapp_go.json
+++ b/benchmarks/ground_truth/webapp_go.json
@@ -490,6 +490,19 @@
       }
     ]
   },
+  "13_rag_search": {
+    "description": "Semantic search: validate token",
+    "query": "rag search \"validate token\"",
+    "expected": [
+      { "name": "ValidateToken" },
+      { "name": "TokenError" },
+      { "name": "ExpiredTokenError" },
+      { "name": "ExtractToken" },
+      { "name": "GenerateToken" },
+      { "name": "RefreshToken" },
+      { "name": "ValidationError" }
+    ]
+  },
   "12_deep_impact": {
     "description": "Deep impact of DatabaseConnection (depth 5)",
     "query": "impact DatabaseConnection --depth 5",

--- a/benchmarks/ground_truth/webapp_py.json
+++ b/benchmarks/ground_truth/webapp_py.json
@@ -668,6 +668,20 @@
       }
     ]
   },
+  "13_rag_search": {
+    "description": "Semantic search: validate token",
+    "query": "rag search \"validate token\"",
+    "expected": [
+      { "name": "validate_token" },
+      { "name": "verify_token" },
+      { "name": "TokenError" },
+      { "name": "ExpiredTokenError" },
+      { "name": "extract_token" },
+      { "name": "generate_token" },
+      { "name": "refresh_token" },
+      { "name": "ValidationError" }
+    ]
+  },
   "12_deep_impact": {
     "description": "Deep impact of DatabaseConnection (depth 5)",
     "query": "impact DatabaseConnection --depth 5",

--- a/benchmarks/ground_truth/webapp_rb.json
+++ b/benchmarks/ground_truth/webapp_rb.json
@@ -608,6 +608,19 @@
       }
     ]
   },
+  "13_rag_search": {
+    "description": "Semantic search: validate token",
+    "query": "rag search \"validate token\"",
+    "expected": [
+      { "name": "validate_token" },
+      { "name": "verify_token" },
+      { "name": "TokenError" },
+      { "name": "ExpiredTokenError" },
+      { "name": "extract_token" },
+      { "name": "generate_token" },
+      { "name": "refresh_token" }
+    ]
+  },
   "12_deep_impact": {
     "description": "Deep impact of DatabaseConnection (depth 5)",
     "query": "impact DatabaseConnection --depth 5",

--- a/benchmarks/ground_truth/webapp_rs.json
+++ b/benchmarks/ground_truth/webapp_rs.json
@@ -695,6 +695,20 @@
       }
     ]
   },
+  "13_rag_search": {
+    "description": "Semantic search: validate token",
+    "query": "rag search \"validate token\"",
+    "expected": [
+      { "name": "validate_token" },
+      { "name": "verify_token" },
+      { "name": "TokenError" },
+      { "name": "ExpiredTokenError" },
+      { "name": "Token" },
+      { "name": "extract_token" },
+      { "name": "generate_token" },
+      { "name": "refresh_token" }
+    ]
+  },
   "12_deep_impact": {
     "description": "Deep impact of DatabaseConnection (depth 5)",
     "query": "impact DatabaseConnection --depth 5",

--- a/benchmarks/ground_truth/webapp_ts.json
+++ b/benchmarks/ground_truth/webapp_ts.json
@@ -666,6 +666,20 @@
       }
     ]
   },
+  "13_rag_search": {
+    "description": "Semantic search: validate token",
+    "query": "rag search \"validate token\"",
+    "expected": [
+      { "name": "validateToken" },
+      { "name": "verifyToken" },
+      { "name": "TokenError" },
+      { "name": "ExpiredTokenError" },
+      { "name": "extractToken" },
+      { "name": "generateToken" },
+      { "name": "refreshToken" },
+      { "name": "ValidationError" }
+    ]
+  },
   "12_deep_impact": {
     "description": "Deep impact of DatabaseConnection (depth 5)",
     "query": "impact DatabaseConnection --depth 5",

--- a/benchmarks/scenarios/13_rag_search.sh
+++ b/benchmarks/scenarios/13_rag_search.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Scenario 13: Semantic search — find code by concept/behavior
+# Question: "Find code related to token validation"
+#
+# Tests: rag search (FTS5 hybrid) vs grep for conceptual queries
+# Measures: token output, command count, recall against ground truth
+#
+# Key differentiator: cartog rag search matches by content (FTS5 + vector),
+# returning structured results. grep returns raw lines, mixing definitions,
+# usages, string literals, and comments.
+
+source "$(dirname "$0")/../lib/common.sh"
+source "$(dirname "$0")/../lib/compare.sh"
+
+SCENARIO="13_rag_search"
+QUERY="validate token"
+
+# Ensure embedding model is downloaded (one-time, ~133MB)
+ensure_rag_model() {
+    if ! $CARTOG rag setup 2>/dev/null | grep -q "already"; then
+        echo -e "  ${YELLOW}Downloading embedding model...${NC}" >&2
+        $CARTOG rag setup >/dev/null 2>&1
+    fi
+}
+
+ensure_rag_model
+
+run_scenario() {
+    local fixture_name="$1"
+    local fixture_dir="$BENCH_DIR/fixtures/$fixture_name"
+
+    should_skip_fixture "$fixture_name" && return 0
+
+    # RAG requires symbol content (populated during index) + embeddings.
+    # Re-index to ensure symbol_content is populated, then build RAG index.
+    (cd "$fixture_dir" && $CARTOG index . --force >/dev/null 2>&1) || true
+    (cd "$fixture_dir" && $CARTOG rag index >/dev/null 2>&1) || true
+
+    echo -e "  ${CYAN}[$fixture_name]${NC} RAG search: '$QUERY'" >&2
+
+    # ── Naive grep: raw string search for both terms ──
+    run_grep "naive" "$fixture_dir" "grep -rn 'validate\|token' . --include='*.*'"
+    local naive_tok=$GREP_TOKENS
+    local naive_out="$GREP_OUTPUT"
+    local naive_cmds=1
+
+    # ── Best-effort grep: both terms on same line, unique files ──
+    run_grep "best" "$fixture_dir" "grep -rln 'validate' . --include='*.*' | xargs grep -l 'token' 2>/dev/null | head -20"
+    local best_tok=$GREP_TOKENS
+    local best_out="$GREP_OUTPUT"
+    local best_cmds=2
+
+    # ── Cartog rag search ──
+    run_cartog_cmd "$fixture_dir" rag search "$QUERY"
+    local cartog_tok=$CARTOG_TOKENS
+    local cartog_out="$CARTOG_OUTPUT"
+    local cartog_cmds=1
+
+    # ── Recall against ground truth ──
+    local naive_recall best_recall cartog_recall
+    read -r _ _ naive_recall <<< "$(check_recall "$naive_out" "$fixture_name" "$SCENARIO" '.expected[].name')"
+    read -r _ _ best_recall  <<< "$(check_recall "$best_out"  "$fixture_name" "$SCENARIO" '.expected[].name')"
+    read -r _ _ cartog_recall <<< "$(check_recall "$cartog_out" "$fixture_name" "$SCENARIO" '.expected[].name')"
+
+    print_comparison "$SCENARIO" "$fixture_name" \
+        "$naive_tok" "$naive_cmds" "$naive_recall" \
+        "$best_tok" "$best_cmds" "$best_recall" \
+        "$cartog_tok" "$cartog_cmds" "$cartog_recall"
+
+    emit_result_json "$SCENARIO" "$fixture_name" \
+        "$naive_tok" "$naive_recall" \
+        "$best_tok" "$best_recall" \
+        "$cartog_tok" "$cartog_recall"
+}
+
+run_scenario "webapp_py"
+run_scenario "webapp_ts"
+run_scenario "webapp_go"
+run_scenario "webapp_rs"
+run_scenario "webapp_rb"

--- a/deny.toml
+++ b/deny.toml
@@ -12,10 +12,11 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "ISC",
-  "Unicode-DFS-2016",
   "Unicode-3.0",
   "Zlib",
   "CC0-1.0",
+  "MPL-2.0",
+  "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -32,30 +32,40 @@ Type "cartog index ."
 Enter
 Sleep 2s
 
-# Step 2: Search
+# Step 2: Keyword search (fast, symbol names)
 Type ""
 Enter
-Type "# Step 2: Find symbols by name"
+Type "# Step 2: Find symbols by name (sub-millisecond)"
 Enter
 Sleep 500ms
 Type "cartog search validate"
 Enter
 Sleep 3s
 
-# Step 3: Refs
+# Step 3: Semantic search (natural language)
 Type ""
 Enter
-Type "# Step 3: Who calls validate_token?"
+Type "# Step 3: Find code by concept (semantic search)"
 Enter
 Sleep 500ms
-Type "cartog refs validate_token"
+Type 'cartog rag search "authentication token validation"'
+Enter
+Sleep 4s
+
+# Step 4: Refs
+Type ""
+Enter
+Type "# Step 4: Who calls validate_token?"
+Enter
+Sleep 500ms
+Type "cartog refs validate_token --kind calls"
 Enter
 Sleep 3s
 
-# Step 4: Impact
+# Step 5: Impact
 Type ""
 Enter
-Type "# Step 4: What breaks if I change it?"
+Type "# Step 5: What breaks if I change it?"
 Enter
 Sleep 500ms
 Type "cartog impact validate_token --depth 3"

--- a/docs/product.md
+++ b/docs/product.md
@@ -17,22 +17,23 @@ Code is a graph of relationships (calls, imports, inherits, type references). Pr
 
 ## Key Features
 
-- **Zero dependencies**: Single binary + SQLite file. No language server, no embedding model, no graph DB.
+- **Zero dependencies**: Single binary + SQLite file. No language server, no graph DB.
 - **Works everywhere**: Claude.ai (as skill), Claude Code (as skill or MCP), any LLM with bash access.
 - **Instant queries**: Pre-computed graph, microsecond lookups.
 - **Incremental indexing**: Git-based change detection, only re-indexes modified files.
+- **Semantic search (opt-in)**: Hybrid FTS5 keyword + vector similarity search over code symbols, with optional cross-encoder re-ranking. ONNX Runtime inference via fastembed. Models auto-downloaded via `cartog rag setup`.
 
 ## Differentiation
 
 | vs Serena MCP | vs codanna | vs Aider |
 |---------------|-----------|----------|
-| No LSP process needed | No embedding model (150MB) | Pre-computed graph, not per-query |
+| No LSP process needed | Optional embedding model | Pre-computed graph, not per-query |
 | Works in claude.ai | No MCP server required | SQLite vs in-memory NetworkX |
-| Single binary | Deterministic results | Full query interface |
+| Single binary | Deterministic + semantic results | Full query interface |
 
 ## Trade-off
 
-Structural/heuristic name resolution, not full semantic. 90% accuracy — enough for most navigation tasks. LSP can be added as optional precision layer later.
+Structural/heuristic name resolution, not full semantic. 90% accuracy — enough for most navigation tasks. LSP can be added as optional precision layer later. Semantic search adds neural embeddings for natural language queries over code.
 
 ## Distribution
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -8,11 +8,13 @@ cartog/
 ├── AGENTS.md                # Guidelines for AI coding agents
 ├── src/
 │   ├── main.rs              # Entry point, CLI dispatch
+│   ├── lib.rs               # Library root, re-exports public modules
 │   ├── commands.rs          # Command handlers (outline, refs, impact, etc.)
 │   ├── cli.rs               # Clap command definitions
 │   ├── db.rs                # SQLite schema, CRUD, query methods
 │   ├── indexer.rs           # Orchestrates: walk files → extract → store → resolve
 │   ├── mcp.rs               # MCP server (tool handlers, path validation, ServerHandler)
+│   ├── watch.rs             # File watcher: debounced re-index + deferred RAG embedding
 │   ├── languages/
 │   │   ├── mod.rs           # Language registry, Extractor trait, shared node_text helper
 │   │   ├── python.rs        # Python tree-sitter extractor
@@ -22,6 +24,13 @@ cartog/
 │   │   ├── rust_lang.rs     # Rust extractor
 │   │   ├── go.rs            # Go extractor
 │   │   └── ruby.rs          # Ruby extractor
+│   ├── rag/
+│   │   ├── mod.rs           # RAG module root, constants (EMBEDDING_DIM)
+│   │   ├── setup.rs         # Model download (triggers fastembed auto-download)
+│   │   ├── embeddings.rs    # ONNX embedding inference via fastembed (BGE-small-en-v1.5)
+│   │   ├── indexer.rs       # Embed symbols, store vectors in sqlite-vec
+│   │   ├── reranker.rs      # Cross-encoder re-ranking via fastembed (BGE-reranker-base)
+│   │   └── search.rs        # FTS5 + vector KNN search, RRF merge, optional re-ranking
 │   └── types.rs             # Symbol, Edge, FileInfo structs
 ├── skills/
 │   └── cartog/              # Agent Skill (agentskills.io)
@@ -37,13 +46,16 @@ cartog/
 │   ├── run.sh               # Benchmark runner (token efficiency, recall, command count)
 │   ├── lib/                 # Shared measurement & comparison helpers
 │   ├── fixtures/
-│   │   ├── webapp_py/       # Python fixture (15 files: auth, models, routes, utils)
-│   │   ├── webapp_rs/       # Rust fixture (12 files: auth, models, routes)
-│   │   └── webapp_rb/       # Ruby fixture (10 files: auth, models, routes, utils)
+│   │   ├── webapp_py/       # Python fixture (69 files)
+│   │   ├── webapp_ts/       # TypeScript fixture (48 files)
+│   │   ├── webapp_go/       # Go fixture (45 files)
+│   │   ├── webapp_rs/       # Rust fixture (65 files)
+│   │   └── webapp_rb/       # Ruby fixture (51 files)
 │   ├── ground_truth/        # Expected relationships per fixture (JSON)
-│   ├── scenarios/           # 7 scenario scripts (01-07)
+│   ├── scenarios/           # 13 scenario scripts (01-13)
 │   └── results/             # Benchmark output (gitignored)
 ├── tests/
+│   ├── rag_relevancy.rs     # RAG relevancy integration benchmark (P@k, R@k, NDCG)
 │   └── fixtures/
 │       └── auth/            # Python fixtures for indexer tests
 │           ├── tokens.py
@@ -58,12 +70,19 @@ cartog/
 
 ## Module Responsibilities
 
-- **cli.rs**: Defines all subcommands via clap derive. No business logic.
-- **db.rs**: Owns the SQLite connection. Schema creation, inserts, and all query methods. Returns domain types.
-- **indexer.rs**: Walks the file tree, delegates to language extractors, writes to db, runs edge resolution.
-- **commands.rs**: All 9 command handlers. Formats output (human-readable or `--json`).
-- **mcp.rs**: MCP server over stdio. `CartogServer` struct with 9 `#[tool]` handlers wrapping the same DB methods as `commands.rs`. Path validation restricts `index` to CWD subtree. Uses `spawn_blocking` for sync DB/indexer calls.
+- **cli.rs**: Defines all subcommands (including `rag` subgroup and `watch`) via clap derive. No business logic.
+- **db.rs**: Owns the SQLite connection. Schema creation (core + RAG tables), inserts, and all query methods. Returns domain types. RAG additions: `symbol_content` (source text), `symbol_fts` (FTS5 index), `symbol_vec` (sqlite-vec vectors), `symbol_embedding_map` (integer ID mapping).
+- **indexer.rs**: Walks the file tree, delegates to language extractors, writes to db, runs edge resolution. Also stores symbol source content for RAG during indexing. Exports `is_ignored_dirname()` for reuse by the watcher.
+- **commands.rs**: Command handlers for all CLI commands including `rag setup/index/search` and `watch`. Formats output (human-readable or `--json`).
+- **mcp.rs**: MCP server over stdio. `CartogServer` struct with 11 `#[tool]` handlers (9 core + 2 RAG). Path validation restricts `index` to CWD subtree. Uses `spawn_blocking` for sync DB/indexer calls. Optionally spawns a background file watcher (`--watch` flag).
+- **watch.rs**: File watcher using `notify-debouncer-mini`. Debounces filesystem events, triggers incremental `index_directory()`. Optionally defers RAG embedding after a configurable delay. Used standalone (`cartog watch`) or embedded in MCP server (`cartog serve --watch`).
 - **languages/mod.rs**: Maps file extensions to extractors, defines the `Extractor` trait and shared `node_text` helper. Each extractor implements `fn extract(&self, source: &str, file_path: &str) -> Result<ExtractionResult>`.
+- **rag/mod.rs**: RAG pipeline constants (`EMBEDDING_DIM = 384`), shared model cache directory (`model_cache_dir()` — XDG-compliant, avoids per-project model downloads).
+- **rag/setup.rs**: Triggers model download by instantiating fastembed engines (models auto-downloaded from HuggingFace on first use).
+- **rag/embeddings.rs**: ONNX Runtime inference via fastembed (`BAAI/bge-small-en-v1.5`). Serialization helpers for sqlite-vec byte format.
+- **rag/indexer.rs**: Embeds all symbols with content, stores in sqlite-vec. Supports incremental (skip existing) and force modes.
+- **rag/search.rs**: Hybrid search combining FTS5 keyword (BM25) + vector KNN (cosine), merged via Reciprocal Rank Fusion (RRF, k=60). Optional cross-encoder re-ranking when model is available.
+- **rag/reranker.rs**: Cross-encoder re-ranking via fastembed (`BAAI/bge-reranker-base`). Scores (query, document) pairs jointly. Auto-enabled when model is downloadable.
 - **types.rs**: Shared data structures. No logic beyond Display/serialization.
 
 ## Conventions

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -18,6 +18,8 @@
 | `rmcp` | MCP server (JSON-RPC over stdio) |
 | `tokio` | Async runtime for MCP server |
 | `tracing` + `tracing-subscriber` | Structured logging (stderr) for MCP server |
+| `fastembed` | ONNX Runtime inference for embeddings + re-ranking (wraps ort, tokenizers, hf-hub) |
+| `sqlite-vec` | Vector similarity search (KNN) in SQLite |
 
 ## Architecture Decisions
 
@@ -27,7 +29,8 @@
 | Storage | SQLite | Zero infra, ~1MB, persists across sessions |
 | Packaging | Skill (primary) | Changes agent workflow, not just adds a tool |
 | Change detection | Git-based + SHA256 fallback + `--force` | Minimal re-indexing, deferred file reads |
-| Vector DB | No | 100MB+ model, non-deterministic, slow |
+| Vector search | sqlite-vec (opt-in) | Embedded in SQLite, no external infra. Models downloaded via `cartog rag setup` |
+| Model cache | `~/.cache/cartog/models` | XDG-compliant shared cache. Precedence: `FASTEMBED_CACHE_DIR` > `XDG_CACHE_HOME/cartog/models` > `~/.cache/cartog/models` |
 | LSP | Deferred | Tree-sitter handles 90% of cases |
 | MCP server | `cartog serve` (stdio) | Skill remains primary; MCP as secondary for zero-context-cost tool access |
 | Watch mode | No | On-demand re-index is sufficient for agent use |

--- a/skills/cartog/references/query_cookbook.md
+++ b/skills/cartog/references/query_cookbook.md
@@ -75,10 +75,64 @@ cartog hierarchy OldClassName          # Subclasses to update
 cartog impact OldClassName --depth 5   # Full blast radius
 ```
 
+## Semantic Search (RAG)
+
+### Setup (one-time)
+```bash
+cartog rag setup          # download embedding + re-ranker models
+cartog rag index .        # embed all symbols
+```
+
+### "Find code related to a concept"
+```bash
+cartog rag search "parse abstract syntax tree"
+cartog rag search "handle HTTP authentication" --kind function
+cartog rag search "database migration" --limit 5
+```
+
+### After code changes, re-index embeddings
+```bash
+cartog rag index .        # incremental — only new/changed symbols
+cartog rag index . --force  # re-embed everything
+```
+
+### Good vs bad RAG queries
+
+| Query | Quality | Why |
+|---|---|---|
+| `"authentication token validation"` | Good | Describes behavior, multiple relevant terms |
+| `"handle HTTP request errors"` | Good | Natural language, matches content in function bodies |
+| `"parse"` | Bad | Too short — use `cartog search parse` instead |
+| `"validate_token"` | Bad | Looks like a symbol name — use `cartog search validate_token` |
+| `"auth*"` | Bad | FTS5 wraps queries in quotes, disabling wildcards |
+
+### Interpreting results
+
+```
+1. Function validate_token  auth/tokens.py:10-20  [fts5+vector] score=0.0328 rerank=8.61
+2. Class AuthService  auth/service.py:1-11  [fts5] score=0.0164 rerank=-4.32
+```
+
+- `[fts5+vector]` — found by both keyword and semantic search (most confident)
+- `[fts5]` — found by keyword search only
+- `[vector]` — found by semantic similarity only (model must be set up)
+- `score` — RRF rank score; only meaningful for ordering within one query
+- `rerank` — cross-encoder relevance score (higher = more relevant). Shown when re-ranker model is available. Results are re-sorted by this score.
+- If all results show `[fts5]` only, run `cartog rag setup && cartog rag index .` to enable vector search
+
+### When RAG search returns nothing useful
+
+1. Try simpler terms: `"token validation"` instead of `"JWT token validation with RSA signatures"`
+2. Check that the index is built: `cartog rag index .`
+3. Fall back to `cartog search` for name-based lookup
+4. Fall back to `grep` for string literals or config values
+
 ## Tips
 
 - Use `--json` when you need to parse output programmatically
 - After making changes, run `cartog index .` to update (uses git to detect changes)
 - Use `cartog index . --force` to rebuild the entire index from scratch
-- Symbol names are matched by simple name — use `validate_token`, not `auth.tokens.validate_token`
-- For method queries, use the method name (e.g., `authenticate`). Dotted names like `UserService.authenticate` are accepted but resolved to the simple part
+- `cartog search` matches symbol names (prefix + substring, case-insensitive)
+- `cartog rag search` matches symbol names AND content (FTS5 tokens + vector similarity)
+- For method queries, use the method name (e.g., `authenticate`), not dotted names
+- RAG search does NOT do substring matching: `"valid"` won't match `validate_token` — use `cartog search valid` for that

--- a/skills/cartog/scripts/query.sh
+++ b/skills/cartog/scripts/query.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 if [ $# -lt 1 ]; then
     echo "Usage: query.sh <command> [args...]"
-    echo "Commands: outline, callees, impact, refs, hierarchy, deps, stats"
+    echo "Commands: search, outline, callees, impact, refs, hierarchy, deps, stats, rag"
     exit 1
 fi
 

--- a/specs/watch.spec.md
+++ b/specs/watch.spec.md
@@ -1,0 +1,200 @@
+# Feature: `cartog watch`
+
+## Overview
+
+A long-running CLI command that watches filesystem events, debounces changes, and automatically re-indexes the code graph + RAG embeddings. Keeps the `.cartog.db` fresh without manual `cartog index` / `cartog rag index` cycles, especially useful during active development before commits.
+
+## Architecture
+
+```
+cartog watch [path] [--debounce 2s] [--rag] [--rag-delay 30s]
+     |
+     v
+notify crate (kqueue macOS / inotify Linux / ReadDirectoryChangesW Windows)
+     |
+     v
+Debounce filter (2s default) ──> code graph index (incremental, ~1-3s)
+     |                                    |
+     |                            symbols_needing_embeddings > 0?
+     |                                    |
+     v                                    v
+                              Deferred RAG batch (30s timer)
+                                    |
+                                    v
+                              rag::indexer::index_embeddings(force=false)
+```
+
+### Key Design Decisions
+
+1. **Debounced file watcher** (not git polling): Uses `notify` crate with a configurable debounce window (default 2s). Responds to actual file saves, not periodic checks. The existing `is_ignored()` filter + `detect_language()` already handle skipping irrelevant files.
+
+2. **Deferred RAG embedding batch**: After each code graph re-index, if there are symbols needing embeddings (`symbols_needing_embeddings().len() > 0`), a timer starts. Resets on each new index cycle. When the timer fires (default 30s of inactivity), embeddings are generated in bulk. This amortizes the ~200ms model load and batches embedding calls.
+
+3. **Single DB connection**: The watcher holds the `Database` handle for its lifetime. No concurrent access concerns since `cartog watch` is the sole writer. MCP server reads are safe because SQLite WAL mode allows concurrent readers.
+
+4. **Graceful shutdown**: Ctrl+C (SIGINT) handler flushes any pending embeddings before exit.
+
+## Functional Requirements
+
+### FR-001: File Change Detection
+When a supported source file (Python, TypeScript/JavaScript, Rust, Go, Ruby) is created, modified, or deleted within the watched directory, the system shall queue a re-index after the debounce window expires.
+
+### FR-002: Debounce Window
+While file change events are arriving within the debounce window (default 2s, configurable via `--debounce`), the system shall reset the timer and not trigger re-indexing until the window elapses without new events.
+
+### FR-003: Incremental Code Graph Re-index
+When the debounce window expires, the system shall run `indexer::index_directory(db, root, false)` (incremental mode) and log the result (files indexed, skipped, removed, symbols, edges).
+
+### FR-004: Ignored Paths
+The system shall not trigger re-indexing for changes in ignored directories (`.git`, `node_modules`, `target`, `__pycache__`, etc.) — reusing the existing `is_ignored()` filter.
+
+### FR-005: Deferred RAG Embedding
+While `--rag` flag is set and symbols needing embeddings exist after a code graph re-index, when the RAG delay timer (default 30s, configurable via `--rag-delay`) expires without new index cycles, the system shall run `rag::indexer::index_embeddings(db, false)` to embed all pending symbols.
+
+### FR-006: RAG Timer Reset
+While embedding is pending and a new code graph re-index occurs, the system shall reset the RAG delay timer to avoid embedding during active editing.
+
+### FR-007: Startup Index
+When `cartog watch` starts, the system shall run one initial incremental index to ensure the DB is current before entering watch mode.
+
+### FR-008: Status Logging
+The system shall log to stderr: startup info (path, debounce, rag mode), each re-index summary, each RAG embedding summary, and shutdown.
+
+### FR-009: Graceful Shutdown
+When SIGINT (Ctrl+C) is received, the system shall flush any pending RAG embeddings, then exit cleanly.
+
+## Non-Functional Requirements
+
+### Performance
+- Code graph re-index latency: < 3s for incremental (< 50 changed files)
+- Memory: embedding engine loaded lazily on first RAG batch, ~300MB resident
+- CPU: idle when no changes (epoll/kqueue, not polling)
+
+### Reliability
+- File watcher errors (e.g., too many open files) shall be logged and retried, not fatal
+- Index errors on individual files shall be logged and skipped (existing behavior)
+- Embedding errors shall be logged per-symbol (existing fallback behavior in `flush_embedding_batch`)
+
+### Platform
+- macOS: kqueue via `notify` crate
+- Linux: inotify via `notify` crate
+- Windows: ReadDirectoryChangesW via `notify` crate
+
+## CLI Interface
+
+```
+cartog watch [OPTIONS] [PATH]
+
+Arguments:
+  [PATH]  Directory to watch (defaults to ".")
+
+Options:
+      --debounce <DURATION>   Debounce window for file changes [default: 2s]
+      --rag                   Enable automatic RAG embedding after index
+      --rag-delay <DURATION>  Delay before batch embedding after last index [default: 30s]
+      --json                  Output events as JSON (global flag)
+```
+
+## Acceptance Criteria
+
+### AC-001: Basic file change triggers re-index
+Given `cartog watch` is running on a directory
+When I save a Python/TS/Rust/Go/Ruby file
+Then the code graph is re-indexed within debounce window + index time
+And the log shows files indexed count > 0
+
+### AC-002: Rapid saves are debounced
+Given `cartog watch --debounce 2s` is running
+When I save a file 5 times in 1 second
+Then re-indexing occurs only once (after the 2s debounce)
+
+### AC-003: Ignored directories don't trigger
+Given `cartog watch` is running
+When a file changes inside `node_modules/` or `.git/`
+Then no re-indexing occurs
+
+### AC-004: File deletion removes stale data
+Given `cartog watch` is running and `foo.py` is indexed
+When I delete `foo.py`
+Then after debounce, re-indexing removes `foo.py` symbols/edges from the DB
+
+### AC-005: RAG embedding batches after inactivity
+Given `cartog watch --rag --rag-delay 10s` is running
+When I save a file and wait 10+ seconds without further changes
+Then RAG embeddings are generated for new/changed symbols
+And the log shows symbols embedded count > 0
+
+### AC-006: RAG timer resets on new changes
+Given `cartog watch --rag --rag-delay 10s` is running
+When I save a file, wait 5s, then save another file
+Then RAG embedding does not start at 10s from first save
+And instead starts at 10s from the second save
+
+### AC-007: Ctrl+C graceful shutdown
+Given `cartog watch --rag` is running with pending embeddings
+When I press Ctrl+C
+Then pending embeddings are flushed before exit
+
+### AC-008: Startup initial index
+Given `.cartog.db` exists but is stale
+When I run `cartog watch`
+Then an initial incremental index runs before entering watch mode
+
+## Error Handling
+
+| Error Condition | Behavior |
+|---|---|
+| Watched directory doesn't exist | Exit with error message |
+| File watcher init fails (permissions) | Exit with error message |
+| Individual file read error | Log warning, skip file, continue watching |
+| Tree-sitter parse error | Log warning, skip file, continue watching |
+| DB write error | Log error, continue watching (next cycle may succeed) |
+| Embedding model not found (--rag) | Log warning, skip RAG embedding, continue code graph indexing |
+| ONNX inference error on symbol | Log warning, skip symbol (existing fallback) |
+
+## Implementation TODO
+
+All items completed.
+
+### Dependencies
+- [x] Add `notify = "7"` to `Cargo.toml` (debounced file watcher)
+- [x] Add `notify-debouncer-mini = "0.5"` to `Cargo.toml` (debounce layer)
+- [x] Add `ctrlc = "3"` to `Cargo.toml` (graceful Ctrl+C handling)
+- [x] ~~`humantime`~~ — dropped in favor of `u64` seconds args (simpler, no extra dep)
+
+### CLI
+- [x] Add `Watch` variant to `Command` enum in `cli.rs`
+- [x] Add `--watch` and `--rag` flags to `Serve` variant in `cli.rs`
+- [x] Wire up both in `main.rs` match arm
+
+### Core: `src/watch.rs`
+- [x] Create `watch.rs` module with `WatchConfig`, `WatchHandle`, `run_watch()`, `spawn_watch()`
+- [x] `notify_debouncer_mini` for debounced file events
+- [x] `is_relevant_path()` filter using `detect_language()` + `is_ignored_dirname()`
+- [x] On debounce fire: `indexer::index_directory(&db, root, false)`
+- [x] RAG deferred timer: checks `symbols_needing_embeddings()`, fires after `rag_delay`
+- [x] Ctrl+C handler via `ctrlc` crate: flush pending RAG, exit cleanly
+
+### MCP Server Integration
+- [x] `cartog serve --watch` spawns background watcher via `spawn_watch()`
+- [x] `cartog serve --watch --rag` also enables deferred RAG embedding
+- [x] `WatchHandle` dropped on server shutdown, signaling watcher thread to stop
+- [x] Watcher opens its own DB connection (SQLite WAL allows concurrent readers)
+
+### Commands
+- [x] `cmd_watch()` in `commands.rs`
+- [x] `run_server(watch, rag)` updated in `mcp.rs`
+
+### Public API for reuse
+- [x] `indexer::is_ignored_dirname()` — extracted from private `is_ignored()` for sharing
+
+### Testing (14 new tests)
+- [x] 13 `is_relevant_path()` tests (language filtering + ignored dirs)
+- [x] 1 `WatchConfig` defaults test
+
+## Out of Scope
+
+- **Git hook integration**: Could be added separately as `cartog hook install`.
+- **Selective RAG**: No per-file embedding control. `--rag` is all-or-nothing.
+- **Remote file watching**: Only local filesystem events.
+- **`--no-initial-index` flag**: Not needed — initial index is fast (incremental).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,6 +137,68 @@ pub enum Command {
         limit: u32,
     },
 
+    /// Watch for file changes and auto-re-index
+    Watch {
+        /// Directory to watch (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: String,
+
+        /// Debounce window in seconds
+        #[arg(long, default_value = "2")]
+        debounce: u64,
+
+        /// Enable automatic RAG embedding after index
+        #[arg(long)]
+        rag: bool,
+
+        /// Delay in seconds before batch embedding after last index
+        #[arg(long, default_value = "30")]
+        rag_delay: u64,
+    },
+
     /// Start MCP server over stdio (for Claude Code, Cursor, and other MCP clients)
-    Serve,
+    Serve {
+        /// Enable file watching with auto-re-index during MCP session
+        #[arg(long)]
+        watch: bool,
+
+        /// Enable automatic RAG embedding when watching
+        #[arg(long)]
+        rag: bool,
+    },
+
+    /// Semantic code search (RAG pipeline)
+    #[command(subcommand)]
+    Rag(RagCommand),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RagCommand {
+    /// Download embedding + re-ranker models from HuggingFace
+    Setup,
+
+    /// Build embedding index for semantic search (requires setup first)
+    Index {
+        /// Directory to index (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: String,
+
+        /// Force re-embed all symbols
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Semantic search over code symbols
+    Search {
+        /// Natural language query
+        query: String,
+
+        /// Filter by symbol kind
+        #[arg(long)]
+        kind: Option<SymbolKindFilter>,
+
+        /// Maximum results to return
+        #[arg(long, default_value = "10")]
+        limit: u32,
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod db;
 pub mod indexer;
 pub mod languages;
+pub mod rag;
 pub mod types;
+pub mod watch;

--- a/src/rag/embeddings.rs
+++ b/src/rag/embeddings.rs
@@ -1,0 +1,187 @@
+use anyhow::{Context, Result};
+use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
+
+use super::{model_cache_dir, EMBEDDING_DIM};
+
+/// Batch size for fastembed internal sub-batching.
+/// Smaller batches reduce padding waste when text lengths vary widely.
+const EMBED_BATCH_SIZE: usize = 64;
+
+/// Embedding engine wrapping a fastembed ONNX model.
+///
+/// Uses ONNX Runtime for inference with SIMD and graph-level optimizations.
+/// The quantized model (BGESmallENV15Q) is ~2-3x faster than full precision
+/// with negligible quality loss.
+pub struct EmbeddingEngine {
+    model: TextEmbedding,
+}
+
+impl EmbeddingEngine {
+    /// Create a new embedding engine using the quantized BGE-small-en-v1.5 model.
+    ///
+    /// Models are cached in the shared directory (see [`super::model_cache_dir`]).
+    pub fn new() -> Result<Self> {
+        let model = TextEmbedding::try_new(
+            TextInitOptions::new(EmbeddingModel::BGESmallENV15Q)
+                .with_cache_dir(model_cache_dir())
+                .with_show_download_progress(false),
+        )
+        .context("Failed to initialize embedding model")?;
+
+        Ok(Self { model })
+    }
+
+    /// Create a new embedding engine, showing download progress on stdout.
+    pub fn new_with_progress() -> Result<Self> {
+        let model = TextEmbedding::try_new(
+            TextInitOptions::new(EmbeddingModel::BGESmallENV15Q)
+                .with_cache_dir(model_cache_dir())
+                .with_show_download_progress(true),
+        )
+        .context("Failed to initialize embedding model")?;
+
+        Ok(Self { model })
+    }
+
+    /// Embed a single text string, returning a normalized vector.
+    pub fn embed(&mut self, text: &str) -> Result<Vec<f32>> {
+        let results = self
+            .model
+            .embed(vec![text], Some(1))
+            .context("Embedding failed")?;
+
+        let vec = results
+            .into_iter()
+            .next()
+            .context("No embedding returned")?;
+
+        debug_assert_eq!(
+            vec.len(),
+            EMBEDDING_DIM,
+            "Expected {EMBEDDING_DIM}-dim embedding, got {}",
+            vec.len()
+        );
+
+        Ok(vec)
+    }
+
+    /// Embed multiple texts in a batch.
+    ///
+    /// Accepts `&[&str]` to avoid forcing callers to own Strings.
+    pub fn embed_batch(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let results = self
+            .model
+            .embed(texts, Some(EMBED_BATCH_SIZE))
+            .context("Batch embedding failed")?;
+
+        debug_assert!(
+            results.iter().all(|v| v.len() == EMBEDDING_DIM),
+            "All embeddings should be {EMBEDDING_DIM}-dim"
+        );
+
+        Ok(results)
+    }
+}
+
+/// Serialize a Vec<f32> to little-endian bytes for sqlite-vec storage.
+pub fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(embedding.len() * 4);
+    for &val in embedding {
+        bytes.extend_from_slice(&val.to_le_bytes());
+    }
+    bytes
+}
+
+/// Deserialize little-endian bytes back to Vec<f32>.
+#[allow(dead_code)]
+pub fn bytes_to_embedding(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_embedding_roundtrip() {
+        let original = vec![0.1_f32, -0.5, 1.0, 0.0, std::f32::consts::PI];
+        let bytes = embedding_to_bytes(&original);
+        let restored = bytes_to_embedding(&bytes);
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn test_embedding_byte_length() {
+        let vec = vec![0.0_f32; EMBEDDING_DIM];
+        let bytes = embedding_to_bytes(&vec);
+        assert_eq!(bytes.len(), EMBEDDING_DIM * 4);
+    }
+
+    #[test]
+    fn test_empty_bytes_roundtrip() {
+        let original: Vec<f32> = vec![];
+        let bytes = embedding_to_bytes(&original);
+        assert!(bytes.is_empty());
+        let restored = bytes_to_embedding(&bytes);
+        assert!(restored.is_empty());
+    }
+
+    /// Engine-level test: verifies the model produces correct-dimension embeddings.
+    /// Requires the embedding model to be downloaded (skipped in CI if unavailable).
+    #[test]
+    fn test_engine_embed_dimension() {
+        let mut engine = match EmbeddingEngine::new() {
+            Ok(e) => e,
+            Err(_) => return, // model not available, skip
+        };
+
+        let vec = engine.embed("fn validate_token(token: &str)").unwrap();
+        assert_eq!(vec.len(), EMBEDDING_DIM);
+
+        // Verify embedding is normalized (L2 norm ≈ 1.0)
+        let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 0.01,
+            "embedding should be L2-normalized, got norm={norm}"
+        );
+    }
+
+    /// Engine-level test: batch embedding produces correct dimensions and count.
+    #[test]
+    fn test_engine_embed_batch() {
+        let mut engine = match EmbeddingEngine::new() {
+            Ok(e) => e,
+            Err(_) => return, // model not available, skip
+        };
+
+        let texts = [
+            "fn foo() -> i32",
+            "class AuthService",
+            "def validate(token)",
+        ];
+        let results = engine.embed_batch(&texts).unwrap();
+        assert_eq!(results.len(), 3);
+        for v in &results {
+            assert_eq!(v.len(), EMBEDDING_DIM);
+        }
+    }
+
+    #[test]
+    fn test_engine_embed_batch_empty() {
+        let mut engine = match EmbeddingEngine::new() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+
+        let texts: &[&str] = &[];
+        let results = engine.embed_batch(texts).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/src/rag/indexer.rs
+++ b/src/rag/indexer.rs
@@ -1,0 +1,235 @@
+use anyhow::{Context, Result};
+use tracing::info;
+
+use crate::db::Database;
+
+use super::embeddings::{embedding_to_bytes, EmbeddingEngine};
+
+/// Result of a RAG indexing operation.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct RagIndexResult {
+    pub symbols_embedded: u32,
+    pub symbols_skipped: u32,
+    pub total_content_symbols: u32,
+}
+
+/// Maximum number of texts sent to the embedding engine in one call.
+/// fastembed sub-batches internally, but chunking here controls progress reporting.
+const CHUNK_SIZE: usize = 512;
+
+/// Maximum pending DB writes before flushing to SQLite.
+const DB_BATCH_LIMIT: usize = 256;
+
+/// Process a batch of texts through the embedding engine and write results to DB.
+///
+/// Returns the number of successfully processed items in this batch.
+fn flush_embedding_batch(
+    engine: &mut EmbeddingEngine,
+    db: &Database,
+    texts: &[String],
+    symbol_ids: &[String],
+    db_batch: &mut Vec<(i64, Vec<u8>)>,
+    result: &mut RagIndexResult,
+) -> Result<usize> {
+    let str_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+    match engine.embed_batch(&str_refs) {
+        Ok(embeddings) => {
+            for (embedding, sid) in embeddings.iter().zip(symbol_ids.iter()) {
+                let embedding_id = db.get_or_create_embedding_id(sid)?;
+                let bytes = embedding_to_bytes(embedding);
+                db_batch.push((embedding_id, bytes));
+                result.symbols_embedded += 1;
+
+                if db_batch.len() >= DB_BATCH_LIMIT {
+                    db.insert_embeddings(db_batch)?;
+                    db_batch.clear();
+                }
+            }
+            Ok(embeddings.len())
+        }
+        Err(e) => {
+            // Batch failed — fall back to one-at-a-time to isolate the bad symbol
+            tracing::warn!(error = %e, "Batch embedding failed, falling back to sequential");
+            let mut count = 0;
+            for (text, sid) in texts.iter().zip(symbol_ids.iter()) {
+                match engine.embed(text) {
+                    Ok(embedding) => {
+                        let embedding_id = db.get_or_create_embedding_id(sid)?;
+                        let bytes = embedding_to_bytes(&embedding);
+                        db_batch.push((embedding_id, bytes));
+                        result.symbols_embedded += 1;
+                        count += 1;
+
+                        if db_batch.len() >= DB_BATCH_LIMIT {
+                            db.insert_embeddings(db_batch)?;
+                            db_batch.clear();
+                        }
+                    }
+                    Err(e2) => {
+                        tracing::warn!(symbol = %sid, error = %e2, "embedding failed, skipping");
+                        result.symbols_skipped += 1;
+                    }
+                }
+            }
+            Ok(count)
+        }
+    }
+}
+
+/// Build the compact embedding text for a symbol.
+///
+/// Uses `header + first line of source` only (~30-60 tokens) instead of full content.
+/// BERT attention is O(n²) in sequence length, so this is the single biggest
+/// performance lever. Full content stays in `symbol_content` for FTS5 and reranking.
+pub fn compact_embedding_text(header: &str, content: &str) -> String {
+    let first_line = content.lines().next().unwrap_or("");
+    format!("{}\n{}", header, first_line)
+}
+
+/// Embed all symbols that have content but no embedding yet.
+///
+/// Requires the embedding model to be available (downloaded via `cartog rag setup`
+/// or auto-downloaded on first use by fastembed).
+/// When `force` is true, clears all existing embeddings and re-embeds everything.
+pub fn index_embeddings(db: &Database, force: bool) -> Result<RagIndexResult> {
+    info!("Loading embedding model...");
+    let mut engine = EmbeddingEngine::new()
+        .context("Failed to load embedding model. Run 'cartog rag setup' to download it.")?;
+
+    let total_content_symbols = db.symbol_content_count()?;
+
+    if force {
+        info!("Force mode: clearing all existing embeddings");
+        db.clear_all_embeddings()?;
+    }
+
+    let symbol_ids = if force {
+        db.all_content_symbol_ids()?
+    } else {
+        db.symbols_needing_embeddings()?
+    };
+
+    let mut result = RagIndexResult {
+        total_content_symbols,
+        ..Default::default()
+    };
+
+    if symbol_ids.is_empty() {
+        info!("No symbols need embedding");
+        return Ok(result);
+    }
+
+    info!("Embedding {} symbols...", symbol_ids.len());
+
+    let mut db_batch: Vec<(i64, Vec<u8>)> = Vec::with_capacity(DB_BATCH_LIMIT);
+    let mut texts: Vec<String> = Vec::with_capacity(CHUNK_SIZE);
+    let mut text_symbol_ids: Vec<String> = Vec::with_capacity(CHUNK_SIZE);
+
+    let total = symbol_ids.len();
+    let mut processed = 0usize;
+
+    // Process in chunks, batch-fetching content for each chunk
+    for chunk in symbol_ids.chunks(CHUNK_SIZE) {
+        let chunk_vec: Vec<String> = chunk.to_vec();
+        let content_map = db.get_symbol_contents_batch(&chunk_vec)?;
+
+        for symbol_id in chunk {
+            let (content, header) = match content_map.get(symbol_id) {
+                Some(c) => c,
+                None => {
+                    result.symbols_skipped += 1;
+                    continue;
+                }
+            };
+
+            texts.push(compact_embedding_text(header, content));
+            text_symbol_ids.push(symbol_id.clone());
+
+            if texts.len() >= CHUNK_SIZE {
+                let count = flush_embedding_batch(
+                    &mut engine,
+                    db,
+                    &texts,
+                    &text_symbol_ids,
+                    &mut db_batch,
+                    &mut result,
+                )?;
+                processed += count;
+                texts.clear();
+                text_symbol_ids.clear();
+
+                if processed % 1000 < CHUNK_SIZE {
+                    info!("  {processed}/{total} symbols embedded");
+                }
+            }
+        }
+    }
+
+    // Flush remaining texts
+    if !texts.is_empty() {
+        let count = flush_embedding_batch(
+            &mut engine,
+            db,
+            &texts,
+            &text_symbol_ids,
+            &mut db_batch,
+            &mut result,
+        )?;
+        processed += count;
+    }
+
+    // Flush remaining DB writes
+    if !db_batch.is_empty() {
+        db.insert_embeddings(&db_batch)?;
+    }
+
+    info!(
+        "Done: {} embedded, {} skipped ({processed}/{total} processed)",
+        result.symbols_embedded, result.symbols_skipped
+    );
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compact_embedding_text_header_plus_first_line() {
+        let header = "// File: auth.py | function validate_token";
+        let content = "def validate_token(token: str) -> bool:\n    if token.is_expired():\n        raise TokenError('expired')\n    return True";
+        let result = compact_embedding_text(header, content);
+        assert_eq!(
+            result,
+            "// File: auth.py | function validate_token\ndef validate_token(token: str) -> bool:"
+        );
+    }
+
+    #[test]
+    fn test_compact_embedding_text_single_line_content() {
+        let header = "// File: config.py | variable MAX_RETRIES";
+        let content = "MAX_RETRIES = 3";
+        let result = compact_embedding_text(header, content);
+        assert_eq!(
+            result,
+            "// File: config.py | variable MAX_RETRIES\nMAX_RETRIES = 3"
+        );
+    }
+
+    #[test]
+    fn test_compact_embedding_text_empty_content() {
+        let header = "// File: a.py | function foo";
+        let content = "";
+        let result = compact_embedding_text(header, content);
+        assert_eq!(result, "// File: a.py | function foo\n");
+    }
+
+    #[test]
+    fn test_compact_embedding_text_multiline_uses_only_first() {
+        let header = "header";
+        let content = "line1\nline2\nline3";
+        let result = compact_embedding_text(header, content);
+        assert_eq!(result, "header\nline1");
+    }
+}

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -1,0 +1,81 @@
+pub mod embeddings;
+pub mod indexer;
+pub mod reranker;
+pub mod search;
+pub mod setup;
+
+/// Embedding dimension for the bge-small-en-v1.5 model.
+pub const EMBEDDING_DIM: usize = 384;
+
+/// Shared model cache directory for ONNX models (embedding + reranker).
+///
+/// Precedence:
+/// 1. `FASTEMBED_CACHE_DIR` env var (fastembed's own convention)
+/// 2. `XDG_CACHE_HOME/cartog/models` (XDG standard)
+/// 3. `~/.cache/cartog/models` (fallback)
+///
+/// This avoids downloading 1.2GB of models per project (fastembed's default is
+/// `.fastembed_cache` in CWD).
+pub fn model_cache_dir() -> std::path::PathBuf {
+    // 1. Respect fastembed's own env var
+    if let Ok(dir) = std::env::var("FASTEMBED_CACHE_DIR") {
+        return std::path::PathBuf::from(dir);
+    }
+
+    // 2. XDG_CACHE_HOME / cartog / models
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        return std::path::PathBuf::from(xdg).join("cartog").join("models");
+    }
+
+    // 3. ~/.cache/cartog/models
+    if let Some(home) = home_dir() {
+        return home.join(".cache").join("cartog").join("models");
+    }
+
+    // Last resort: fastembed's default (CWD/.fastembed_cache)
+    std::path::PathBuf::from(".fastembed_cache")
+}
+
+/// Get the user's home directory (no external dependency needed).
+fn home_dir() -> Option<std::path::PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE")) // Windows fallback
+        .ok()
+        .map(std::path::PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_model_cache_dir_is_not_local() {
+        // Unless FASTEMBED_CACHE_DIR is explicitly set to a local path,
+        // model_cache_dir should NOT return ".fastembed_cache" (the per-project default).
+        let dir = model_cache_dir();
+        let dir_str = dir.to_string_lossy();
+        // On any system with HOME set, this should be an absolute path
+        if std::env::var("FASTEMBED_CACHE_DIR").is_err() {
+            assert!(
+                dir_str.contains("cartog"),
+                "cache dir should contain 'cartog', got: {dir_str}"
+            );
+            assert!(
+                !dir_str.starts_with('.'),
+                "cache dir should be absolute, not relative: {dir_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_model_cache_dir_ends_with_models() {
+        if std::env::var("FASTEMBED_CACHE_DIR").is_err() {
+            let dir = model_cache_dir();
+            assert!(
+                dir.ends_with("models"),
+                "cache dir should end with 'models', got: {}",
+                dir.display()
+            );
+        }
+    }
+}

--- a/src/rag/reranker.rs
+++ b/src/rag/reranker.rs
@@ -1,0 +1,64 @@
+use anyhow::{Context, Result};
+use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
+
+use super::model_cache_dir;
+
+/// Cross-encoder re-ranker for scoring (query, document) pairs.
+///
+/// Uses ONNX Runtime via fastembed for inference. The BGE-reranker-base model
+/// processes query and document jointly through all transformer layers,
+/// producing a relevance score for each pair.
+pub struct CrossEncoderEngine {
+    model: TextRerank,
+}
+
+impl CrossEncoderEngine {
+    /// Load the cross-encoder re-ranker model.
+    ///
+    /// Models are cached in the shared directory (see [`super::model_cache_dir`]).
+    pub fn load() -> Result<Self> {
+        let model = TextRerank::try_new(
+            RerankInitOptions::new(RerankerModel::BGERerankerBase)
+                .with_cache_dir(model_cache_dir())
+                .with_show_download_progress(false),
+        )
+        .context("Failed to initialize cross-encoder model")?;
+
+        Ok(Self { model })
+    }
+
+    /// Load with download progress displayed on stdout.
+    pub fn load_with_progress() -> Result<Self> {
+        let model = TextRerank::try_new(
+            RerankInitOptions::new(RerankerModel::BGERerankerBase)
+                .with_cache_dir(model_cache_dir())
+                .with_show_download_progress(true),
+        )
+        .context("Failed to initialize cross-encoder model")?;
+
+        Ok(Self { model })
+    }
+
+    /// Score multiple documents against a single query.
+    ///
+    /// Returns scores in the same order as the input documents.
+    /// Uses index-based placement (O(n)) instead of sorting (O(n log n)).
+    pub fn score_batch(&mut self, query: &str, documents: &[&str]) -> Result<Vec<f32>> {
+        if documents.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let results = self
+            .model
+            .rerank(query, documents, false, None)
+            .context("Cross-encoder batch scoring failed")?;
+
+        // Results come back sorted by score descending — place back by original index.
+        let mut scores = vec![0.0f32; documents.len()];
+        for r in &results {
+            scores[r.index] = r.score;
+        }
+
+        Ok(scores)
+    }
+}

--- a/src/rag/search.rs
+++ b/src/rag/search.rs
@@ -1,0 +1,1138 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use std::sync::Mutex;
+
+use crate::db::Database;
+use crate::types::{Symbol, SymbolKind};
+
+use super::embeddings::{embedding_to_bytes, EmbeddingEngine};
+use super::reranker::CrossEncoderEngine;
+
+/// Cached embedding engine — loaded once, reused across search calls.
+static EMBEDDING_ENGINE: Mutex<Option<EmbeddingEngine>> = Mutex::new(None);
+
+/// Cached cross-encoder engine — loaded once, reused across search calls.
+/// Uses tri-state: None = not attempted, Some(None) = load failed, Some(Some(_)) = ready.
+static RERANKER_ENGINE: Mutex<Option<Option<CrossEncoderEngine>>> = Mutex::new(None);
+
+/// Get or initialize the cached embedding engine.
+///
+/// NOTE: The Mutex is held for the entire duration of model inference.
+/// This is fine for single-threaded CLI and MCP usage (one query at a time).
+/// If the MCP server becomes multi-threaded with concurrent queries,
+/// this should be replaced with a pool or per-thread engine.
+fn with_embedding_engine<F, R>(f: F) -> Result<R>
+where
+    F: FnOnce(&mut EmbeddingEngine) -> Result<R>,
+{
+    let mut guard = EMBEDDING_ENGINE
+        .lock()
+        .map_err(|_| anyhow::anyhow!("embedding engine lock poisoned"))?;
+    if guard.is_none() {
+        *guard = Some(EmbeddingEngine::new()?);
+    }
+    f(guard.as_mut().unwrap())
+}
+
+/// Get or initialize the cached cross-encoder engine.
+///
+/// Returns None if model is not available (not downloaded) or lock is poisoned.
+/// Uses tri-state caching: once a load attempt fails, it is not retried,
+/// avoiding repeated filesystem/network probes on every search call.
+fn with_reranker_engine<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&mut CrossEncoderEngine) -> R,
+{
+    let mut guard = RERANKER_ENGINE.lock().ok()?;
+    if guard.is_none() {
+        // First attempt: try to load, cache the result either way
+        match CrossEncoderEngine::load() {
+            Ok(engine) => *guard = Some(Some(engine)),
+            Err(e) => {
+                tracing::debug!(error = %e, "Cross-encoder not available, skipping re-ranking");
+                *guard = Some(None); // Cache the failure — don't retry
+                return None;
+            }
+        }
+    }
+    guard.as_mut().unwrap().as_mut().map(f)
+}
+
+/// A search result combining symbol metadata with relevance info.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchResult {
+    pub symbol: Symbol,
+    pub content: Option<String>,
+    pub rrf_score: f64,
+    /// Cross-encoder re-ranking score (higher = more relevant). Present only when
+    /// the cross-encoder model is available.
+    pub rerank_score: Option<f64>,
+    /// Which retrieval methods found this result.
+    pub sources: Vec<String>,
+}
+
+/// Result of a hybrid search operation.
+#[derive(Debug, Serialize)]
+pub struct HybridSearchResult {
+    pub results: Vec<SearchResult>,
+    pub fts_count: u32,
+    pub vec_count: u32,
+    pub merged_count: u32,
+}
+
+/// Reciprocal Rank Fusion: merge multiple ranked lists into a single ranking.
+///
+/// `k = 60` is the standard constant from the original RRF paper (Cormack et al., 2009).
+fn rrf_merge(ranked_lists: &[(&str, Vec<String>)], k: f64) -> Vec<(String, f64, Vec<String>)> {
+    let mut scores: HashMap<String, (f64, Vec<String>)> = HashMap::new();
+
+    for (source_name, list) in ranked_lists {
+        let source = (*source_name).to_string();
+        for (rank, id) in list.iter().enumerate() {
+            let entry = scores
+                .entry(id.clone())
+                .or_insert_with(|| (0.0, Vec::new()));
+            entry.0 += 1.0 / (k + rank as f64 + 1.0);
+            if !entry.1.iter().any(|s| s == source_name) {
+                entry.1.push(source.clone());
+            }
+        }
+    }
+
+    let mut results: Vec<(String, f64, Vec<String>)> = scores
+        .into_iter()
+        .map(|(id, (score, sources))| (id, score, sources))
+        .collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results
+}
+
+/// Run hybrid search: FTS5 keyword + vector KNN, merged with RRF.
+///
+/// When `kind_filter` is set, results are filtered before applying `limit`,
+/// so the caller always gets up to `limit` results of the requested kind.
+pub fn hybrid_search(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    kind_filter: Option<SymbolKind>,
+) -> Result<HybridSearchResult> {
+    let retrieval_limit = (limit * 3).max(20); // Over-retrieve for better merge
+
+    // 1. FTS5 keyword search
+    let fts_results = fts5_search_safe(db, query, retrieval_limit)?;
+    let fts_count = fts_results.len() as u32;
+
+    // 2. Vector search (if embeddings exist in the DB)
+    let vec_results = if db.embedding_count()? > 0 {
+        vector_search(db, query, retrieval_limit)?
+    } else {
+        Vec::new()
+    };
+    let vec_count = vec_results.len() as u32;
+
+    // 3. RRF merge
+    let ranked_lists: Vec<(&str, Vec<String>)> =
+        vec![("fts5", fts_results), ("vector", vec_results)];
+    let merged = rrf_merge(&ranked_lists, 60.0);
+    let merged_count = merged.len() as u32;
+
+    // 4. Hydrate all merged candidates with symbol data + content.
+    let candidate_ids: Vec<String> = merged.iter().map(|(id, _, _)| id.clone()).collect();
+
+    let symbols = db.get_symbols_by_ids(&candidate_ids)?;
+
+    let score_map: HashMap<&str, (f64, &Vec<String>)> = merged
+        .iter()
+        .map(|(id, score, sources)| (id.as_str(), (*score, sources)))
+        .collect();
+
+    let symbol_map: HashMap<&str, &Symbol> = symbols.iter().map(|s| (s.id.as_str(), s)).collect();
+
+    let empty_sources = Vec::new();
+    let mut candidates: Vec<SearchResult> = Vec::new();
+    for id in &candidate_ids {
+        if let Some(sym) = symbol_map.get(id.as_str()) {
+            let (score, sources) = score_map
+                .get(id.as_str())
+                .copied()
+                .unwrap_or((0.0, &empty_sources));
+
+            let content = db.get_symbol_content(id)?.map(|(c, _)| c);
+
+            candidates.push(SearchResult {
+                symbol: (*sym).clone(),
+                content,
+                rrf_score: score,
+                rerank_score: None,
+                sources: sources.clone(),
+            });
+        }
+    }
+
+    // 5. Cross-encoder re-ranking (if model is available).
+    //    Cap at 50 candidates to bound latency.
+    const RERANK_MAX: usize = 50;
+    let rerank_slice = if candidates.len() > RERANK_MAX {
+        &mut candidates[..RERANK_MAX]
+    } else {
+        &mut candidates[..]
+    };
+    with_reranker_engine(|engine| {
+        rerank_candidates(engine, query, rerank_slice);
+    });
+
+    // 6. Apply kind filter + limit on (re-ranked) candidates.
+    let mut results = Vec::new();
+    for candidate in candidates {
+        if results.len() >= limit as usize {
+            break;
+        }
+        if let Some(ref filter) = kind_filter {
+            if &candidate.symbol.kind != filter {
+                continue;
+            }
+        }
+        results.push(candidate);
+    }
+
+    Ok(HybridSearchResult {
+        results,
+        fts_count,
+        vec_count,
+        merged_count,
+    })
+}
+
+/// Re-rank candidates in place using a cross-encoder.
+///
+/// Batches all (query, content) pairs for a single ONNX inference call,
+/// then re-sorts by cross-encoder score descending.
+/// Candidates without content retain their original order at the end.
+fn rerank_candidates(
+    engine: &mut CrossEncoderEngine,
+    query: &str,
+    candidates: &mut [SearchResult],
+) {
+    // Collect indices of candidates that have content (no cloning).
+    let scoreable_indices: Vec<usize> = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| c.content.as_ref().map(|_| i))
+        .collect();
+
+    if scoreable_indices.is_empty() {
+        return;
+    }
+
+    // Build doc refs from the candidates' content (borrow, not clone).
+    let docs: Vec<&str> = scoreable_indices
+        .iter()
+        .map(|&i| candidates[i].content.as_deref().unwrap())
+        .collect();
+
+    match engine.score_batch(query, &docs) {
+        Ok(scores) => {
+            for (&idx, score) in scoreable_indices.iter().zip(scores.iter()) {
+                candidates[idx].rerank_score = Some(*score as f64);
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Cross-encoder batch scoring failed, keeping RRF order");
+        }
+    }
+
+    // Stable sort: candidates with rerank_score come first (sorted by score desc),
+    // then candidates without score (in original RRF order).
+    candidates.sort_by(|a, b| match (a.rerank_score, b.rerank_score) {
+        (Some(sa), Some(sb)) => sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+}
+
+/// FTS5 search with safe query escaping.
+///
+/// Tries three strategies in order, returning the first non-empty result:
+/// 1. **Phrase**: `"validate token"` — exact adjacent match (highest precision)
+/// 2. **AND**: `"validate" AND "token"` — all terms present (good precision)
+/// 3. **OR**: `"validate" OR "token"` — any term present (highest recall, lowest precision)
+///
+/// Only FTS5 syntax errors trigger fallback; real DB errors are propagated.
+fn fts5_search_safe(db: &Database, query: &str, limit: u32) -> Result<Vec<String>> {
+    let terms: Vec<String> = query
+        .split_whitespace()
+        .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
+        .collect();
+    if terms.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 1. Phrase search (exact adjacency)
+    let phrase_query = format!("\"{}\"", query.replace('"', "\"\""));
+    match db.fts5_search(&phrase_query, limit) {
+        Ok(results) if !results.is_empty() => return Ok(results),
+        Err(e) if !is_fts5_syntax_error(&e) => return Err(e),
+        _ => {}
+    }
+
+    // 2. AND search (all terms present, any order)
+    if terms.len() > 1 {
+        let and_query = terms.join(" AND ");
+        match db.fts5_search(&and_query, limit) {
+            Ok(results) if !results.is_empty() => return Ok(results),
+            Err(e) if !is_fts5_syntax_error(&e) => return Err(e),
+            _ => {}
+        }
+    }
+
+    // 3. OR search (any term present — broadest, lowest precision)
+    let or_query = terms.join(" OR ");
+    match db.fts5_search(&or_query, limit) {
+        Ok(results) => Ok(results),
+        Err(e) if !is_fts5_syntax_error(&e) => Err(e),
+        _ => Ok(Vec::new()),
+    }
+}
+
+/// Check if an error is an FTS5 query syntax error (expected, safe to retry).
+fn is_fts5_syntax_error(err: &anyhow::Error) -> bool {
+    let msg = err.to_string().to_lowercase();
+    msg.contains("fts5") || msg.contains("syntax") || msg.contains("parse")
+}
+
+/// Vector search: embed the query and find nearest neighbors.
+fn vector_search(db: &Database, query: &str, limit: u32) -> Result<Vec<String>> {
+    let query_embedding = with_embedding_engine(|engine| engine.embed(query))?;
+    let query_bytes = embedding_to_bytes(&query_embedding);
+
+    let nn_results = db.vector_search(&query_bytes, limit)?;
+
+    // Map embedding IDs back to symbol IDs
+    let embedding_ids: Vec<i64> = nn_results.iter().map(|(id, _)| *id).collect();
+    let id_map = db.symbol_ids_for_embeddings(&embedding_ids)?;
+    let id_lookup: HashMap<i64, String> = id_map.into_iter().collect();
+
+    // Preserve distance ordering
+    let symbol_ids: Vec<String> = nn_results
+        .iter()
+        .filter_map(|(eid, _)| id_lookup.get(eid).cloned())
+        .collect();
+
+    Ok(symbol_ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SymbolKind;
+
+    /// Create a symbol + content pair and insert into the database.
+    fn insert_symbol_with_content(
+        db: &Database,
+        name: &str,
+        kind: SymbolKind,
+        file: &str,
+        line: u32,
+        content: &str,
+    ) -> Symbol {
+        let sym = Symbol::new(name, kind, file, line, line + 10, 0, content.len() as u32);
+        db.insert_symbol(&sym).unwrap();
+        let header = format!("// File: {file} | {kind} {name}", kind = sym.kind);
+        db.upsert_symbol_content(&sym.id, name, content, &header)
+            .unwrap();
+        sym
+    }
+
+    // ── RRF merge unit tests ──
+
+    #[test]
+    fn test_rrf_merge_single_list() {
+        let list = vec![(
+            "fts5",
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        )];
+        let merged = rrf_merge(&list, 60.0);
+
+        assert_eq!(merged.len(), 3);
+        // First item should have highest score
+        assert_eq!(merged[0].0, "a");
+        assert!(merged[0].1 > merged[1].1);
+        assert!(merged[1].1 > merged[2].1);
+    }
+
+    #[test]
+    fn test_rrf_merge_two_lists() {
+        let lists = vec![
+            (
+                "fts5",
+                vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            ),
+            (
+                "vec",
+                vec!["b".to_string(), "d".to_string(), "a".to_string()],
+            ),
+        ];
+        let merged = rrf_merge(&lists, 60.0);
+
+        // "b" appears rank 1 in fts5 + rank 0 in vec → highest combined score
+        // "a" appears rank 0 in fts5 + rank 2 in vec
+        assert_eq!(merged[0].0, "b"); // rank 1 + rank 0
+        assert_eq!(merged[1].0, "a"); // rank 0 + rank 2
+
+        // Check sources
+        let b = merged.iter().find(|(id, _, _)| id == "b").unwrap();
+        assert!(b.2.contains(&"fts5".to_string()));
+        assert!(b.2.contains(&"vec".to_string()));
+    }
+
+    #[test]
+    fn test_rrf_merge_no_overlap() {
+        let lists = vec![
+            ("fts5", vec!["a".to_string(), "b".to_string()]),
+            ("vec", vec!["c".to_string(), "d".to_string()]),
+        ];
+        let merged = rrf_merge(&lists, 60.0);
+
+        assert_eq!(merged.len(), 4);
+        // Items at rank 0 should tie, then rank 1 should tie
+        let scores: Vec<f64> = merged.iter().map(|(_, s, _)| *s).collect();
+        assert!((scores[0] - scores[1]).abs() < f64::EPSILON);
+        assert!((scores[2] - scores[3]).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_rrf_merge_empty() {
+        let lists: Vec<(&str, Vec<String>)> = vec![("fts5", vec![]), ("vec", vec![])];
+        let merged = rrf_merge(&lists, 60.0);
+        assert!(merged.is_empty());
+    }
+
+    // ── hybrid_search integration tests (FTS5-only, no model needed) ──
+    //
+    // These tests populate an in-memory DB with realistic code symbols and assert
+    // on ranking order, precision, and edge cases. They serve as regression baselines:
+    // if you change the search pipeline, failing tests indicate a quality change.
+
+    /// Shared corpus: a realistic mix of symbols across a Python codebase.
+    /// Used by multiple tests to verify ranking against a consistent dataset.
+    fn seed_python_corpus(db: &Database) {
+        insert_symbol_with_content(
+            db,
+            "AuthService",
+            SymbolKind::Class,
+            "auth/service.py",
+            1,
+            "class AuthService:\n    def authenticate(self, username, password):\n        token = generate_token(username)\n        return token",
+        );
+        insert_symbol_with_content(
+            db,
+            "validate_token",
+            SymbolKind::Function,
+            "auth/tokens.py",
+            10,
+            "def validate_token(token: str) -> bool:\n    if token.is_expired():\n        raise TokenError('expired')\n    return True",
+        );
+        insert_symbol_with_content(
+            db,
+            "generate_token",
+            SymbolKind::Function,
+            "auth/tokens.py",
+            20,
+            "def generate_token(username: str) -> str:\n    payload = {'sub': username}\n    return jwt.encode(payload, SECRET_KEY)",
+        );
+        insert_symbol_with_content(
+            db,
+            "UserRepository",
+            SymbolKind::Class,
+            "models/user.py",
+            1,
+            "class UserRepository:\n    def find_by_email(self, email: str) -> User:\n        return self.db.query(User).filter(email=email).first()",
+        );
+        insert_symbol_with_content(
+            db,
+            "send_email",
+            SymbolKind::Function,
+            "notifications/email.py",
+            5,
+            "def send_email(to: str, subject: str, body: str) -> None:\n    smtp = connect_smtp()\n    smtp.send(to, subject, body)",
+        );
+    }
+
+    // ── Per-language smoke tests ──
+
+    #[test]
+    fn test_hybrid_search_python_ranking() {
+        let db = Database::open_memory().unwrap();
+        seed_python_corpus(&db);
+
+        // "validate token" should rank validate_token #1 (both terms in name+content)
+        let result = hybrid_search(&db, "validate token", 10, None).unwrap();
+        assert!(result.fts_count > 0, "FTS5 should find results");
+        assert_eq!(result.vec_count, 0, "no embeddings → no vector results");
+        assert_eq!(result.results[0].symbol.name, "validate_token");
+        assert!(result.results[0].sources.contains(&"fts5".to_string()));
+
+        // generate_token matches "token" but NOT "validate" — must rank below validate_token
+        if let Some(gen_pos) = result
+            .results
+            .iter()
+            .position(|r| r.symbol.name == "generate_token")
+        {
+            assert!(
+                gen_pos > 0,
+                "generate_token should rank below validate_token"
+            );
+        }
+
+        // "authenticate" should find AuthService (content match)
+        let result = hybrid_search(&db, "authenticate", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "AuthService");
+
+        // send_email should NOT appear for an auth-related query
+        let names: Vec<&str> = result
+            .results
+            .iter()
+            .map(|r| r.symbol.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"send_email"),
+            "unrelated symbol should not appear for 'authenticate'"
+        );
+    }
+
+    #[test]
+    fn test_hybrid_search_typescript_ranking() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "UserService",
+            SymbolKind::Class,
+            "src/services/user.ts",
+            1,
+            "export class UserService {\n  async findById(id: string): Promise<User> {\n    return this.repository.findOne(id);\n  }\n}",
+        );
+        insert_symbol_with_content(
+            &db,
+            "createRouter",
+            SymbolKind::Function,
+            "src/routes/index.ts",
+            5,
+            "export function createRouter(app: Express): Router {\n  const router = Router();\n  router.get('/users', listUsers);\n  return router;\n}",
+        );
+        insert_symbol_with_content(
+            &db,
+            "DatabaseConnection",
+            SymbolKind::Class,
+            "src/db/connection.ts",
+            1,
+            "export class DatabaseConnection {\n  private pool: Pool;\n  async connect(config: DbConfig): Promise<void> {\n    this.pool = await createPool(config);\n  }\n}",
+        );
+
+        // "connect" matches DatabaseConnection's content; the others don't mention "connect"
+        let result = hybrid_search(&db, "connect", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "DatabaseConnection");
+        assert_eq!(
+            result.results.len(),
+            1,
+            "only DatabaseConnection contains 'connect'"
+        );
+
+        // "router" should rank createRouter #1
+        let result = hybrid_search(&db, "router", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "createRouter");
+    }
+
+    #[test]
+    fn test_hybrid_search_rust_ranking() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "extract",
+            SymbolKind::Method,
+            "src/languages/python.rs",
+            15,
+            "fn extract(&self, source: &str, file_path: &str) -> Result<ExtractionResult> {\n    let tree = self.parser.parse(source)?;\n    let mut symbols = Vec::new();\n    walk_tree(&tree, &mut symbols);\n    Ok(ExtractionResult { symbols, edges: vec![] })\n}",
+        );
+        insert_symbol_with_content(
+            &db,
+            "Database",
+            SymbolKind::Class,
+            "src/db.rs",
+            20,
+            "pub struct Database {\n    conn: Connection,\n}\nimpl Database {\n    pub fn open(path: impl AsRef<Path>) -> Result<Self> {\n        let conn = Connection::open(path)?;\n        Ok(Self { conn })\n    }\n}",
+        );
+        insert_symbol_with_content(
+            &db,
+            "resolve_edges",
+            SymbolKind::Method,
+            "src/db.rs",
+            100,
+            "pub fn resolve_edges(&self) -> Result<u32> {\n    // Match target_name to symbols: same file > same dir > unique project match\n    let mut resolved = 0;\n    resolved\n}",
+        );
+
+        // "extract symbols" — both terms in extract's content; Database/resolve_edges don't have "extract"
+        let result = hybrid_search(&db, "extract symbols", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "extract");
+
+        // "resolve edges" — only resolve_edges has both terms
+        let result = hybrid_search(&db, "resolve edges", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "resolve_edges");
+
+        // "Database" should not return extract or resolve_edges as #1
+        let result = hybrid_search(&db, "Database", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "Database");
+    }
+
+    #[test]
+    fn test_hybrid_search_go_ranking() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "HandleRequest",
+            SymbolKind::Function,
+            "handlers/auth.go",
+            10,
+            "func HandleRequest(w http.ResponseWriter, r *http.Request) {\n\ttoken := r.Header.Get(\"Authorization\")\n\tif !ValidateToken(token) {\n\t\thttp.Error(w, \"unauthorized\", 401)\n\t}\n}",
+        );
+        insert_symbol_with_content(
+            &db,
+            "Repository",
+            SymbolKind::Class,
+            "models/repository.go",
+            5,
+            "type Repository struct {\n\tdb *sql.DB\n}\n\nfunc (r *Repository) FindByID(id string) (*User, error) {\n\trow := r.db.QueryRow(\"SELECT * FROM users WHERE id = ?\", id)\n\treturn scanUser(row)\n}",
+        );
+
+        // "handle request" — HandleRequest has both terms in name+content
+        let result = hybrid_search(&db, "handle request", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "HandleRequest");
+
+        // Repository should not appear for "handle request" (no shared terms)
+        let names: Vec<&str> = result
+            .results
+            .iter()
+            .map(|r| r.symbol.name.as_str())
+            .collect();
+        assert!(!names.contains(&"Repository"));
+    }
+
+    #[test]
+    fn test_hybrid_search_ruby_ranking() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "SessionManager",
+            SymbolKind::Class,
+            "lib/session_manager.rb",
+            1,
+            "class SessionManager\n  def initialize(store)\n    @store = store\n  end\n\n  def create_session(user)\n    token = SecureRandom.hex(32)\n    @store.set(token, user.id)\n    token\n  end\nend",
+        );
+        insert_symbol_with_content(
+            &db,
+            "migrate",
+            SymbolKind::Method,
+            "db/migrate.rb",
+            5,
+            "def migrate(version:)\n  pending = migrations.select { |m| m.version > version }\n  pending.each { |m| m.up }\nend",
+        );
+
+        // "session" — SessionManager has it in name+content, migrate doesn't
+        let result = hybrid_search(&db, "session", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "SessionManager");
+        let names: Vec<&str> = result
+            .results
+            .iter()
+            .map(|r| r.symbol.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"migrate"),
+            "unrelated symbol should not appear"
+        );
+
+        // "migrate" — exact name match
+        let result = hybrid_search(&db, "migrate", 10, None).unwrap();
+        assert_eq!(result.results[0].symbol.name, "migrate");
+    }
+
+    // ── Precision and ranking tests ──
+
+    #[test]
+    fn test_ranking_relevant_above_irrelevant() {
+        let db = Database::open_memory().unwrap();
+        seed_python_corpus(&db);
+
+        // "token" appears in validate_token and generate_token content, NOT in send_email
+        let result = hybrid_search(&db, "token", 10, None).unwrap();
+        let names: Vec<&str> = result
+            .results
+            .iter()
+            .map(|r| r.symbol.name.as_str())
+            .collect();
+        assert!(
+            names.contains(&"validate_token"),
+            "validate_token should appear for 'token'"
+        );
+        assert!(
+            names.contains(&"generate_token"),
+            "generate_token should appear for 'token'"
+        );
+        assert!(
+            !names.contains(&"send_email"),
+            "send_email should NOT appear for 'token'"
+        );
+    }
+
+    #[test]
+    fn test_ranking_multi_term_beats_single_term() {
+        let db = Database::open_memory().unwrap();
+        seed_python_corpus(&db);
+
+        // "validate token" as a phrase matches validate_token exactly (FTS5 splits
+        // underscores into separate tokens). generate_token doesn't match the phrase
+        // because "validate" is not in its content.
+        let result = hybrid_search(&db, "validate token", 10, None).unwrap();
+        assert_eq!(
+            result.results[0].symbol.name, "validate_token",
+            "symbol matching both terms as phrase should rank #1"
+        );
+
+        // Now test OR ranking: "generate token" — generate_token and AuthService both
+        // contain "generate" and "token". Both should appear in top results.
+        let result = hybrid_search(&db, "generate token", 10, None).unwrap();
+        let top_names: Vec<&str> = result
+            .results
+            .iter()
+            .take(3)
+            .map(|r| r.symbol.name.as_str())
+            .collect();
+        assert!(
+            top_names.contains(&"generate_token"),
+            "generate_token should be in top 3 for 'generate token', got: {top_names:?}"
+        );
+        // validate_token should also appear (has "token") but ranked lower
+        if let Some(val) = result
+            .results
+            .iter()
+            .find(|r| r.symbol.name == "validate_token")
+        {
+            assert!(
+                result.results[0].rrf_score >= val.rrf_score,
+                "phrase match should score >= single-term match"
+            );
+        }
+    }
+
+    // ── FTS5 normalized name tests ──
+    //
+    // The normalized_name column in the FTS5 index splits camelCase/PascalCase/snake_case
+    // into individual words, enabling keyword matching across naming conventions.
+
+    #[test]
+    fn test_fts5_camel_case_matches_via_normalized_name() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "DatabaseConnection",
+            SymbolKind::Class,
+            "db.ts",
+            1,
+            "export class DatabaseConnection { }",
+        );
+
+        // "database" matches via normalized_name column ("database connection")
+        let result = hybrid_search(&db, "database", 10, None).unwrap();
+        assert_eq!(
+            result.results.len(),
+            1,
+            "normalized_name should split PascalCase — 'database' should match 'DatabaseConnection'"
+        );
+        assert_eq!(result.results[0].symbol.name, "DatabaseConnection");
+    }
+
+    #[test]
+    fn test_fts5_camel_case_multi_term() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "validateToken",
+            SymbolKind::Function,
+            "auth.ts",
+            1,
+            "function validateToken(t: string) { }",
+        );
+        insert_symbol_with_content(
+            &db,
+            "generateToken",
+            SymbolKind::Function,
+            "auth.ts",
+            10,
+            "function generateToken(user: string) { }",
+        );
+
+        // "validate token" as phrase matches normalized_name "validate token" exactly
+        let result = hybrid_search(&db, "validate token", 10, None).unwrap();
+        assert!(
+            !result.results.is_empty(),
+            "phrase 'validate token' should match validateToken via normalized_name"
+        );
+        assert_eq!(result.results[0].symbol.name, "validateToken");
+    }
+
+    #[test]
+    fn test_fts5_screaming_snake_case_matches() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "TOKEN_EXPIRY",
+            SymbolKind::Variable,
+            "config.py",
+            1,
+            "TOKEN_EXPIRY = 3600",
+        );
+
+        let result = hybrid_search(&db, "token expiry", 10, None).unwrap();
+        assert_eq!(
+            result.results.len(),
+            1,
+            "normalized_name should split SCREAMING_SNAKE — 'token expiry' should match 'TOKEN_EXPIRY'"
+        );
+    }
+
+    #[test]
+    fn test_fts5_limitation_no_substring_match() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "validate_token",
+            SymbolKind::Function,
+            "auth.py",
+            1,
+            "def validate_token(token): pass",
+        );
+
+        // FTS5 is token-based, not substring-based.
+        // "valid" does NOT match "validate" or "validate_token".
+        // Use `cartog search` for substring matching.
+        let result = hybrid_search(&db, "valid", 10, None).unwrap();
+        assert!(
+            result.results.is_empty(),
+            "FTS5 does not do substring matching — 'valid' should not match 'validate_token'. \
+             Use `cartog search` for substring matching."
+        );
+    }
+
+    // ── AND fallback test ──
+
+    #[test]
+    fn test_fts5_and_fallback_non_adjacent_terms() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "process_request",
+            SymbolKind::Function,
+            "server.py",
+            1,
+            "def process_request(req):\n    validated = validate(req)\n    response = build_response(validated)\n    return response",
+        );
+        insert_symbol_with_content(
+            &db,
+            "build_response",
+            SymbolKind::Function,
+            "server.py",
+            10,
+            "def build_response(data):\n    return Response(data=data, status=200)",
+        );
+
+        // "validate response" — no symbol has these words adjacent (phrase won't match).
+        // AND fallback: process_request has both "validate" and "response" in content.
+        // build_response has only "response" — should rank below process_request.
+        let result = hybrid_search(&db, "validate response", 10, None).unwrap();
+        assert!(
+            !result.results.is_empty(),
+            "AND fallback should find results"
+        );
+        assert_eq!(
+            result.results[0].symbol.name, "process_request",
+            "symbol containing both terms should rank #1 via AND fallback"
+        );
+    }
+
+    // ── Kind filter test ──
+
+    #[test]
+    fn test_hybrid_search_kind_filter() {
+        let db = Database::open_memory().unwrap();
+        seed_python_corpus(&db);
+
+        // Without filter: "token" matches functions and possibly classes
+        let all = hybrid_search(&db, "token", 10, None).unwrap();
+        assert!(all.results.len() >= 2);
+
+        // With kind=Function filter: only functions returned, still respects limit
+        let funcs = hybrid_search(&db, "token", 10, Some(SymbolKind::Function)).unwrap();
+        for r in &funcs.results {
+            assert_eq!(r.symbol.kind, SymbolKind::Function);
+        }
+
+        // With kind=Class: AuthService mentions "token" in content
+        let classes = hybrid_search(&db, "token", 10, Some(SymbolKind::Class)).unwrap();
+        for r in &classes.results {
+            assert_eq!(r.symbol.kind, SymbolKind::Class);
+        }
+    }
+
+    #[test]
+    fn test_kind_filter_respects_limit() {
+        let db = Database::open_memory().unwrap();
+        // Insert 5 functions and 5 classes, all mentioning "handler"
+        for i in 0..5 {
+            insert_symbol_with_content(
+                &db,
+                &format!("handle_func_{i}"),
+                SymbolKind::Function,
+                "handlers.py",
+                i * 20,
+                &format!("def handle_func_{i}(request): return handler_response({i})"),
+            );
+            insert_symbol_with_content(
+                &db,
+                &format!("HandlerClass{i}"),
+                SymbolKind::Class,
+                "handlers.py",
+                i * 20 + 10,
+                &format!(
+                    "class HandlerClass{i}:\n    def handle(self): return handler_result({i})"
+                ),
+            );
+        }
+
+        // Request 3 functions — should get exactly 3 despite 10 total matches
+        let result = hybrid_search(&db, "handler", 3, Some(SymbolKind::Function)).unwrap();
+        assert_eq!(
+            result.results.len(),
+            3,
+            "kind filter + limit should return exactly 3"
+        );
+        for r in &result.results {
+            assert_eq!(r.symbol.kind, SymbolKind::Function);
+        }
+    }
+
+    // ── Cross-language test ──
+
+    #[test]
+    fn test_hybrid_search_cross_language() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "validate",
+            SymbolKind::Function,
+            "auth.py",
+            1,
+            "def validate(token: str) -> bool:\n    return check_signature(token)",
+        );
+        insert_symbol_with_content(
+            &db,
+            "validate",
+            SymbolKind::Function,
+            "src/auth.ts",
+            1,
+            "export function validate(token: string): boolean {\n  return checkSignature(token);\n}",
+        );
+        insert_symbol_with_content(
+            &db,
+            "validate",
+            SymbolKind::Function,
+            "auth.go",
+            1,
+            "func validate(token string) bool {\n\treturn checkSignature(token)\n}",
+        );
+
+        let result = hybrid_search(&db, "validate", 10, None).unwrap();
+        assert_eq!(
+            result.results.len(),
+            3,
+            "should find validate in all 3 languages"
+        );
+        for r in &result.results {
+            assert_eq!(r.symbol.name, "validate");
+        }
+    }
+
+    // ── Edge cases ──
+
+    #[test]
+    fn test_hybrid_search_no_results() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "foo",
+            SymbolKind::Function,
+            "a.py",
+            1,
+            "def foo(): pass",
+        );
+
+        let result = hybrid_search(&db, "zzz_nonexistent_term", 10, None).unwrap();
+        assert!(result.results.is_empty());
+        assert_eq!(result.fts_count, 0);
+        assert_eq!(result.vec_count, 0);
+    }
+
+    #[test]
+    fn test_hybrid_search_content_returned() {
+        let db = Database::open_memory().unwrap();
+        let content = "def greet(name: str) -> str:\n    return f'Hello, {name}!'";
+        insert_symbol_with_content(&db, "greet", SymbolKind::Function, "hello.py", 1, content);
+
+        let result = hybrid_search(&db, "greet", 10, None).unwrap();
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].content.as_deref(), Some(content));
+    }
+
+    #[test]
+    fn test_hybrid_search_respects_limit() {
+        let db = Database::open_memory().unwrap();
+        for i in 0..10 {
+            insert_symbol_with_content(
+                &db,
+                &format!("handler_{i}"),
+                SymbolKind::Function,
+                "handlers.py",
+                i * 15,
+                &format!("def handler_{i}(request):\n    return response(handler={i})"),
+            );
+        }
+
+        let result = hybrid_search(&db, "handler", 3, None).unwrap();
+        assert_eq!(
+            result.results.len(),
+            3,
+            "should return exactly limit results"
+        );
+        assert!(result.fts_count > 3, "FTS should over-retrieve");
+    }
+
+    // ── Rerank sorting tests ──
+
+    fn make_result(
+        name: &str,
+        rrf: f64,
+        rerank: Option<f64>,
+        content: Option<&str>,
+    ) -> SearchResult {
+        SearchResult {
+            symbol: Symbol::new(name, SymbolKind::Function, "test.py", 1, 10, 0, 100),
+            content: content.map(|s| s.to_string()),
+            rrf_score: rrf,
+            rerank_score: rerank,
+            sources: vec!["fts5".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_rerank_sort_reorders_by_score_descending() {
+        let mut candidates = [
+            make_result("low", 0.9, Some(1.0), Some("low content")),
+            make_result("high", 0.5, Some(9.0), Some("high content")),
+            make_result("mid", 0.7, Some(5.0), Some("mid content")),
+        ];
+
+        // Simulate what rerank_candidates does after scoring: just sort
+        candidates.sort_by(|a, b| match (a.rerank_score, b.rerank_score) {
+            (Some(sa), Some(sb)) => sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+
+        assert_eq!(candidates[0].symbol.name, "high");
+        assert_eq!(candidates[1].symbol.name, "mid");
+        assert_eq!(candidates[2].symbol.name, "low");
+    }
+
+    #[test]
+    fn test_rerank_sort_scored_before_unscored() {
+        let mut candidates = [
+            make_result("no_content", 0.9, None, None),
+            make_result("scored", 0.3, Some(2.0), Some("content")),
+            make_result("also_no_content", 0.8, None, None),
+        ];
+
+        candidates.sort_by(|a, b| match (a.rerank_score, b.rerank_score) {
+            (Some(sa), Some(sb)) => sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+
+        assert_eq!(candidates[0].symbol.name, "scored");
+        // Unscored maintain relative order (stable sort)
+        assert_eq!(candidates[1].symbol.name, "no_content");
+        assert_eq!(candidates[2].symbol.name, "also_no_content");
+    }
+
+    #[test]
+    fn test_rerank_sort_all_unscored_preserves_order() {
+        let mut candidates = [
+            make_result("first", 0.9, None, None),
+            make_result("second", 0.5, None, None),
+            make_result("third", 0.3, None, None),
+        ];
+
+        candidates.sort_by(|a, b| match (a.rerank_score, b.rerank_score) {
+            (Some(sa), Some(sb)) => sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+
+        // No rerank scores → original (RRF) order preserved
+        assert_eq!(candidates[0].symbol.name, "first");
+        assert_eq!(candidates[1].symbol.name, "second");
+        assert_eq!(candidates[2].symbol.name, "third");
+    }
+
+    #[test]
+    fn test_hybrid_search_rerank_score_consistency() {
+        let db = Database::open_memory().unwrap();
+        insert_symbol_with_content(
+            &db,
+            "process_data",
+            SymbolKind::Function,
+            "data.py",
+            1,
+            "def process_data(items):\n    return [transform(i) for i in items]",
+        );
+
+        let result = hybrid_search(&db, "process data", 10, None).unwrap();
+        assert!(!result.results.is_empty());
+
+        // Re-ranking depends on whether the cross-encoder model is downloadable.
+        // In CI / offline environments, rerank_score will be None.
+        // In environments with the model, results with content will have a rerank_score.
+        let has_rerank = result.results.iter().any(|r| r.rerank_score.is_some());
+        if has_rerank {
+            for r in &result.results {
+                if r.content.is_some() {
+                    assert!(
+                        r.rerank_score.is_some(),
+                        "rerank_score should be set when cross-encoder is available"
+                    );
+                }
+            }
+        } else {
+            for r in &result.results {
+                assert!(
+                    r.rerank_score.is_none(),
+                    "rerank_score should be None without cross-encoder model"
+                );
+            }
+        }
+    }
+}

--- a/src/rag/setup.rs
+++ b/src/rag/setup.rs
@@ -1,0 +1,40 @@
+use anyhow::{Context, Result};
+
+use super::embeddings::EmbeddingEngine;
+use super::model_cache_dir;
+use super::reranker::CrossEncoderEngine;
+
+/// Result of the setup operation.
+#[derive(Debug, serde::Serialize)]
+pub struct SetupResult {
+    pub model_dir: String,
+}
+
+/// Download the embedding model by initializing the fastembed engine.
+///
+/// fastembed automatically downloads the ONNX model from HuggingFace on first use.
+/// This function eagerly triggers that download so the user sees progress.
+pub fn download_model() -> Result<SetupResult> {
+    let cache_dir = model_cache_dir();
+
+    let _engine =
+        EmbeddingEngine::new_with_progress().context("Failed to download embedding model")?;
+
+    Ok(SetupResult {
+        model_dir: cache_dir.display().to_string(),
+    })
+}
+
+/// Download the cross-encoder re-ranker model.
+///
+/// fastembed automatically downloads the ONNX model from HuggingFace on first use.
+pub fn download_cross_encoder() -> Result<SetupResult> {
+    let cache_dir = model_cache_dir();
+
+    let _engine = CrossEncoderEngine::load_with_progress()
+        .context("Failed to download cross-encoder model")?;
+
+    Ok(SetupResult {
+        model_dir: cache_dir.display().to_string(),
+    })
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,742 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use tracing::{debug, info, warn};
+
+use crate::db::Database;
+use crate::indexer::{self, is_ignored_dirname};
+use crate::languages::detect_language;
+use crate::rag;
+
+/// Configuration for the watch loop.
+pub struct WatchConfig {
+    /// Root directory to watch.
+    pub root: PathBuf,
+    /// Debounce window for filesystem events.
+    pub debounce: Duration,
+    /// Whether to auto-embed after indexing.
+    pub rag: bool,
+    /// Delay after last index before embedding (only when `rag` is true).
+    pub rag_delay: Duration,
+}
+
+impl WatchConfig {
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            debounce: Duration::from_secs(2),
+            rag: false,
+            rag_delay: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Handle returned by `spawn_watch`. Drop or call `stop()` to shut down the watcher.
+pub struct WatchHandle {
+    shutdown: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl WatchHandle {
+    /// Signal the watch loop to stop and wait for it to finish.
+    pub fn stop(mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for WatchHandle {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        // Don't join on drop — the thread will exit on next loop iteration.
+    }
+}
+
+/// Spawn the watch loop on a background thread.
+///
+/// Returns a `WatchHandle` that can be used to stop the watcher.
+/// The watcher opens its own `Database` connection (SQLite WAL allows concurrent readers).
+pub fn spawn_watch(config: WatchConfig, db_path: &str) -> Result<WatchHandle> {
+    let root = config
+        .root
+        .canonicalize()
+        .context("cannot resolve watch root")?;
+
+    if !root.is_dir() {
+        anyhow::bail!("watch target is not a directory: {}", root.display());
+    }
+
+    let db_path = db_path.to_string();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = Arc::clone(&shutdown);
+
+    let thread = std::thread::Builder::new()
+        .name("cartog-watch".into())
+        .spawn(move || {
+            if let Err(e) = watch_loop(config, &root, &db_path, &shutdown_clone) {
+                warn!(error = %e, "watch loop exited with error");
+            }
+        })
+        .context("failed to spawn watch thread")?;
+
+    Ok(WatchHandle {
+        shutdown,
+        thread: Some(thread),
+    })
+}
+
+/// Run the watch loop in the foreground (blocking).
+///
+/// Used by `cartog watch` CLI command.
+pub fn run_watch(config: WatchConfig, db_path: &str) -> Result<()> {
+    let root = config
+        .root
+        .canonicalize()
+        .context("cannot resolve watch root")?;
+
+    if !root.is_dir() {
+        anyhow::bail!("watch target is not a directory: {}", root.display());
+    }
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = Arc::clone(&shutdown);
+
+    // Install Ctrl+C handler for graceful shutdown
+    install_ctrlc_handler(&shutdown_clone);
+
+    watch_loop(config, &root, db_path, &shutdown)
+}
+
+/// Install a Ctrl+C handler that sets the shutdown flag.
+fn install_ctrlc_handler(flag: &Arc<AtomicBool>) {
+    let flag = Arc::clone(flag);
+    let _ = ctrlc::set_handler(move || {
+        flag.store(true, Ordering::SeqCst);
+    });
+}
+
+/// Core watch loop. Runs until `shutdown` is set.
+fn watch_loop(
+    config: WatchConfig,
+    root: &Path,
+    db_path: &str,
+    shutdown: &AtomicBool,
+) -> Result<()> {
+    let db = Database::open(db_path).context("failed to open database for watcher")?;
+
+    info!(
+        path = %root.display(),
+        debounce_ms = config.debounce.as_millis(),
+        rag = config.rag,
+        rag_delay_s = config.rag_delay.as_secs(),
+        "starting watch"
+    );
+
+    // Initial incremental index to ensure DB is current
+    match indexer::index_directory(&db, root, false) {
+        Ok(r) => info!(
+            files = r.files_indexed,
+            skipped = r.files_skipped,
+            removed = r.files_removed,
+            symbols = r.symbols_added,
+            "initial index complete"
+        ),
+        Err(e) => warn!(error = %e, "initial index failed"),
+    }
+
+    // Set up the debounced file watcher
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut debouncer =
+        new_debouncer(config.debounce, tx).context("failed to create file watcher")?;
+
+    debouncer
+        .watcher()
+        .watch(root, notify::RecursiveMode::Recursive)
+        .context("failed to start watching directory")?;
+
+    info!("watching for changes (Ctrl+C to stop)");
+
+    // RAG timer state: when we last indexed (to defer embedding)
+    let mut rag_pending = false;
+    let mut last_index_time: Option<Instant> = None;
+
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+
+        // Wait for events with a timeout so we can check shutdown + RAG timer
+        let poll_timeout = if config.rag && rag_pending {
+            Duration::from_millis(500) // Poll frequently to check RAG timer
+        } else {
+            Duration::from_secs(1) // Idle poll for shutdown check
+        };
+
+        match rx.recv_timeout(poll_timeout) {
+            Ok(Ok(events)) => {
+                // Filter events to only supported source files in non-ignored dirs
+                let relevant = events.iter().any(|event| {
+                    event.kind == DebouncedEventKind::Any && is_relevant_path(&event.path, root)
+                });
+
+                if relevant {
+                    debug!(
+                        count = events.len(),
+                        "file change events received, re-indexing"
+                    );
+                    match indexer::index_directory(&db, root, false) {
+                        Ok(r) => {
+                            if r.files_indexed > 0 || r.files_removed > 0 {
+                                info!(
+                                    files = r.files_indexed,
+                                    skipped = r.files_skipped,
+                                    removed = r.files_removed,
+                                    symbols = r.symbols_added,
+                                    "re-indexed"
+                                );
+                            }
+                            // Check if RAG embedding is needed
+                            if config.rag {
+                                match db.symbols_needing_embeddings() {
+                                    Ok(needing) if !needing.is_empty() => {
+                                        debug!(
+                                            pending = needing.len(),
+                                            "symbols need embedding, starting RAG timer"
+                                        );
+                                        rag_pending = true;
+                                        last_index_time = Some(Instant::now());
+                                    }
+                                    Ok(_) => {
+                                        // No symbols need embedding
+                                        rag_pending = false;
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "failed to check embedding status");
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => warn!(error = %e, "re-index failed"),
+                    }
+                }
+            }
+            Ok(Err(error)) => {
+                warn!(error = %error, "file watcher error");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Check RAG timer
+                if config.rag && rag_pending {
+                    if let Some(last) = last_index_time {
+                        if last.elapsed() >= config.rag_delay {
+                            info!("RAG delay elapsed, embedding pending symbols");
+                            match rag::indexer::index_embeddings(&db, false) {
+                                Ok(r) => {
+                                    info!(
+                                        embedded = r.symbols_embedded,
+                                        skipped = r.symbols_skipped,
+                                        "RAG embedding complete"
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!(error = %e, "RAG embedding failed");
+                                }
+                            }
+                            rag_pending = false;
+                            last_index_time = None;
+                        }
+                    }
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                warn!("file watcher channel disconnected");
+                break;
+            }
+        }
+    }
+
+    // Flush pending RAG embeddings on shutdown
+    if config.rag && rag_pending {
+        info!("flushing pending RAG embeddings before shutdown");
+        match rag::indexer::index_embeddings(&db, false) {
+            Ok(r) => info!(embedded = r.symbols_embedded, "final RAG flush complete"),
+            Err(e) => warn!(error = %e, "final RAG flush failed"),
+        }
+    }
+
+    info!("watch stopped");
+    Ok(())
+}
+
+/// Check if a path is relevant for indexing: supported language + not in ignored directory.
+///
+/// Returns `false` for:
+/// - Files with unsupported extensions (no tree-sitter extractor)
+/// - Files outside the watched root (e.g., symlink escapes)
+/// - Files under an ignored directory (`.git`, `node_modules`, etc.)
+fn is_relevant_path(path: &Path, root: &Path) -> bool {
+    // Must be a supported source file
+    if detect_language(path).is_none() {
+        return false;
+    }
+
+    // Must be under the watched root
+    let relative = match path.strip_prefix(root) {
+        Ok(rel) => rel,
+        Err(_) => return false,
+    };
+
+    // Check that no ancestor directory is ignored
+    if let Some(parent) = relative.parent() {
+        for component in parent.components() {
+            if let std::path::Component::Normal(name) = component {
+                if let Some(name_str) = name.to_str() {
+                    if is_ignored_dirname(name_str) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── Language coverage: all supported extensions ──
+
+    #[test]
+    fn test_relevant_python_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/main.py"), &root));
+    }
+
+    #[test]
+    fn test_relevant_python_stub() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/types.pyi"), &root));
+    }
+
+    #[test]
+    fn test_relevant_typescript_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/app.ts"), &root));
+    }
+
+    #[test]
+    fn test_relevant_tsx_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/App.tsx"), &root));
+    }
+
+    #[test]
+    fn test_relevant_javascript_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/index.js"), &root));
+    }
+
+    #[test]
+    fn test_relevant_jsx_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/App.jsx"), &root));
+    }
+
+    #[test]
+    fn test_relevant_mjs_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/utils.mjs"), &root));
+    }
+
+    #[test]
+    fn test_relevant_cjs_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(
+            Path::new("/project/src/config.cjs"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_relevant_rust_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/src/lib.rs"), &root));
+    }
+
+    #[test]
+    fn test_relevant_go_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/cmd/main.go"), &root));
+    }
+
+    #[test]
+    fn test_relevant_ruby_file() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(
+            Path::new("/project/lib/service.rb"),
+            &root
+        ));
+    }
+
+    // ── Irrelevant file types ──
+
+    #[test]
+    fn test_irrelevant_json_file() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(Path::new("/project/package.json"), &root));
+    }
+
+    #[test]
+    fn test_irrelevant_markdown_file() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(Path::new("/project/README.md"), &root));
+    }
+
+    #[test]
+    fn test_irrelevant_toml_file() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(Path::new("/project/Cargo.toml"), &root));
+    }
+
+    #[test]
+    fn test_irrelevant_yaml_file() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.github/ci.yml"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_irrelevant_no_extension() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(Path::new("/project/Makefile"), &root));
+    }
+
+    // ── Ignored directories (all entries from is_ignored_dirname) ──
+
+    #[test]
+    fn test_ignored_node_modules() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/node_modules/pkg/index.js"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_git_dir() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.git/hooks/pre-commit.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_target_dir() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/target/debug/build.rs"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_pycache() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/src/__pycache__/mod.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_nested_vendor() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/lib/vendor/gem/lib.rb"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_venv() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.venv/lib/site.py"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/venv/lib/site.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_env() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.env/lib/site.py"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/env/lib/site.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_dist_build() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/dist/bundle.js"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/build/output.js"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_next_nuxt() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.next/server/app.js"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/.nuxt/dist/app.js"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_mypy_pytest_tox() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.mypy_cache/3.11/mod.py"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/.pytest_cache/v/test.py"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/.tox/py311/lib.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_ignored_hg_svn() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.hg/store/data.py"),
+            &root
+        ));
+        assert!(!is_relevant_path(
+            Path::new("/project/.svn/entries.py"),
+            &root
+        ));
+    }
+
+    // ── Path boundary conditions ──
+
+    #[test]
+    fn test_hidden_dir_ignored() {
+        let root = PathBuf::from("/project");
+        assert!(!is_relevant_path(
+            Path::new("/project/.hidden/script.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_root_level_file_allowed() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(Path::new("/project/setup.py"), &root));
+    }
+
+    #[test]
+    fn test_deeply_nested_file_allowed() {
+        let root = PathBuf::from("/project");
+        assert!(is_relevant_path(
+            Path::new("/project/src/auth/tokens/validate.py"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn test_path_outside_root_rejected() {
+        let root = PathBuf::from("/project");
+        assert!(
+            !is_relevant_path(Path::new("/other/project/main.py"), &root),
+            "files outside root should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_path_sibling_of_root_rejected() {
+        let root = PathBuf::from("/workspace/project-a");
+        assert!(
+            !is_relevant_path(Path::new("/workspace/project-b/main.py"), &root),
+            "files in sibling directory should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_path_partial_prefix_rejected() {
+        let root = PathBuf::from("/project");
+        // "/project-b/main.py" starts with "/project" as a string but is not under /project/
+        assert!(
+            !is_relevant_path(Path::new("/project-b/main.py"), &root),
+            "partial prefix match should be rejected (strip_prefix handles this correctly)"
+        );
+    }
+
+    // ── WatchConfig ──
+
+    #[test]
+    fn test_config_defaults() {
+        let config = WatchConfig::new(PathBuf::from("."));
+        assert_eq!(config.debounce, Duration::from_secs(2));
+        assert!(!config.rag);
+        assert_eq!(config.rag_delay, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_config_custom_values() {
+        let mut config = WatchConfig::new(PathBuf::from("/my/project"));
+        config.debounce = Duration::from_secs(5);
+        config.rag = true;
+        config.rag_delay = Duration::from_secs(60);
+        assert_eq!(config.root, PathBuf::from("/my/project"));
+        assert_eq!(config.debounce, Duration::from_secs(5));
+        assert!(config.rag);
+        assert_eq!(config.rag_delay, Duration::from_secs(60));
+    }
+
+    // ── spawn_watch error paths ──
+
+    #[test]
+    fn test_spawn_watch_nonexistent_dir() {
+        let config = WatchConfig::new(PathBuf::from("/nonexistent/path/xyz"));
+        let result = spawn_watch(config, ":memory:");
+        assert!(result.is_err(), "should fail for nonexistent directory");
+    }
+
+    #[test]
+    fn test_spawn_watch_file_not_dir() {
+        // Use Cargo.toml as a file that exists but is not a directory
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let config = WatchConfig::new(manifest);
+        let result = spawn_watch(config, ":memory:");
+        assert!(
+            result.is_err(),
+            "should fail when target is a file, not dir"
+        );
+    }
+
+    // ── is_ignored_dirname direct tests ──
+
+    #[test]
+    fn test_is_ignored_dirname_known_dirs() {
+        let ignored = [
+            ".git",
+            ".hg",
+            ".svn",
+            "node_modules",
+            "__pycache__",
+            ".mypy_cache",
+            ".pytest_cache",
+            ".tox",
+            ".venv",
+            "venv",
+            ".env",
+            "env",
+            "target",
+            "dist",
+            "build",
+            ".next",
+            ".nuxt",
+            "vendor",
+        ];
+        for name in &ignored {
+            assert!(is_ignored_dirname(name), "{name} should be ignored");
+        }
+    }
+
+    #[test]
+    fn test_is_ignored_dirname_hidden_dirs() {
+        assert!(is_ignored_dirname(".hidden"));
+        assert!(is_ignored_dirname(".cache"));
+        assert!(is_ignored_dirname(".config"));
+    }
+
+    #[test]
+    fn test_is_ignored_dirname_allowed_dirs() {
+        let allowed = [
+            "src", "lib", "tests", "docs", "app", "cmd", "internal", "pkg",
+        ];
+        for name in &allowed {
+            assert!(!is_ignored_dirname(name), "{name} should NOT be ignored");
+        }
+    }
+
+    #[test]
+    fn test_is_ignored_dirname_case_sensitive() {
+        // "Target" != "target" — should NOT be ignored (case-sensitive match)
+        assert!(!is_ignored_dirname("Target"));
+        assert!(!is_ignored_dirname("NODE_MODULES"));
+        assert!(!is_ignored_dirname("Vendor"));
+    }
+
+    // ── WatchHandle shutdown ──
+
+    #[test]
+    fn test_watch_handle_drop_signals_shutdown() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let handle = WatchHandle {
+            shutdown: shutdown_clone,
+            thread: None,
+        };
+        assert!(!shutdown.load(Ordering::SeqCst));
+        drop(handle);
+        assert!(
+            shutdown.load(Ordering::SeqCst),
+            "drop should set shutdown flag"
+        );
+    }
+
+    #[test]
+    fn test_watch_handle_stop_signals_and_joins() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let shutdown_for_thread = Arc::clone(&shutdown);
+
+        let thread = std::thread::spawn(move || {
+            // Simulate work loop that checks shutdown
+            while !shutdown_for_thread.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        });
+
+        let handle = WatchHandle {
+            shutdown: shutdown_clone,
+            thread: Some(thread),
+        };
+        handle.stop(); // Should set flag AND join thread
+        assert!(shutdown.load(Ordering::SeqCst));
+    }
+}

--- a/tests/rag_relevancy.rs
+++ b/tests/rag_relevancy.rs
@@ -1,0 +1,250 @@
+//! RAG search relevancy benchmark.
+//!
+//! Indexes the Python benchmark fixture, runs a fixed set of queries with
+//! expected results, and computes precision@k, recall@k, and NDCG@k.
+//!
+//! Run with: `cargo test --test rag_relevancy -- --nocapture`
+//!
+//! The output is a table of scores per query, plus aggregated means.
+//! Use this to compare search quality before/after changes.
+
+use std::path::Path;
+
+use cartog::db::Database;
+use cartog::indexer::index_directory;
+use cartog::rag::search::hybrid_search;
+
+/// A single relevancy test case.
+struct QueryCase {
+    /// Natural language query to run.
+    query: &'static str,
+    /// Symbol names that MUST appear in the top-k results, in ideal rank order.
+    /// First = most relevant. Used for NDCG.
+    expected: &'static [&'static str],
+    /// k — how many results to evaluate.
+    k: usize,
+}
+
+/// Precision@k: fraction of top-k results that are in the expected set.
+fn precision_at_k(results: &[String], expected: &[&str], k: usize) -> f64 {
+    let top_k: Vec<&str> = results.iter().take(k).map(|s| s.as_str()).collect();
+    if top_k.is_empty() {
+        return 0.0;
+    }
+    let hits = top_k.iter().filter(|r| expected.contains(r)).count();
+    hits as f64 / top_k.len() as f64
+}
+
+/// Recall@k: fraction of expected items that appear in the top-k results.
+fn recall_at_k(results: &[String], expected: &[&str], k: usize) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    let top_k: Vec<&str> = results.iter().take(k).map(|s| s.as_str()).collect();
+    let hits = expected.iter().filter(|e| top_k.contains(e)).count();
+    hits as f64 / expected.len() as f64
+}
+
+/// NDCG@k: Normalized Discounted Cumulative Gain.
+///
+/// `expected` defines the ideal relevance order: position 0 = rel score len,
+/// position 1 = rel score len-1, etc. (graded relevance by expected rank).
+fn ndcg_at_k(results: &[String], expected: &[&str], k: usize) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+
+    // Assign relevance scores: expected[0] gets score len, expected[1] gets len-1, etc.
+    let max_rel = expected.len();
+    let relevance = |name: &str| -> f64 {
+        expected
+            .iter()
+            .position(|e| *e == name)
+            .map(|pos| (max_rel - pos) as f64)
+            .unwrap_or(0.0)
+    };
+
+    // DCG@k
+    let dcg: f64 = results
+        .iter()
+        .take(k)
+        .enumerate()
+        .map(|(i, name)| relevance(name) / (2.0_f64 + i as f64).log2())
+        .sum();
+
+    // Ideal DCG@k (expected in perfect order)
+    let idcg: f64 = expected
+        .iter()
+        .take(k)
+        .enumerate()
+        .map(|(i, _)| (max_rel - i) as f64 / (2.0_f64 + i as f64).log2())
+        .sum();
+
+    if idcg == 0.0 {
+        0.0
+    } else {
+        dcg / idcg
+    }
+}
+
+fn setup_db() -> Database {
+    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("benchmarks")
+        .join("fixtures")
+        .join("webapp_py");
+
+    let db = Database::open_memory().expect("open in-memory DB");
+    index_directory(&db, &fixture_dir, true).expect("index fixture");
+    db
+}
+
+#[test]
+fn rag_relevancy_benchmark() {
+    let db = setup_db();
+
+    // Ground truth: expected symbol names come from `cartog search` on webapp_py.
+    // Ordered by ideal relevance (best match first) for NDCG scoring.
+    let cases = vec![
+        QueryCase {
+            query: "validate token",
+            expected: &["validate_token", "verify_token", "extract_token"],
+            k: 5,
+        },
+        QueryCase {
+            query: "database connection",
+            expected: &["DatabaseConnection", "ConnectionHandle", "get_connection"],
+            k: 5,
+        },
+        QueryCase {
+            query: "authenticate user",
+            expected: &["authenticate", "login", "AuthService"],
+            k: 5,
+        },
+        QueryCase {
+            query: "send email",
+            expected: &[
+                "send_welcome_email",
+                "send_password_reset_email",
+                "EmailSender",
+                "process_email_queue",
+            ],
+            k: 5,
+        },
+        QueryCase {
+            query: "cache",
+            expected: &["cache_get", "cache_set", "cache_invalidate", "BaseCache"],
+            k: 5,
+        },
+        QueryCase {
+            query: "error exception",
+            expected: &["AppError", "TokenError", "DatabaseError", "ValidationError"],
+            k: 10,
+        },
+        QueryCase {
+            query: "middleware",
+            expected: &[
+                "auth_middleware",
+                "logging_middleware",
+                "rate_limit_middleware",
+                "cors_middleware",
+            ],
+            k: 5,
+        },
+        QueryCase {
+            query: "user",
+            expected: &["User", "UserQueries", "get_current_user"],
+            k: 5,
+        },
+        QueryCase {
+            query: "login route",
+            expected: &["login_route", "logout_route", "refresh_route"],
+            k: 5,
+        },
+        QueryCase {
+            query: "generate token",
+            expected: &["generate_token"],
+            k: 3,
+        },
+    ];
+
+    // Try loading the cross-encoder to check availability.
+    let reranker_active = cartog::rag::reranker::CrossEncoderEngine::load().is_ok();
+
+    println!();
+    println!(
+        "  Re-ranker: {}",
+        if reranker_active {
+            "active"
+        } else {
+            "off (model not downloaded)"
+        }
+    );
+    println!();
+    println!(
+        "  {:<35} {:>10} {:>10} {:>10} {:>6}",
+        "Query", "P@k", "R@k", "NDCG@k", "k"
+    );
+    println!("  {}", "-".repeat(75));
+
+    let mut total_p = 0.0;
+    let mut total_r = 0.0;
+    let mut total_ndcg = 0.0;
+    let n = cases.len() as f64;
+
+    for case in &cases {
+        let result = hybrid_search(&db, case.query, case.k as u32, None)
+            .unwrap_or_else(|e| panic!("search failed for '{}': {e}", case.query));
+
+        let names: Vec<String> = result
+            .results
+            .iter()
+            .map(|r| r.symbol.name.clone())
+            .collect();
+
+        let p = precision_at_k(&names, case.expected, case.k);
+        let r = recall_at_k(&names, case.expected, case.k);
+        let ndcg = ndcg_at_k(&names, case.expected, case.k);
+
+        total_p += p;
+        total_r += r;
+        total_ndcg += ndcg;
+
+        println!(
+            "  {:<35} {:>9.1}% {:>9.1}% {:>9.3}  {:>5}",
+            case.query,
+            p * 100.0,
+            r * 100.0,
+            ndcg,
+            case.k
+        );
+
+        // Print actual results for debugging
+        let actual_str = if names.is_empty() {
+            "(no results)".to_string()
+        } else {
+            names
+                .iter()
+                .take(case.k)
+                .map(|n| {
+                    if case.expected.contains(&n.as_str()) {
+                        format!("[{n}]")
+                    } else {
+                        n.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        println!("    got: {actual_str}");
+    }
+
+    println!("  {}", "-".repeat(75));
+    println!(
+        "  {:<35} {:>9.1}% {:>9.1}% {:>9.3}",
+        "MEAN",
+        total_p / n * 100.0,
+        total_r / n * 100.0,
+        total_ndcg / n,
+    );
+    println!();
+}


### PR DESCRIPTION
- RAG: hybrid FTS5 + vector KNN search with RRF merge and cross-encoder re-ranking, fastembed ONNX inference (BAAI/bge-small-en-v1.5), shared model cache (~/.cache/cartog/models/), sqlite-vec vector storage
- Watch: cartog watch CLI + cartog serve --watch background mode, debounced re-index with deferred RAG embedding, notify-debouncer-mini
- MCP: 11 tools (9 core + 2 RAG), --watch and --rag flags for serve
- Skill: smart search routing (keyword/semantic/parallel), narrowing pattern, updated decision heuristics
- README: privacy section, search routing guide, watch/serve docs
- Fix: is_relevant_path bug (path outside root returned true)
- Add LICENSE file (MIT), benchmark scenario 13 (rag_search)