### PR TITLE
feat: improve AST navigation with query API, richer types, and better edge resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlite-vec",
+ "streaming-iterator",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["development-tools", "command-line-utilities"]
 
 [dependencies]
 tree-sitter = "0.24"
+streaming-iterator = "0.1"
 tree-sitter-python = "0.23"
 tree-sitter-javascript = "0.23"
 tree-sitter-typescript = "0.23"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,11 @@ pub enum SymbolKindFilter {
     Method,
     Variable,
     Import,
+    Interface,
+    Enum,
+    TypeAlias,
+    Trait,
+    Module,
 }
 
 impl From<SymbolKindFilter> for SymbolKind {
@@ -33,6 +38,11 @@ impl From<SymbolKindFilter> for SymbolKind {
             SymbolKindFilter::Method => SymbolKind::Method,
             SymbolKindFilter::Variable => SymbolKind::Variable,
             SymbolKindFilter::Import => SymbolKind::Import,
+            SymbolKindFilter::Interface => SymbolKind::Interface,
+            SymbolKindFilter::Enum => SymbolKind::Enum,
+            SymbolKindFilter::TypeAlias => SymbolKind::TypeAlias,
+            SymbolKindFilter::Trait => SymbolKind::Trait,
+            SymbolKindFilter::Module => SymbolKind::Module,
         }
     }
 }
@@ -45,6 +55,8 @@ pub enum EdgeKindFilter {
     Inherits,
     References,
     Raises,
+    Implements,
+    TypeOf,
 }
 
 impl From<EdgeKindFilter> for EdgeKind {
@@ -55,6 +67,8 @@ impl From<EdgeKindFilter> for EdgeKind {
             EdgeKindFilter::Inherits => EdgeKind::Inherits,
             EdgeKindFilter::References => EdgeKind::References,
             EdgeKindFilter::Raises => EdgeKind::Raises,
+            EdgeKindFilter::Implements => EdgeKind::Implements,
+            EdgeKindFilter::TypeOf => EdgeKind::TypeOf,
         }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -399,17 +399,25 @@ impl Database {
     // ── Edge Resolution ──
 
     /// Resolve target_name → target_id for all unresolved edges.
-    /// Priority: exact match in same file > same directory > unique project-wide match.
+    ///
+    /// 5-tier priority resolution:
+    /// 1. Same file — symbol with matching name in the same file
+    /// 2. Import-path — follow imports to find the target in the imported file
+    /// 3. Same directory — symbol in a file in the same directory
+    /// 4. Parent scope preference — when multiple global matches, prefer same parent scope
+    /// 5. Unique project-wide match — exactly one symbol with that name globally
     pub fn resolve_edges(&self) -> Result<u32> {
         let mut resolved = 0u32;
 
         let mut unresolved_stmt = self.conn.prepare(
-            "SELECT e.id, e.target_name, e.file_path
+            "SELECT e.id, e.target_name, e.file_path, e.source_id
              FROM edges e WHERE e.target_id IS NULL",
         )?;
 
-        let unresolved: Vec<(i64, String, String)> = unresolved_stmt
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        let unresolved: Vec<(i64, String, String, String)> = unresolved_stmt
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         let tx = self.conn.unchecked_transaction()?;
@@ -417,17 +425,38 @@ impl Database {
         let mut same_file_stmt = self
             .conn
             .prepare("SELECT id FROM symbols WHERE name = ?1 AND file_path = ?2 LIMIT 1")?;
+
+        // Import-path resolution: find files that the source file imports from,
+        // then look for the target symbol in those files
+        let mut import_resolve_stmt = self.conn.prepare(
+            "SELECT s.id FROM symbols s
+             INNER JOIN edges ie ON ie.kind = 'imports' AND ie.target_name = ?1
+             INNER JOIN symbols is2 ON is2.id = ie.source_id AND is2.file_path = ?2
+             WHERE s.name = ?1 AND s.kind != 'import'
+             LIMIT 1",
+        )?;
+
         let mut same_dir_stmt = self
             .conn
             .prepare("SELECT id FROM symbols WHERE name = ?1 AND file_path LIKE ?2 LIMIT 1")?;
+
+        // Parent scope preference: find symbols with same name and same parent scope
+        let mut parent_scope_stmt = self.conn.prepare(
+            "SELECT s.id FROM symbols s
+             INNER JOIN symbols source ON source.id = ?2
+             WHERE s.name = ?1 AND s.parent_id = source.parent_id AND s.id != source.id
+             LIMIT 1",
+        )?;
+
         let mut anywhere_stmt = self
             .conn
-            .prepare("SELECT id FROM symbols WHERE name = ?1 LIMIT 2")?;
+            .prepare("SELECT id FROM symbols WHERE name = ?1 AND kind != 'import' LIMIT 2")?;
+
         let mut update_stmt = self
             .conn
             .prepare("UPDATE edges SET target_id = ?1 WHERE id = ?2")?;
 
-        for (edge_id, target_name, edge_file) in &unresolved {
+        for (edge_id, target_name, edge_file, source_id) in &unresolved {
             let simple_name = target_name.rsplit('.').next().unwrap_or(target_name);
 
             // 1) Same file
@@ -441,7 +470,19 @@ impl Database {
                 continue;
             }
 
-            // 2) Same directory
+            // 2) Import-path resolution: if this file imports the target name,
+            //    find the symbol in any file that could be the import source
+            let target_id: Option<String> = import_resolve_stmt
+                .query_row(params![simple_name, edge_file], |row| row.get(0))
+                .optional()?;
+
+            if let Some(tid) = target_id {
+                update_stmt.execute(params![tid, edge_id])?;
+                resolved += 1;
+                continue;
+            }
+
+            // 3) Same directory
             let dir = edge_file
                 .rsplit_once('/')
                 .map(|(d, _)| format!("{d}/%"))
@@ -459,7 +500,19 @@ impl Database {
                 }
             }
 
-            // 3) Unique project-wide match — fetch at most 2 rows; resolve only if exactly 1
+            // 4) Parent scope preference: if the source symbol has a parent,
+            //    prefer a target in the same parent scope
+            let target_id: Option<String> = parent_scope_stmt
+                .query_row(params![simple_name, source_id], |row| row.get(0))
+                .optional()?;
+
+            if let Some(tid) = target_id {
+                update_stmt.execute(params![tid, edge_id])?;
+                resolved += 1;
+                continue;
+            }
+
+            // 5) Unique project-wide match — fetch at most 2 rows; resolve only if exactly 1
             let mut rows = anywhere_stmt.query(params![simple_name])?;
             let first = rows.next()?.and_then(|r| r.get::<_, String>(0).ok());
             let has_second = rows.next()?.is_some();

--- a/src/db.rs
+++ b/src/db.rs
@@ -426,13 +426,19 @@ impl Database {
             .conn
             .prepare("SELECT id FROM symbols WHERE name = ?1 AND file_path = ?2 LIMIT 1")?;
 
-        // Import-path resolution: find files that the source file imports from,
-        // then look for the target symbol in those files
+        // Import-path resolution: if this file has a resolved import edge for the
+        // target name, follow it to find the target's file, then look for a
+        // non-import symbol with that name in that file.
+        // Only works when the import edge was already resolved (e.g. via same-file
+        // match in an earlier iteration); otherwise returns no rows and falls through.
         let mut import_resolve_stmt = self.conn.prepare(
             "SELECT s.id FROM symbols s
              INNER JOIN edges ie ON ie.kind = 'imports' AND ie.target_name = ?1
+                 AND ie.target_id IS NOT NULL
              INNER JOIN symbols is2 ON is2.id = ie.source_id AND is2.file_path = ?2
+             INNER JOIN symbols resolved ON resolved.id = ie.target_id
              WHERE s.name = ?1 AND s.kind != 'import'
+                 AND s.file_path = resolved.file_path
              LIMIT 1",
         )?;
 

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -245,8 +245,9 @@ fn extract_type_spec(
     let type_node = node.child_by_field_name("type");
 
     let kind = match type_node.map(|t| t.kind()) {
-        Some("struct_type") | Some("interface_type") => SymbolKind::Class,
-        _ => SymbolKind::Variable, // type alias
+        Some("struct_type") => SymbolKind::Class,
+        Some("interface_type") => SymbolKind::Interface,
+        _ => SymbolKind::TypeAlias,
     };
 
     let sym_id = symbol_id(file_path, &name, start_line);
@@ -910,7 +911,7 @@ type Reader interface {
 
         let iface = result.symbols.iter().find(|s| s.name == "Reader");
         assert!(iface.is_some());
-        assert_eq!(iface.unwrap().kind, SymbolKind::Class);
+        assert_eq!(iface.unwrap().kind, SymbolKind::Interface);
     }
 
     #[test]
@@ -1200,13 +1201,13 @@ type UserID int64
 "#,
         );
 
-        // Non-struct/interface types are Variable (type alias)
+        // Non-struct/interface types are TypeAlias
         let handler = result.symbols.iter().find(|s| s.name == "Handler").unwrap();
-        assert_eq!(handler.kind, SymbolKind::Variable);
+        assert_eq!(handler.kind, SymbolKind::TypeAlias);
         assert_eq!(handler.visibility, Visibility::Public);
 
         let uid = result.symbols.iter().find(|s| s.name == "UserID").unwrap();
-        assert_eq!(uid.kind, SymbolKind::Variable);
+        assert_eq!(uid.kind, SymbolKind::TypeAlias);
     }
 
     #[test]

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -636,7 +636,7 @@ fn extract_super_interfaces_edges(
             // direct type_identifier (e.g. extends_interfaces on interface)
             let name = extract_simple_type_name(child, source);
             if !name.is_empty() {
-                edges.push(Edge::new(sym_id, name, edge_kind.clone(), file_path, line));
+                edges.push(Edge::new(sym_id, name, edge_kind, file_path, line));
             }
         }
     }

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -609,7 +609,7 @@ fn extract_super_interfaces_edges(
             for type_node in child.named_children(&mut child.walk()) {
                 let name = extract_simple_type_name(type_node, source);
                 if !name.is_empty() {
-                    edges.push(Edge::new(sym_id, name, edge_kind.clone(), file_path, line));
+                    edges.push(Edge::new(sym_id, name, edge_kind, file_path, line));
                 }
             }
         } else {

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -97,7 +97,7 @@ fn extract_class_like(
     let sym_id = symbol_id(file_path, &name, start_line);
     let mut sym = Symbol::new(
         name.clone(),
-        SymbolKind::Class,
+        if node.kind() == "enum_declaration" { SymbolKind::Enum } else { SymbolKind::Class },
         file_path,
         start_line,
         end_line,
@@ -121,7 +121,7 @@ fn extract_class_like(
 
     // implements (super_interfaces)
     if let Some(si) = node.child_by_field_name("interfaces") {
-        extract_super_interfaces_edges(si, source, file_path, &sym_id, start_line, edges);
+        extract_super_interfaces_edges(si, source, file_path, &sym_id, start_line, EdgeKind::Implements, edges);
     }
 
     // Walk body for methods, constructors, fields, nested named classes
@@ -157,7 +157,7 @@ fn extract_interface(
     let sym_id = symbol_id(file_path, &name, start_line);
     let mut sym = Symbol::new(
         name.clone(),
-        SymbolKind::Class,
+        SymbolKind::Interface,
         file_path,
         start_line,
         end_line,
@@ -177,7 +177,7 @@ fn extract_interface(
     // extends (extends_interfaces)
     for child in node.named_children(&mut node.walk()) {
         if child.kind() == "extends_interfaces" {
-            extract_super_interfaces_edges(child, source, file_path, &sym_id, start_line, edges);
+            extract_super_interfaces_edges(child, source, file_path, &sym_id, start_line, EdgeKind::Inherits, edges);
         }
     }
 
@@ -599,6 +599,7 @@ fn extract_super_interfaces_edges(
     file_path: &str,
     sym_id: &str,
     line: u32,
+    edge_kind: EdgeKind,
     edges: &mut Vec<Edge>,
 ) {
     // super_interfaces → type_list → type_identifier / scoped_type_identifier / generic_type
@@ -608,14 +609,14 @@ fn extract_super_interfaces_edges(
             for type_node in child.named_children(&mut child.walk()) {
                 let name = extract_simple_type_name(type_node, source);
                 if !name.is_empty() {
-                    edges.push(Edge::new(sym_id, name, EdgeKind::Inherits, file_path, line));
+                    edges.push(Edge::new(sym_id, name, edge_kind.clone(), file_path, line));
                 }
             }
         } else {
             // direct type_identifier (e.g. extends_interfaces on interface)
             let name = extract_simple_type_name(child, source);
             if !name.is_empty() {
-                edges.push(Edge::new(sym_id, name, EdgeKind::Inherits, file_path, line));
+                edges.push(Edge::new(sym_id, name, edge_kind.clone(), file_path, line));
             }
         }
     }
@@ -984,7 +985,7 @@ public interface Repository {
             .iter()
             .find(|s| s.name == "Repository")
             .unwrap();
-        assert_eq!(sym.kind, SymbolKind::Class);
+        assert_eq!(sym.kind, SymbolKind::Interface);
         assert_eq!(sym.visibility, Visibility::Public);
     }
 
@@ -998,7 +999,7 @@ public enum Status {
 "#,
         );
         let sym = result.symbols.iter().find(|s| s.name == "Status").unwrap();
-        assert_eq!(sym.kind, SymbolKind::Class);
+        assert_eq!(sym.kind, SymbolKind::Enum);
         assert_eq!(sym.visibility, Visibility::Public);
     }
 
@@ -1158,10 +1159,17 @@ public class UserService extends BaseService implements Repository, Auditable {
             .iter()
             .filter(|e| e.kind == EdgeKind::Inherits)
             .collect();
-        let targets: Vec<&str> = inherits.iter().map(|e| e.target_name.as_str()).collect();
-        assert!(targets.contains(&"BaseService"));
-        assert!(targets.contains(&"Repository"));
-        assert!(targets.contains(&"Auditable"));
+        let inherits_targets: Vec<&str> = inherits.iter().map(|e| e.target_name.as_str()).collect();
+        assert!(inherits_targets.contains(&"BaseService"));
+
+        let implements: Vec<_> = result
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Implements)
+            .collect();
+        let implements_targets: Vec<&str> = implements.iter().map(|e| e.target_name.as_str()).collect();
+        assert!(implements_targets.contains(&"Repository"));
+        assert!(implements_targets.contains(&"Auditable"));
     }
 
     #[test]

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -97,7 +97,11 @@ fn extract_class_like(
     let sym_id = symbol_id(file_path, &name, start_line);
     let mut sym = Symbol::new(
         name.clone(),
-        if node.kind() == "enum_declaration" { SymbolKind::Enum } else { SymbolKind::Class },
+        if node.kind() == "enum_declaration" {
+            SymbolKind::Enum
+        } else {
+            SymbolKind::Class
+        },
         file_path,
         start_line,
         end_line,
@@ -121,7 +125,15 @@ fn extract_class_like(
 
     // implements (super_interfaces)
     if let Some(si) = node.child_by_field_name("interfaces") {
-        extract_super_interfaces_edges(si, source, file_path, &sym_id, start_line, EdgeKind::Implements, edges);
+        extract_super_interfaces_edges(
+            si,
+            source,
+            file_path,
+            &sym_id,
+            start_line,
+            EdgeKind::Implements,
+            edges,
+        );
     }
 
     // Walk body for methods, constructors, fields, nested named classes
@@ -177,7 +189,15 @@ fn extract_interface(
     // extends (extends_interfaces)
     for child in node.named_children(&mut node.walk()) {
         if child.kind() == "extends_interfaces" {
-            extract_super_interfaces_edges(child, source, file_path, &sym_id, start_line, EdgeKind::Inherits, edges);
+            extract_super_interfaces_edges(
+                child,
+                source,
+                file_path,
+                &sym_id,
+                start_line,
+                EdgeKind::Inherits,
+                edges,
+            );
         }
     }
 
@@ -1167,7 +1187,8 @@ public class UserService extends BaseService implements Repository, Auditable {
             .iter()
             .filter(|e| e.kind == EdgeKind::Implements)
             .collect();
-        let implements_targets: Vec<&str> = implements.iter().map(|e| e.target_name.as_str()).collect();
+        let implements_targets: Vec<&str> =
+            implements.iter().map(|e| e.target_name.as_str()).collect();
         assert!(implements_targets.contains(&"Repository"));
         assert!(implements_targets.contains(&"Auditable"));
     }

--- a/src/languages/javascript.rs
+++ b/src/languages/javascript.rs
@@ -5,15 +5,18 @@ use super::{js_shared, ExtractionResult, Extractor};
 
 pub struct JavaScriptExtractor {
     parser: Parser,
+    queries: js_shared::JsQueries,
 }
 
 impl JavaScriptExtractor {
     pub fn new() -> Self {
+        let lang = Language::new(tree_sitter_javascript::LANGUAGE);
         let mut parser = Parser::new();
         parser
-            .set_language(&Language::new(tree_sitter_javascript::LANGUAGE))
+            .set_language(&lang)
             .expect("JavaScript grammar should always load");
-        Self { parser }
+        let queries = js_shared::JsQueries::new(&lang);
+        Self { parser, queries }
     }
 }
 
@@ -25,7 +28,7 @@ impl Default for JavaScriptExtractor {
 
 impl Extractor for JavaScriptExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        js_shared::extract(&mut self.parser, source, file_path)
+        js_shared::extract(&mut self.parser, &self.queries, source, file_path)
     }
 }
 

--- a/src/languages/js_shared.rs
+++ b/src/languages/js_shared.rs
@@ -9,7 +9,7 @@ use tree_sitter::{Language, Node, Parser, QueryCursor};
 
 use crate::types::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::queries::CachedQuery;
+use super::queries::{is_inside_nested_scope, CachedQuery};
 use super::{node_text, ExtractionResult};
 
 /// Pre-compiled tree-sitter queries for JS/TS extraction.
@@ -685,24 +685,13 @@ fn extract_enum(
 
 // ── Call / Throw walking (query-based) ──
 
-/// Check whether a captured node is inside a nested function or class scope
-/// relative to the search root. If so, it belongs to a different scope and
-/// should be skipped.
-fn is_inside_nested_scope(node: Node, root: Node) -> bool {
-    let mut parent = node.parent();
-    while let Some(p) = parent {
-        if p.id() == root.id() {
-            return false;
-        }
-        match p.kind() {
-            "function_declaration" | "arrow_function" | "function_expression"
-            | "class_declaration" | "method_definition" => return true,
-            _ => {}
-        }
-        parent = p.parent();
-    }
-    false
-}
+const JS_SCOPE_KINDS: &[&str] = &[
+    "function_declaration",
+    "arrow_function",
+    "function_expression",
+    "class_declaration",
+    "method_definition",
+];
 
 fn walk_for_calls_and_throws_q(
     node: Node,
@@ -719,7 +708,7 @@ fn walk_for_calls_and_throws_q(
     for m in cursor.matches(&queries.call_query.query, node, source.as_bytes()) {
         for capture in m.captures {
             if capture.index == queries.call_callee_idx
-                && !is_inside_nested_scope(capture.node, node)
+                && !is_inside_nested_scope(capture.node, node, JS_SCOPE_KINDS)
             {
                 let name = node_text(capture.node, source);
                 if !name.is_empty() {
@@ -740,7 +729,7 @@ fn walk_for_calls_and_throws_q(
     for m in cursor.matches(&queries.new_query.query, node, source.as_bytes()) {
         for capture in m.captures {
             if capture.index == queries.new_ctor_idx
-                && !is_inside_nested_scope(capture.node, node)
+                && !is_inside_nested_scope(capture.node, node, JS_SCOPE_KINDS)
             {
                 let name = node_text(capture.node, source);
                 if !name.is_empty() {
@@ -762,7 +751,7 @@ fn walk_for_calls_and_throws_q(
     for m in cursor.matches(&queries.throw_query.query, node, source.as_bytes()) {
         for capture in m.captures {
             if capture.index == queries.throw_exc_idx
-                && !is_inside_nested_scope(capture.node, node)
+                && !is_inside_nested_scope(capture.node, node, JS_SCOPE_KINDS)
             {
                 let line = capture.node.start_position().row as u32 + 1;
                 let name = node_text(capture.node, source);

--- a/src/languages/js_shared.rs
+++ b/src/languages/js_shared.rs
@@ -24,8 +24,8 @@ pub struct JsQueries {
     /// `throw new Error()`, `throw expr`
     throw_query: CachedQuery,
     throw_exc_idx: u32,
-    /// Type identifiers in annotations
-    type_ref_query: CachedQuery,
+    /// Type identifiers in annotations (TypeScript only; JS has no `type_identifier` node)
+    type_ref_query: Option<CachedQuery>,
     type_ref_idx: u32,
 }
 
@@ -53,8 +53,15 @@ impl JsQueries {
         );
         let throw_exc_idx = throw_query.capture_index("exception");
 
-        let type_ref_query = CachedQuery::new(language, "(type_identifier) @type_ref");
-        let type_ref_idx = type_ref_query.capture_index("type_ref");
+        // `type_identifier` exists only in TypeScript grammars, not plain JavaScript.
+        let (type_ref_query, type_ref_idx) =
+            match CachedQuery::try_new(language, "(type_identifier) @type_ref") {
+                Some(q) => {
+                    let idx = q.capture_index("type_ref");
+                    (Some(q), idx)
+                }
+                None => (None, 0),
+            };
 
         Self {
             call_query,
@@ -820,8 +827,12 @@ fn collect_type_refs_q(
     queries: &JsQueries,
     edges: &mut Vec<Edge>,
 ) {
+    let type_ref_query = match &queries.type_ref_query {
+        Some(q) => q,
+        None => return,
+    };
     let mut cursor = QueryCursor::new();
-    let mut matches = cursor.matches(&queries.type_ref_query.query, node, source.as_bytes());
+    let mut matches = cursor.matches(&type_ref_query.query, node, source.as_bytes());
     while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == queries.type_ref_idx {

--- a/src/languages/js_shared.rs
+++ b/src/languages/js_shared.rs
@@ -5,14 +5,76 @@
 //! kinds for functions, classes, imports, and calls are identical.
 
 use anyhow::Result;
-use tree_sitter::{Node, Parser};
+use tree_sitter::{Language, Node, Parser, QueryCursor};
 
 use crate::types::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
+use super::queries::CachedQuery;
 use super::{node_text, ExtractionResult};
 
+/// Pre-compiled tree-sitter queries for JS/TS extraction.
+pub struct JsQueries {
+    /// `foo()`, `obj.method()`
+    call_query: CachedQuery,
+    call_callee_idx: u32,
+    /// `new Foo()`
+    new_query: CachedQuery,
+    new_ctor_idx: u32,
+    /// `throw new Error()`, `throw expr`
+    throw_query: CachedQuery,
+    throw_exc_idx: u32,
+    /// Type identifiers in annotations
+    type_ref_query: CachedQuery,
+    type_ref_idx: u32,
+}
+
+impl JsQueries {
+    pub fn new(language: &Language) -> Self {
+        let call_query = CachedQuery::new(
+            language,
+            "(call_expression function: [(identifier) (member_expression)] @callee)",
+        );
+        let call_callee_idx = call_query.capture_index("callee");
+
+        let new_query = CachedQuery::new(
+            language,
+            "(new_expression constructor: [(identifier) (member_expression)] @ctor)",
+        );
+        let new_ctor_idx = new_query.capture_index("ctor");
+
+        let throw_query = CachedQuery::new(
+            language,
+            r#"(throw_statement
+              [(new_expression constructor: [(identifier) (member_expression)] @exception)
+               (call_expression function: [(identifier) (member_expression)] @exception)
+               (identifier) @exception
+               (member_expression) @exception])"#,
+        );
+        let throw_exc_idx = throw_query.capture_index("exception");
+
+        let type_ref_query = CachedQuery::new(language, "(type_identifier) @type_ref");
+        let type_ref_idx = type_ref_query.capture_index("type_ref");
+
+        Self {
+            call_query,
+            call_callee_idx,
+            new_query,
+            new_ctor_idx,
+            throw_query,
+            throw_exc_idx,
+            type_ref_query,
+            type_ref_idx,
+        }
+    }
+}
+
 /// Parse source and extract symbols + edges. Works for JS, TS, and TSX.
-pub fn extract(parser: &mut Parser, source: &str, file_path: &str) -> Result<ExtractionResult> {
+pub fn extract(
+    parser: &mut Parser,
+    queries: &JsQueries,
+    source: &str,
+    file_path: &str,
+) -> Result<ExtractionResult> {
     let tree = parser
         .parse(source, None)
         .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
@@ -25,6 +87,7 @@ pub fn extract(parser: &mut Parser, source: &str, file_path: &str) -> Result<Ext
         source,
         file_path,
         None,
+        queries,
         &mut symbols,
         &mut edges,
     );
@@ -37,21 +100,24 @@ fn extract_node(
     source: &str,
     file_path: &str,
     parent_id: Option<&str>,
+    queries: &JsQueries,
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
     match node.kind() {
         // Functions
         "function_declaration" => {
-            extract_function(node, source, file_path, parent_id, symbols, edges);
+            extract_function(node, source, file_path, parent_id, queries, symbols, edges);
         }
         // Arrow functions and function expressions assigned to variables
         "lexical_declaration" | "variable_declaration" => {
-            extract_variable_declaration(node, source, file_path, parent_id, symbols, edges);
+            extract_variable_declaration(
+                node, source, file_path, parent_id, queries, symbols, edges,
+            );
         }
         // Classes
         "class_declaration" => {
-            extract_class(node, source, file_path, parent_id, symbols, edges);
+            extract_class(node, source, file_path, parent_id, queries, symbols, edges);
         }
         // Imports
         "import_statement" => {
@@ -60,12 +126,12 @@ fn extract_node(
         // Exports that wrap declarations
         "export_statement" => {
             for child in node.named_children(&mut node.walk()) {
-                extract_node(child, source, file_path, parent_id, symbols, edges);
+                extract_node(child, source, file_path, parent_id, queries, symbols, edges);
             }
         }
         // Expression statements — scan for calls
         "expression_statement" => {
-            walk_for_calls_and_throws(node, source, file_path, parent_id, edges);
+            walk_for_calls_and_throws_q(node, source, file_path, parent_id, queries, edges);
         }
         // TypeScript-specific
         "interface_declaration" => {
@@ -79,7 +145,7 @@ fn extract_node(
         }
         _ => {
             for child in node.named_children(&mut node.walk()) {
-                extract_node(child, source, file_path, parent_id, symbols, edges);
+                extract_node(child, source, file_path, parent_id, queries, symbols, edges);
             }
         }
     }
@@ -92,6 +158,7 @@ fn extract_function(
     source: &str,
     file_path: &str,
     parent_id: Option<&str>,
+    queries: &JsQueries,
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
@@ -131,12 +198,12 @@ fn extract_function(
     );
 
     // Extract type annotation references from parameters and return type
-    extract_fn_type_refs(node, source, file_path, &sym_id, edges);
+    extract_fn_type_refs_q(node, source, file_path, &sym_id, queries, edges);
 
     // Walk body for calls/throws
     if let Some(body) = node.child_by_field_name("body") {
-        walk_for_calls_and_throws(body, source, file_path, Some(&sym_id), edges);
-        walk_body_for_nested(body, source, file_path, &sym_id, symbols, edges);
+        walk_for_calls_and_throws_q(body, source, file_path, Some(&sym_id), queries, edges);
+        walk_body_for_nested(body, source, file_path, &sym_id, queries, symbols, edges);
     }
 }
 
@@ -147,6 +214,7 @@ fn extract_variable_declaration(
     source: &str,
     file_path: &str,
     parent_id: Option<&str>,
+    queries: &JsQueries,
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
@@ -192,11 +260,18 @@ fn extract_variable_declaration(
                 .with_docstring(docstring),
             );
 
-            extract_fn_type_refs(val, source, file_path, &sym_id, edges);
+            extract_fn_type_refs_q(val, source, file_path, &sym_id, queries, edges);
 
             if let Some(body) = val.child_by_field_name("body") {
-                walk_for_calls_and_throws(body, source, file_path, Some(&sym_id), edges);
-                walk_body_for_nested(body, source, file_path, &sym_id, symbols, edges);
+                walk_for_calls_and_throws_q(
+                    body,
+                    source,
+                    file_path,
+                    Some(&sym_id),
+                    queries,
+                    edges,
+                );
+                walk_body_for_nested(body, source, file_path, &sym_id, queries, symbols, edges);
             }
         } else {
             // Plain variable
@@ -214,8 +289,6 @@ fn extract_variable_declaration(
                 .with_parent(parent_id)
                 .with_docstring(docstring),
             );
-            // Note: don't walk for calls here — the parent function body
-            // already walks the entire subtree via walk_for_calls_and_throws
         }
     }
 }
@@ -227,6 +300,7 @@ fn extract_class(
     source: &str,
     file_path: &str,
     parent_id: Option<&str>,
+    queries: &JsQueries,
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
@@ -261,7 +335,6 @@ fn extract_class(
                 for clause in child.named_children(&mut child.walk()) {
                     match clause.kind() {
                         "extends_clause" => {
-                            // TS: extends_clause has a "value" field
                             if let Some(val) = clause.child_by_field_name("value") {
                                 let base_name = extract_type_name(val, source);
                                 if !base_name.is_empty() {
@@ -282,7 +355,7 @@ fn extract_class(
                                     edges.push(Edge::new(
                                         sym_id.clone(),
                                         iface_name,
-                                        EdgeKind::Inherits,
+                                        EdgeKind::Implements,
                                         file_path,
                                         tc.start_position().row as u32 + 1,
                                     ));
@@ -314,7 +387,7 @@ fn extract_class(
         for child in body.named_children(&mut body.walk()) {
             match child.kind() {
                 "method_definition" => {
-                    extract_method(child, source, file_path, &sym_id, symbols, edges);
+                    extract_method(child, source, file_path, &sym_id, queries, symbols, edges);
                 }
                 "public_field_definition" | "field_definition" | "property_definition" => {
                     extract_field(child, source, file_path, &sym_id, symbols);
@@ -330,6 +403,7 @@ fn extract_method(
     source: &str,
     file_path: &str,
     class_id: &str,
+    queries: &JsQueries,
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
@@ -363,10 +437,10 @@ fn extract_method(
         .with_docstring(docstring),
     );
 
-    extract_fn_type_refs(node, source, file_path, &sym_id, edges);
+    extract_fn_type_refs_q(node, source, file_path, &sym_id, queries, edges);
 
     if let Some(body) = node.child_by_field_name("body") {
-        walk_for_calls_and_throws(body, source, file_path, Some(&sym_id), edges);
+        walk_for_calls_and_throws_q(body, source, file_path, Some(&sym_id), queries, edges);
     }
 }
 
@@ -517,7 +591,7 @@ fn extract_interface(
     symbols.push(
         Symbol::new(
             &name,
-            SymbolKind::Class,
+            SymbolKind::Interface,
             file_path,
             start_line,
             end_line,
@@ -567,7 +641,7 @@ fn extract_type_alias(
     symbols.push(
         Symbol::new(
             &name,
-            SymbolKind::Variable,
+            SymbolKind::TypeAlias,
             file_path,
             start_line,
             node.end_position().row as u32 + 1,
@@ -597,7 +671,7 @@ fn extract_enum(
     symbols.push(
         Symbol::new(
             &name,
-            SymbolKind::Class,
+            SymbolKind::Enum,
             file_path,
             start_line,
             node.end_position().row as u32 + 1,
@@ -609,107 +683,92 @@ fn extract_enum(
     );
 }
 
-// ── Call / Throw walking ──
+// ── Call / Throw walking (query-based) ──
 
-fn walk_for_calls_and_throws(
+/// Check whether a captured node is inside a nested function or class scope
+/// relative to the search root. If so, it belongs to a different scope and
+/// should be skipped.
+fn is_inside_nested_scope(node: Node, root: Node) -> bool {
+    let mut parent = node.parent();
+    while let Some(p) = parent {
+        if p.id() == root.id() {
+            return false;
+        }
+        match p.kind() {
+            "function_declaration" | "arrow_function" | "function_expression"
+            | "class_declaration" | "method_definition" => return true,
+            _ => {}
+        }
+        parent = p.parent();
+    }
+    false
+}
+
+fn walk_for_calls_and_throws_q(
     node: Node,
     source: &str,
     file_path: &str,
     context_id: Option<&str>,
+    queries: &JsQueries,
     edges: &mut Vec<Edge>,
 ) {
-    let mut cursor = node.walk();
-    let mut did_visit_children = false;
+    let Some(ctx) = context_id else { return };
 
-    loop {
-        let current = cursor.node();
-
-        if !did_visit_children {
-            match current.kind() {
-                "call_expression" => {
-                    if let Some(ctx) = context_id {
-                        if let Some(func) = current.child_by_field_name("function") {
-                            let callee_name = node_text(func, source).to_string();
-                            if !callee_name.is_empty() {
-                                edges.push(Edge::new(
-                                    ctx.to_string(),
-                                    callee_name,
-                                    EdgeKind::Calls,
-                                    file_path,
-                                    current.start_position().row as u32 + 1,
-                                ));
-                            }
-                        }
-                    }
+    // Collect call edges
+    let mut cursor = QueryCursor::new();
+    for m in cursor.matches(&queries.call_query.query, node, source.as_bytes()) {
+        for capture in m.captures {
+            if capture.index == queries.call_callee_idx
+                && !is_inside_nested_scope(capture.node, node)
+            {
+                let name = node_text(capture.node, source);
+                if !name.is_empty() {
+                    edges.push(Edge::new(
+                        ctx,
+                        name,
+                        EdgeKind::Calls,
+                        file_path,
+                        capture.node.start_position().row as u32 + 1,
+                    ));
                 }
-                "new_expression" => {
-                    if let Some(ctx) = context_id {
-                        if let Some(ctor) = current.child_by_field_name("constructor") {
-                            let ctor_name = node_text(ctor, source).to_string();
-                            if !ctor_name.is_empty() {
-                                edges.push(Edge::new(
-                                    ctx.to_string(),
-                                    ctor_name,
-                                    EdgeKind::Calls,
-                                    file_path,
-                                    current.start_position().row as u32 + 1,
-                                ));
-                            }
-                        }
-                    }
-                }
-                "throw_statement" => {
-                    if let Some(ctx) = context_id {
-                        if let Some(exc) = current.named_child(0) {
-                            let exc_name = if exc.kind() == "new_expression" {
-                                exc.child_by_field_name("constructor")
-                                    .map(|c| node_text(c, source).to_string())
-                                    .unwrap_or_default()
-                            } else if exc.kind() == "call_expression" {
-                                exc.child_by_field_name("function")
-                                    .map(|f| node_text(f, source).to_string())
-                                    .unwrap_or_default()
-                            } else {
-                                node_text(exc, source).to_string()
-                            };
-                            if !exc_name.is_empty() {
-                                edges.push(Edge::new(
-                                    ctx.to_string(),
-                                    exc_name,
-                                    EdgeKind::Raises,
-                                    file_path,
-                                    current.start_position().row as u32 + 1,
-                                ));
-                            }
-                        }
-                    }
-                }
-                // Don't descend into nested function/class scopes
-                "function_declaration"
-                | "class_declaration"
-                | "arrow_function"
-                | "function_expression" => {
-                    did_visit_children = true;
-                    continue;
-                }
-                _ => {}
             }
         }
+    }
 
-        if !did_visit_children && cursor.goto_first_child() {
-            did_visit_children = false;
-            continue;
-        }
-        did_visit_children = false;
-        if cursor.goto_next_sibling() {
-            continue;
-        }
-        loop {
-            if !cursor.goto_parent() {
-                return;
+    // Collect new expression edges (also treated as calls)
+    let mut cursor = QueryCursor::new();
+    for m in cursor.matches(&queries.new_query.query, node, source.as_bytes()) {
+        for capture in m.captures {
+            if capture.index == queries.new_ctor_idx
+                && !is_inside_nested_scope(capture.node, node)
+            {
+                let name = node_text(capture.node, source);
+                if !name.is_empty() {
+                    edges.push(Edge::new(
+                        ctx,
+                        name,
+                        EdgeKind::Calls,
+                        file_path,
+                        capture.node.start_position().row as u32 + 1,
+                    ));
+                }
             }
-            if cursor.goto_next_sibling() {
-                break;
+        }
+    }
+
+    // Collect throw edges
+    let mut cursor = QueryCursor::new();
+    let mut seen_throws = std::collections::HashSet::new();
+    for m in cursor.matches(&queries.throw_query.query, node, source.as_bytes()) {
+        for capture in m.captures {
+            if capture.index == queries.throw_exc_idx
+                && !is_inside_nested_scope(capture.node, node)
+            {
+                let line = capture.node.start_position().row as u32 + 1;
+                let name = node_text(capture.node, source);
+                if !name.is_empty() && seen_throws.insert((name.to_string(), line)) {
+                    edges.push(Edge::new(ctx, name, EdgeKind::Raises, file_path, line));
+                }
             }
         }
     }
@@ -720,6 +779,7 @@ fn walk_body_for_nested(
     source: &str,
     file_path: &str,
     parent_id: &str,
+    queries: &JsQueries,
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
@@ -729,56 +789,67 @@ fn walk_body_for_nested(
             | "class_declaration"
             | "lexical_declaration"
             | "variable_declaration" => {
-                extract_node(child, source, file_path, Some(parent_id), symbols, edges);
+                extract_node(
+                    child,
+                    source,
+                    file_path,
+                    Some(parent_id),
+                    queries,
+                    symbols,
+                    edges,
+                );
             }
             _ => {}
         }
     }
 }
 
-// ── Type reference extraction ──
+// ── Type reference extraction (query-based) ──
 
 /// Extract type annotation references from function parameters and return type.
-fn extract_fn_type_refs(
+fn extract_fn_type_refs_q(
     node: Node,
     source: &str,
     file_path: &str,
     sym_id: &str,
+    queries: &JsQueries,
     edges: &mut Vec<Edge>,
 ) {
-    // Walk parameters looking for type_annotation nodes
+    // Walk parameters looking for type_identifier nodes
     if let Some(params) = node.child_by_field_name("parameters") {
-        collect_type_refs_recursive(params, source, file_path, sym_id, edges);
+        collect_type_refs_q(params, source, file_path, sym_id, queries, edges);
     }
     // Return type annotation
     if let Some(ret) = node.child_by_field_name("return_type") {
-        collect_type_refs_recursive(ret, source, file_path, sym_id, edges);
+        collect_type_refs_q(ret, source, file_path, sym_id, queries, edges);
     }
 }
 
-/// Recursively walk a subtree collecting type_identifier references.
-fn collect_type_refs_recursive(
+/// Collect type_identifier references from a subtree using query API.
+fn collect_type_refs_q(
     node: Node,
     source: &str,
     file_path: &str,
     sym_id: &str,
+    queries: &JsQueries,
     edges: &mut Vec<Edge>,
 ) {
-    if node.kind() == "type_identifier" {
-        let name = node_text(node, source);
-        // Skip built-in types (lowercase: string, number, boolean, void, etc.)
-        if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_uppercase()) {
-            edges.push(Edge::new(
-                sym_id,
-                name,
-                EdgeKind::References,
-                file_path,
-                node.start_position().row as u32 + 1,
-            ));
-        }
-    } else {
-        for child in node.named_children(&mut node.walk()) {
-            collect_type_refs_recursive(child, source, file_path, sym_id, edges);
+    let mut cursor = QueryCursor::new();
+    for m in cursor.matches(&queries.type_ref_query.query, node, source.as_bytes()) {
+        for capture in m.captures {
+            if capture.index == queries.type_ref_idx {
+                let name = node_text(capture.node, source);
+                // Skip built-in types (lowercase: string, number, boolean, void, etc.)
+                if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_uppercase()) {
+                    edges.push(Edge::new(
+                        sym_id,
+                        name,
+                        EdgeKind::References,
+                        file_path,
+                        capture.node.start_position().row as u32 + 1,
+                    ));
+                }
+            }
         }
     }
 }

--- a/src/languages/js_shared.rs
+++ b/src/languages/js_shared.rs
@@ -5,6 +5,7 @@
 //! kinds for functions, classes, imports, and calls are identical.
 
 use anyhow::Result;
+use streaming_iterator::StreamingIterator;
 use tree_sitter::{Language, Node, Parser, QueryCursor};
 
 use crate::types::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
@@ -698,7 +699,8 @@ fn walk_for_calls_and_throws_q(
 
     // Collect call edges
     let mut cursor = QueryCursor::new();
-    for m in cursor.matches(&queries.call_query.query, node, source.as_bytes()) {
+    let mut matches = cursor.matches(&queries.call_query.query, node, source.as_bytes());
+    while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == queries.call_callee_idx
                 && !is_inside_nested_scope(capture.node, node, JS_SCOPE_KINDS)
@@ -719,7 +721,8 @@ fn walk_for_calls_and_throws_q(
 
     // Collect new expression edges (also treated as calls)
     let mut cursor = QueryCursor::new();
-    for m in cursor.matches(&queries.new_query.query, node, source.as_bytes()) {
+    let mut matches = cursor.matches(&queries.new_query.query, node, source.as_bytes());
+    while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == queries.new_ctor_idx
                 && !is_inside_nested_scope(capture.node, node, JS_SCOPE_KINDS)
@@ -741,7 +744,8 @@ fn walk_for_calls_and_throws_q(
     // Collect throw edges
     let mut cursor = QueryCursor::new();
     let mut seen_throws = std::collections::HashSet::new();
-    for m in cursor.matches(&queries.throw_query.query, node, source.as_bytes()) {
+    let mut matches = cursor.matches(&queries.throw_query.query, node, source.as_bytes());
+    while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == queries.throw_exc_idx
                 && !is_inside_nested_scope(capture.node, node, JS_SCOPE_KINDS)
@@ -817,7 +821,8 @@ fn collect_type_refs_q(
     edges: &mut Vec<Edge>,
 ) {
     let mut cursor = QueryCursor::new();
-    for m in cursor.matches(&queries.type_ref_query.query, node, source.as_bytes()) {
+    let mut matches = cursor.matches(&queries.type_ref_query.query, node, source.as_bytes());
+    while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == queries.type_ref_idx {
                 let name = node_text(capture.node, source);

--- a/src/languages/js_shared.rs
+++ b/src/languages/js_shared.rs
@@ -263,14 +263,7 @@ fn extract_variable_declaration(
             extract_fn_type_refs_q(val, source, file_path, &sym_id, queries, edges);
 
             if let Some(body) = val.child_by_field_name("body") {
-                walk_for_calls_and_throws_q(
-                    body,
-                    source,
-                    file_path,
-                    Some(&sym_id),
-                    queries,
-                    edges,
-                );
+                walk_for_calls_and_throws_q(body, source, file_path, Some(&sym_id), queries, edges);
                 walk_body_for_nested(body, source, file_path, &sym_id, queries, symbols, edges);
             }
         } else {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -3,6 +3,7 @@ pub mod java;
 pub mod javascript;
 mod js_shared;
 pub mod python;
+pub(crate) mod queries;
 pub mod ruby;
 pub mod rust_lang;
 pub mod typescript;

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -26,10 +26,8 @@ impl PythonExtractor {
             .set_language(&lang)
             .expect("Python grammar should always load");
 
-        let call_query = CachedQuery::new(
-            &lang,
-            "(call function: [(identifier) (attribute)] @callee)",
-        );
+        let call_query =
+            CachedQuery::new(&lang, "(call function: [(identifier) (attribute)] @callee)");
         let raise_query = CachedQuery::new(
             &lang,
             r#"(raise_statement
@@ -246,7 +244,15 @@ fn extract_function(
         for child in body.named_children(&mut body.walk()) {
             match child.kind() {
                 "function_definition" | "class_definition" | "decorated_definition" => {
-                    extract_node(queries, child, source, file_path, Some(&sym_id), symbols, edges);
+                    extract_node(
+                        queries,
+                        child,
+                        source,
+                        file_path,
+                        Some(&sym_id),
+                        symbols,
+                        edges,
+                    );
                 }
                 _ => {}
             }
@@ -310,7 +316,15 @@ fn extract_class(
     // Walk class body for methods, nested classes, assignments
     if let Some(body) = node.child_by_field_name("body") {
         for child in body.named_children(&mut body.walk()) {
-            extract_node(queries, child, source, file_path, Some(&sym_id), symbols, edges);
+            extract_node(
+                queries,
+                child,
+                source,
+                file_path,
+                Some(&sym_id),
+                symbols,
+                edges,
+            );
         }
     }
 }
@@ -447,16 +461,8 @@ fn walk_for_calls_and_raises_q(
                     }
                     let line = capture.node.start_position().row as u32 + 1;
                     let exc_name = node_text(capture.node, source);
-                    if !exc_name.is_empty()
-                        && seen_raises.insert((exc_name.to_string(), line))
-                    {
-                        edges.push(Edge::new(
-                            ctx,
-                            exc_name,
-                            EdgeKind::Raises,
-                            file_path,
-                            line,
-                        ));
+                    if !exc_name.is_empty() && seen_raises.insert((exc_name.to_string(), line)) {
+                        edges.push(Edge::new(ctx, exc_name, EdgeKind::Raises, file_path, line));
                     }
                 }
             }

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -3,7 +3,7 @@ use tree_sitter::{Language, Node, Parser, QueryCursor};
 
 use crate::types::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::queries::CachedQuery;
+use super::queries::{is_inside_nested_scope, CachedQuery};
 use super::{node_text, ExtractionResult, Extractor};
 
 pub struct PythonExtractor {
@@ -417,7 +417,7 @@ fn walk_for_calls_and_raises_q(
             for capture in m.captures {
                 if capture.index == callee_idx {
                     // Skip if inside a nested function/class definition
-                    if is_inside_nested_scope(capture.node, node) {
+                    if is_inside_nested_scope(capture.node, node, PY_SCOPE_KINDS) {
                         continue;
                     }
                     let callee_name = node_text(capture.node, source);
@@ -442,12 +442,14 @@ fn walk_for_calls_and_raises_q(
         for m in cursor.matches(&queries.raise.query, node, source.as_bytes()) {
             for capture in m.captures {
                 if capture.index == exception_idx {
-                    if is_inside_nested_scope(capture.node, node) {
+                    if is_inside_nested_scope(capture.node, node, PY_SCOPE_KINDS) {
                         continue;
                     }
                     let line = capture.node.start_position().row as u32 + 1;
                     let exc_name = node_text(capture.node, source);
-                    if !exc_name.is_empty() && seen_raises.insert(line) {
+                    if !exc_name.is_empty()
+                        && seen_raises.insert((exc_name.to_string(), line))
+                    {
                         edges.push(Edge::new(
                             ctx,
                             exc_name,
@@ -467,7 +469,7 @@ fn walk_for_calls_and_raises_q(
         for m in cursor.matches(&queries.except.query, node, source.as_bytes()) {
             for capture in m.captures {
                 if capture.index == except_type_idx {
-                    if is_inside_nested_scope(capture.node, node) {
+                    if is_inside_nested_scope(capture.node, node, PY_SCOPE_KINDS) {
                         continue;
                     }
                     let type_name = node_text(capture.node, source);
@@ -488,23 +490,7 @@ fn walk_for_calls_and_raises_q(
     }
 }
 
-/// Check if a node is inside a nested function/class definition relative to the scope root.
-///
-/// Returns true if there's a function_definition or class_definition between
-/// `node` and `scope_root`, meaning the node belongs to a nested scope.
-fn is_inside_nested_scope(node: Node, scope_root: Node) -> bool {
-    let mut current = node.parent();
-    while let Some(parent) = current {
-        if parent.id() == scope_root.id() {
-            return false;
-        }
-        if parent.kind() == "function_definition" || parent.kind() == "class_definition" {
-            return true;
-        }
-        current = parent.parent();
-    }
-    false
-}
+const PY_SCOPE_KINDS: &[&str] = &["function_definition", "class_definition"];
 
 // ── Reference helpers ──
 

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -1,21 +1,62 @@
 use anyhow::Result;
-use tree_sitter::{Language, Node, Parser};
+use tree_sitter::{Language, Node, Parser, QueryCursor};
 
 use crate::types::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
+use super::queries::CachedQuery;
 use super::{node_text, ExtractionResult, Extractor};
 
 pub struct PythonExtractor {
     parser: Parser,
+    /// Query for call expressions: `foo()`, `obj.method()`
+    call_query: CachedQuery,
+    /// Query for raise statements: `raise ValueError("msg")`
+    raise_query: CachedQuery,
+    /// Query for except clauses: `except ValueError:`
+    except_query: CachedQuery,
+    /// Query for type identifiers in annotations
+    type_ref_query: CachedQuery,
 }
 
 impl PythonExtractor {
     pub fn new() -> Self {
+        let lang = Language::new(tree_sitter_python::LANGUAGE);
         let mut parser = Parser::new();
         parser
-            .set_language(&Language::new(tree_sitter_python::LANGUAGE))
+            .set_language(&lang)
             .expect("Python grammar should always load");
-        Self { parser }
+
+        let call_query = CachedQuery::new(
+            &lang,
+            "(call function: [(identifier) (attribute)] @callee)",
+        );
+        let raise_query = CachedQuery::new(
+            &lang,
+            r#"(raise_statement
+              [(call function: [(identifier) (attribute)] @exception)
+               (identifier) @exception
+               (attribute) @exception])"#,
+        );
+        let except_query = CachedQuery::new(
+            &lang,
+            r#"(except_clause
+              [(identifier) @exception_type
+               (tuple (identifier) @exception_type)
+               (attribute) @exception_type])"#,
+        );
+        let type_ref_query = CachedQuery::new(
+            &lang,
+            r#"[(identifier) @type_ref
+               (attribute) @type_ref]"#,
+        );
+
+        Self {
+            parser,
+            call_query,
+            raise_query,
+            except_query,
+            type_ref_query,
+        }
     }
 }
 
@@ -23,6 +64,14 @@ impl Default for PythonExtractor {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Bundled query references passed through extraction functions.
+struct Queries<'a> {
+    call: &'a CachedQuery,
+    raise: &'a CachedQuery,
+    except: &'a CachedQuery,
+    type_ref: &'a CachedQuery,
 }
 
 impl Extractor for PythonExtractor {
@@ -35,8 +84,16 @@ impl Extractor for PythonExtractor {
         let mut symbols = Vec::new();
         let mut edges = Vec::new();
 
+        let queries = Queries {
+            call: &self.call_query,
+            raise: &self.raise_query,
+            except: &self.except_query,
+            type_ref: &self.type_ref_query,
+        };
+
         let root = tree.root_node();
         extract_node(
+            &queries,
             root,
             source,
             file_path,
@@ -50,6 +107,7 @@ impl Extractor for PythonExtractor {
 }
 
 fn extract_node(
+    queries: &Queries,
     node: Node,
     source: &str,
     file_path: &str,
@@ -59,10 +117,10 @@ fn extract_node(
 ) {
     match node.kind() {
         "function_definition" => {
-            extract_function(node, source, file_path, parent_id, symbols, edges);
+            extract_function(queries, node, source, file_path, parent_id, symbols, edges);
         }
         "class_definition" => {
-            extract_class(node, source, file_path, parent_id, symbols, edges);
+            extract_class(queries, node, source, file_path, parent_id, symbols, edges);
         }
         "decorated_definition" => {
             // Find the actual definition first to compute its symbol ID for decorator edges
@@ -83,7 +141,7 @@ fn extract_node(
                 } else if child.kind() == "function_definition"
                     || child.kind() == "class_definition"
                 {
-                    extract_node(child, source, file_path, parent_id, symbols, edges);
+                    extract_node(queries, child, source, file_path, parent_id, symbols, edges);
                 }
             }
         }
@@ -97,18 +155,19 @@ fn extract_node(
                 }
             }
             // Still walk children for call expressions
-            walk_for_calls_and_raises(node, source, file_path, parent_id, edges);
+            walk_for_calls_and_raises_q(queries, node, source, file_path, parent_id, edges);
         }
         _ => {
             // Recurse into children
             for child in node.named_children(&mut node.walk()) {
-                extract_node(child, source, file_path, parent_id, symbols, edges);
+                extract_node(queries, child, source, file_path, parent_id, symbols, edges);
             }
         }
     }
 }
 
 fn extract_function(
+    queries: &Queries,
     node: Node,
     source: &str,
     file_path: &str,
@@ -178,16 +237,16 @@ fn extract_function(
     symbols.push(sym);
 
     // Extract type annotation references from parameters and return type
-    extract_fn_type_refs(node, source, file_path, &sym_id, edges);
+    extract_fn_type_refs(queries, node, source, file_path, &sym_id, edges);
 
     // Walk the function body for calls, raises, etc.
     if let Some(body) = node.child_by_field_name("body") {
-        walk_for_calls_and_raises(body, source, file_path, Some(&sym_id), edges);
+        walk_for_calls_and_raises_q(queries, body, source, file_path, Some(&sym_id), edges);
         // Recurse for nested functions/classes
         for child in body.named_children(&mut body.walk()) {
             match child.kind() {
                 "function_definition" | "class_definition" | "decorated_definition" => {
-                    extract_node(child, source, file_path, Some(&sym_id), symbols, edges);
+                    extract_node(queries, child, source, file_path, Some(&sym_id), symbols, edges);
                 }
                 _ => {}
             }
@@ -196,6 +255,7 @@ fn extract_function(
 }
 
 fn extract_class(
+    queries: &Queries,
     node: Node,
     source: &str,
     file_path: &str,
@@ -250,7 +310,7 @@ fn extract_class(
     // Walk class body for methods, nested classes, assignments
     if let Some(body) = node.child_by_field_name("body") {
         for child in body.named_children(&mut body.walk()) {
-            extract_node(child, source, file_path, Some(&sym_id), symbols, edges);
+            extract_node(queries, child, source, file_path, Some(&sym_id), symbols, edges);
         }
     }
 }
@@ -332,131 +392,125 @@ fn extract_assignment(
     }
 }
 
-/// Walk a subtree looking for call expressions and raise statements.
-fn walk_for_calls_and_raises(
+/// Walk a subtree looking for call expressions, raise statements, and except clauses.
+///
+/// Uses tree-sitter queries instead of manual cursor walks for clarity and correctness.
+fn walk_for_calls_and_raises_q(
+    queries: &Queries,
     node: Node,
     source: &str,
     file_path: &str,
     context_id: Option<&str>,
     edges: &mut Vec<Edge>,
 ) {
-    let mut cursor = node.walk();
-    let mut did_visit_children = false;
+    let Some(ctx) = context_id else { return };
 
-    loop {
-        let current = cursor.node();
+    let callee_idx = queries.call.capture_index("callee");
+    let exception_idx = queries.raise.capture_index("exception");
+    let except_type_idx = queries.except.capture_index("exception_type");
 
-        if !did_visit_children {
-            match current.kind() {
-                "call" => {
-                    if let Some(ctx) = context_id {
-                        if let Some(func) = current.child_by_field_name("function") {
-                            let callee_name = node_text(func, source);
-                            if !callee_name.is_empty() {
-                                edges.push(Edge::new(
-                                    ctx,
-                                    callee_name,
-                                    EdgeKind::Calls,
-                                    file_path,
-                                    current.start_position().row as u32 + 1,
-                                ));
-                            }
-                        }
+    // Calls: foo(), obj.method()
+    {
+        let mut cursor = QueryCursor::new();
+        // Exclude nested function/class bodies from call detection
+        for m in cursor.matches(&queries.call.query, node, source.as_bytes()) {
+            for capture in m.captures {
+                if capture.index == callee_idx {
+                    // Skip if inside a nested function/class definition
+                    if is_inside_nested_scope(capture.node, node) {
+                        continue;
+                    }
+                    let callee_name = node_text(capture.node, source);
+                    if !callee_name.is_empty() {
+                        edges.push(Edge::new(
+                            ctx,
+                            callee_name,
+                            EdgeKind::Calls,
+                            file_path,
+                            capture.node.start_position().row as u32 + 1,
+                        ));
                     }
                 }
-                "raise_statement" => {
-                    if let Some(ctx) = context_id {
-                        if let Some(exc) = current.named_child(0) {
-                            let exc_name = if exc.kind() == "call" {
-                                exc.child_by_field_name("function")
-                                    .map(|f| node_text(f, source))
-                                    .unwrap_or("")
-                            } else {
-                                node_text(exc, source)
-                            };
-                            if !exc_name.is_empty() {
-                                edges.push(Edge::new(
-                                    ctx,
-                                    exc_name,
-                                    EdgeKind::Raises,
-                                    file_path,
-                                    current.start_position().row as u32 + 1,
-                                ));
-                            }
-                        }
-                    }
-                }
-                "except_clause" => {
-                    // except ValueError as e: — extract exception type reference
-                    if let Some(ctx) = context_id {
-                        for child in current.named_children(&mut current.walk()) {
-                            if child.kind() == "identifier" || child.kind() == "attribute" {
-                                let type_name = node_text(child, source);
-                                if !type_name.is_empty()
-                                    && type_name.chars().next().is_some_and(|c| c.is_uppercase())
-                                {
-                                    edges.push(Edge::new(
-                                        ctx,
-                                        type_name,
-                                        EdgeKind::References,
-                                        file_path,
-                                        child.start_position().row as u32 + 1,
-                                    ));
-                                }
-                                break; // only the first identifier/attribute is the exception type
-                            }
-                            // except (TypeError, ValueError):
-                            if child.kind() == "tuple" {
-                                for tc in child.named_children(&mut child.walk()) {
-                                    let type_name = node_text(tc, source);
-                                    if !type_name.is_empty() {
-                                        edges.push(Edge::new(
-                                            ctx,
-                                            type_name,
-                                            EdgeKind::References,
-                                            file_path,
-                                            tc.start_position().row as u32 + 1,
-                                        ));
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-                // Don't descend into nested function/class definitions
-                "function_definition" | "class_definition" => {
-                    did_visit_children = true;
-                    continue;
-                }
-                _ => {}
-            }
-        }
-
-        // Tree walking logic
-        if !did_visit_children && cursor.goto_first_child() {
-            did_visit_children = false;
-            continue;
-        }
-        did_visit_children = false;
-        if cursor.goto_next_sibling() {
-            continue;
-        }
-        loop {
-            if !cursor.goto_parent() {
-                return;
-            }
-            if cursor.goto_next_sibling() {
-                break;
             }
         }
     }
+
+    // Raises: raise ValueError("msg")
+    {
+        let mut cursor = QueryCursor::new();
+        let mut seen_raises = std::collections::HashSet::new();
+        for m in cursor.matches(&queries.raise.query, node, source.as_bytes()) {
+            for capture in m.captures {
+                if capture.index == exception_idx {
+                    if is_inside_nested_scope(capture.node, node) {
+                        continue;
+                    }
+                    let line = capture.node.start_position().row as u32 + 1;
+                    let exc_name = node_text(capture.node, source);
+                    if !exc_name.is_empty() && seen_raises.insert(line) {
+                        edges.push(Edge::new(
+                            ctx,
+                            exc_name,
+                            EdgeKind::Raises,
+                            file_path,
+                            line,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // Except clauses: except ValueError as e:
+    {
+        let mut cursor = QueryCursor::new();
+        for m in cursor.matches(&queries.except.query, node, source.as_bytes()) {
+            for capture in m.captures {
+                if capture.index == except_type_idx {
+                    if is_inside_nested_scope(capture.node, node) {
+                        continue;
+                    }
+                    let type_name = node_text(capture.node, source);
+                    if !type_name.is_empty()
+                        && type_name.chars().next().is_some_and(|c| c.is_uppercase())
+                    {
+                        edges.push(Edge::new(
+                            ctx,
+                            type_name,
+                            EdgeKind::References,
+                            file_path,
+                            capture.node.start_position().row as u32 + 1,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Check if a node is inside a nested function/class definition relative to the scope root.
+///
+/// Returns true if there's a function_definition or class_definition between
+/// `node` and `scope_root`, meaning the node belongs to a nested scope.
+fn is_inside_nested_scope(node: Node, scope_root: Node) -> bool {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if parent.id() == scope_root.id() {
+            return false;
+        }
+        if parent.kind() == "function_definition" || parent.kind() == "class_definition" {
+            return true;
+        }
+        current = parent.parent();
+    }
+    false
 }
 
 // ── Reference helpers ──
 
 /// Extract type annotation references from function parameters and return type.
 fn extract_fn_type_refs(
+    queries: &Queries,
     node: Node,
     source: &str,
     file_path: &str,
@@ -468,56 +522,54 @@ fn extract_fn_type_refs(
         for param in params.named_children(&mut params.walk()) {
             // typed_parameter, typed_default_parameter
             if let Some(type_node) = param.child_by_field_name("type") {
-                collect_type_refs(type_node, source, file_path, sym_id, edges);
+                collect_type_refs(queries, type_node, source, file_path, sym_id, edges);
             }
         }
     }
     // Return type annotation
     if let Some(ret) = node.child_by_field_name("return_type") {
-        collect_type_refs(ret, source, file_path, sym_id, edges);
+        collect_type_refs(queries, ret, source, file_path, sym_id, edges);
     }
 }
 
-/// Recursively collect type name references from a type annotation node.
+/// Collect type name references from a type annotation node using queries.
 fn collect_type_refs(
+    queries: &Queries,
     node: Node,
     source: &str,
     file_path: &str,
     sym_id: &str,
     edges: &mut Vec<Edge>,
 ) {
-    match node.kind() {
-        "identifier" => {
-            let name = node_text(node, source);
-            // Skip builtins and lowercase names (int, str, bool, etc.)
-            if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_uppercase()) {
-                edges.push(Edge::new(
-                    sym_id,
-                    name,
-                    EdgeKind::References,
-                    file_path,
-                    node.start_position().row as u32 + 1,
-                ));
-            }
-        }
-        "attribute" => {
-            // e.g. typing.Optional — emit the full dotted name
-            let name = node_text(node, source);
-            if !name.is_empty() {
-                edges.push(Edge::new(
-                    sym_id,
-                    name,
-                    EdgeKind::References,
-                    file_path,
-                    node.start_position().row as u32 + 1,
-                ));
-            }
-        }
-        // For subscript types like Optional[str], List[int], Dict[str, int]
-        // recurse into children to capture the outer type and inner types
-        _ => {
-            for child in node.named_children(&mut node.walk()) {
-                collect_type_refs(child, source, file_path, sym_id, edges);
+    let type_ref_idx = queries.type_ref.capture_index("type_ref");
+    let mut cursor = QueryCursor::new();
+    for m in cursor.matches(&queries.type_ref.query, node, source.as_bytes()) {
+        for capture in m.captures {
+            if capture.index == type_ref_idx {
+                let name = node_text(capture.node, source);
+                if capture.node.kind() == "identifier" {
+                    // Skip builtins and lowercase names (int, str, bool, etc.)
+                    if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_uppercase()) {
+                        edges.push(Edge::new(
+                            sym_id,
+                            name,
+                            EdgeKind::References,
+                            file_path,
+                            capture.node.start_position().row as u32 + 1,
+                        ));
+                    }
+                } else if capture.node.kind() == "attribute" {
+                    // e.g. typing.Optional — emit the full dotted name
+                    if !name.is_empty() {
+                        edges.push(Edge::new(
+                            sym_id,
+                            name,
+                            EdgeKind::References,
+                            file_path,
+                            capture.node.start_position().row as u32 + 1,
+                        ));
+                    }
+                }
             }
         }
     }

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use streaming_iterator::StreamingIterator;
 use tree_sitter::{Language, Node, Parser, QueryCursor};
 
 use crate::types::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
@@ -427,7 +428,8 @@ fn walk_for_calls_and_raises_q(
     {
         let mut cursor = QueryCursor::new();
         // Exclude nested function/class bodies from call detection
-        for m in cursor.matches(&queries.call.query, node, source.as_bytes()) {
+        let mut matches = cursor.matches(&queries.call.query, node, source.as_bytes());
+        while let Some(m) = matches.next() {
             for capture in m.captures {
                 if capture.index == callee_idx {
                     // Skip if inside a nested function/class definition
@@ -453,7 +455,8 @@ fn walk_for_calls_and_raises_q(
     {
         let mut cursor = QueryCursor::new();
         let mut seen_raises = std::collections::HashSet::new();
-        for m in cursor.matches(&queries.raise.query, node, source.as_bytes()) {
+        let mut matches = cursor.matches(&queries.raise.query, node, source.as_bytes());
+        while let Some(m) = matches.next() {
             for capture in m.captures {
                 if capture.index == exception_idx {
                     if is_inside_nested_scope(capture.node, node, PY_SCOPE_KINDS) {
@@ -472,7 +475,8 @@ fn walk_for_calls_and_raises_q(
     // Except clauses: except ValueError as e:
     {
         let mut cursor = QueryCursor::new();
-        for m in cursor.matches(&queries.except.query, node, source.as_bytes()) {
+        let mut matches = cursor.matches(&queries.except.query, node, source.as_bytes());
+        while let Some(m) = matches.next() {
             for capture in m.captures {
                 if capture.index == except_type_idx {
                     if is_inside_nested_scope(capture.node, node, PY_SCOPE_KINDS) {
@@ -535,7 +539,8 @@ fn collect_type_refs(
 ) {
     let type_ref_idx = queries.type_ref.capture_index("type_ref");
     let mut cursor = QueryCursor::new();
-    for m in cursor.matches(&queries.type_ref.query, node, source.as_bytes()) {
+    let mut matches = cursor.matches(&queries.type_ref.query, node, source.as_bytes());
+    while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == type_ref_idx {
                 let name = node_text(capture.node, source);

--- a/src/languages/queries.rs
+++ b/src/languages/queries.rs
@@ -1,0 +1,201 @@
+//! Shared tree-sitter query helpers for language extractors.
+//!
+//! Provides utilities to run declarative S-expression queries against tree-sitter
+//! syntax trees, replacing verbose manual cursor-walk loops with concise patterns.
+
+use tree_sitter::{Language, Node, Query, QueryCursor};
+
+use crate::types::{Edge, EdgeKind};
+
+use super::node_text;
+
+/// A compiled query cached for reuse across multiple files.
+///
+/// Compile once per extractor (in `new()`), reuse on every `extract()` call.
+pub struct CachedQuery {
+    pub query: Query,
+}
+
+impl CachedQuery {
+    /// Compile a tree-sitter S-expression query for the given language.
+    ///
+    /// # Panics
+    /// Panics if the query pattern is invalid — this indicates a bug in the
+    /// hard-coded query string, not a runtime error.
+    pub fn new(language: &Language, pattern: &str) -> Self {
+        let query = Query::new(language, pattern)
+            .unwrap_or_else(|e| panic!("invalid tree-sitter query: {e}\npattern: {pattern}"));
+        Self { query }
+    }
+
+    /// Get the index of a named capture, or panic if it doesn't exist.
+    pub fn capture_index(&self, name: &str) -> u32 {
+        self.query
+            .capture_index_for_name(name)
+            .unwrap_or_else(|| panic!("capture @{name} not found in query"))
+    }
+}
+
+/// Walk a subtree collecting call edges using a pre-compiled query.
+///
+/// This replaces the manual `walk_for_calls` cursor loops used across all extractors.
+/// The query should capture `@callee` for the function/method name node.
+pub fn collect_call_edges(
+    query: &CachedQuery,
+    callee_idx: u32,
+    node: Node,
+    source: &str,
+    file_path: &str,
+    context_id: &str,
+    edges: &mut Vec<Edge>,
+) {
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query.query, node, source.as_bytes());
+
+    for m in matches {
+        for capture in m.captures {
+            if capture.index == callee_idx {
+                let callee_name = node_text(capture.node, source);
+                if !callee_name.is_empty() {
+                    edges.push(Edge::new(
+                        context_id,
+                        callee_name,
+                        EdgeKind::Calls,
+                        file_path,
+                        capture.node.start_position().row as u32 + 1,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Walk a subtree collecting edges of any kind using a pre-compiled query.
+///
+/// Generic version that takes edge kind as a parameter. The query should
+/// capture `@target` for the target name node.
+pub fn collect_edges(
+    query: &CachedQuery,
+    target_idx: u32,
+    kind: EdgeKind,
+    node: Node,
+    source: &str,
+    file_path: &str,
+    context_id: &str,
+    edges: &mut Vec<Edge>,
+) {
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query.query, node, source.as_bytes());
+
+    for m in matches {
+        for capture in m.captures {
+            if capture.index == target_idx {
+                let name = node_text(capture.node, source);
+                if !name.is_empty() {
+                    edges.push(Edge::new(
+                        context_id,
+                        name,
+                        kind,
+                        file_path,
+                        capture.node.start_position().row as u32 + 1,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Walk a subtree collecting type reference edges (uppercase identifiers only).
+///
+/// Filters out lowercase names (builtins like `int`, `str`, `bool`).
+pub fn collect_type_ref_edges(
+    query: &CachedQuery,
+    target_idx: u32,
+    node: Node,
+    source: &str,
+    file_path: &str,
+    context_id: &str,
+    edges: &mut Vec<Edge>,
+) {
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query.query, node, source.as_bytes());
+
+    for m in matches {
+        for capture in m.captures {
+            if capture.index == target_idx {
+                let name = node_text(capture.node, source);
+                if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_uppercase()) {
+                    edges.push(Edge::new(
+                        context_id,
+                        name,
+                        EdgeKind::References,
+                        file_path,
+                        capture.node.start_position().row as u32 + 1,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cached_query_compiles() {
+        let lang = Language::new(tree_sitter_python::LANGUAGE);
+        let q = CachedQuery::new(&lang, "(call function: (identifier) @callee)");
+        assert_eq!(q.capture_index("callee"), 0);
+    }
+
+    #[test]
+    fn test_collect_call_edges_python() {
+        let lang = Language::new(tree_sitter_python::LANGUAGE);
+        let q = CachedQuery::new(&lang, "(call function: (identifier) @callee)");
+        let callee_idx = q.capture_index("callee");
+
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang).unwrap();
+        let source = "def foo():\n    bar()\n    baz(42)\n";
+        let tree = parser.parse(source, None).unwrap();
+
+        // Find the function body to search within
+        let root = tree.root_node();
+        let mut edges = Vec::new();
+        collect_call_edges(&q, callee_idx, root, source, "test.py", "test:foo:1", &mut edges);
+
+        assert_eq!(edges.len(), 2);
+        let targets: Vec<&str> = edges.iter().map(|e| e.target_name.as_str()).collect();
+        assert!(targets.contains(&"bar"));
+        assert!(targets.contains(&"baz"));
+    }
+
+    #[test]
+    fn test_collect_type_ref_edges_filters_lowercase() {
+        let lang = Language::new(tree_sitter_python::LANGUAGE);
+        let q = CachedQuery::new(&lang, "(identifier) @target");
+        let target_idx = q.capture_index("target");
+
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang).unwrap();
+        let source = "x: int = User()";
+        let tree = parser.parse(source, None).unwrap();
+
+        let mut edges = Vec::new();
+        collect_type_ref_edges(
+            &q,
+            target_idx,
+            tree.root_node(),
+            source,
+            "test.py",
+            "test:x:1",
+            &mut edges,
+        );
+
+        let targets: Vec<&str> = edges.iter().map(|e| e.target_name.as_str()).collect();
+        assert!(targets.contains(&"User"));
+        assert!(!targets.contains(&"int"));
+        assert!(!targets.contains(&"x"));
+    }
+}

--- a/src/languages/queries.rs
+++ b/src/languages/queries.rs
@@ -3,11 +3,7 @@
 //! Provides utilities to run declarative S-expression queries against tree-sitter
 //! syntax trees, replacing verbose manual cursor-walk loops with concise patterns.
 
-use tree_sitter::{Language, Node, Query, QueryCursor};
-
-use crate::types::{Edge, EdgeKind};
-
-use super::node_text;
+use tree_sitter::{Language, Node, Query};
 
 /// A compiled query cached for reuse across multiple files.
 ///
@@ -36,166 +32,34 @@ impl CachedQuery {
     }
 }
 
-/// Walk a subtree collecting call edges using a pre-compiled query.
+/// Check whether a captured node is inside a nested scope relative to a root node.
 ///
-/// This replaces the manual `walk_for_calls` cursor loops used across all extractors.
-/// The query should capture `@callee` for the function/method name node.
-pub fn collect_call_edges(
-    query: &CachedQuery,
-    callee_idx: u32,
-    node: Node,
-    source: &str,
-    file_path: &str,
-    context_id: &str,
-    edges: &mut Vec<Edge>,
-) {
-    let mut cursor = QueryCursor::new();
-    let matches = cursor.matches(&query.query, node, source.as_bytes());
-
-    for m in matches {
-        for capture in m.captures {
-            if capture.index == callee_idx {
-                let callee_name = node_text(capture.node, source);
-                if !callee_name.is_empty() {
-                    edges.push(Edge::new(
-                        context_id,
-                        callee_name,
-                        EdgeKind::Calls,
-                        file_path,
-                        capture.node.start_position().row as u32 + 1,
-                    ));
-                }
-            }
+/// Walks up the tree from `node` to `root`. If any ancestor between them matches
+/// one of the `scope_kinds`, returns `true` — meaning the node belongs to a nested
+/// scope and should be skipped when extracting edges for the root scope.
+pub fn is_inside_nested_scope(node: Node, root: Node, scope_kinds: &[&str]) -> bool {
+    let mut current = node.parent();
+    while let Some(p) = current {
+        if p.id() == root.id() {
+            return false;
         }
-    }
-}
-
-/// Walk a subtree collecting edges of any kind using a pre-compiled query.
-///
-/// Generic version that takes edge kind as a parameter. The query should
-/// capture `@target` for the target name node.
-pub fn collect_edges(
-    query: &CachedQuery,
-    target_idx: u32,
-    kind: EdgeKind,
-    node: Node,
-    source: &str,
-    file_path: &str,
-    context_id: &str,
-    edges: &mut Vec<Edge>,
-) {
-    let mut cursor = QueryCursor::new();
-    let matches = cursor.matches(&query.query, node, source.as_bytes());
-
-    for m in matches {
-        for capture in m.captures {
-            if capture.index == target_idx {
-                let name = node_text(capture.node, source);
-                if !name.is_empty() {
-                    edges.push(Edge::new(
-                        context_id,
-                        name,
-                        kind,
-                        file_path,
-                        capture.node.start_position().row as u32 + 1,
-                    ));
-                }
-            }
+        if scope_kinds.contains(&p.kind()) {
+            return true;
         }
+        current = p.parent();
     }
-}
-
-/// Walk a subtree collecting type reference edges (uppercase identifiers only).
-///
-/// Filters out lowercase names (builtins like `int`, `str`, `bool`).
-pub fn collect_type_ref_edges(
-    query: &CachedQuery,
-    target_idx: u32,
-    node: Node,
-    source: &str,
-    file_path: &str,
-    context_id: &str,
-    edges: &mut Vec<Edge>,
-) {
-    let mut cursor = QueryCursor::new();
-    let matches = cursor.matches(&query.query, node, source.as_bytes());
-
-    for m in matches {
-        for capture in m.captures {
-            if capture.index == target_idx {
-                let name = node_text(capture.node, source);
-                if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_uppercase()) {
-                    edges.push(Edge::new(
-                        context_id,
-                        name,
-                        EdgeKind::References,
-                        file_path,
-                        capture.node.start_position().row as u32 + 1,
-                    ));
-                }
-            }
-        }
-    }
+    false
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tree_sitter::Language;
 
     #[test]
     fn test_cached_query_compiles() {
         let lang = Language::new(tree_sitter_python::LANGUAGE);
         let q = CachedQuery::new(&lang, "(call function: (identifier) @callee)");
         assert_eq!(q.capture_index("callee"), 0);
-    }
-
-    #[test]
-    fn test_collect_call_edges_python() {
-        let lang = Language::new(tree_sitter_python::LANGUAGE);
-        let q = CachedQuery::new(&lang, "(call function: (identifier) @callee)");
-        let callee_idx = q.capture_index("callee");
-
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&lang).unwrap();
-        let source = "def foo():\n    bar()\n    baz(42)\n";
-        let tree = parser.parse(source, None).unwrap();
-
-        // Find the function body to search within
-        let root = tree.root_node();
-        let mut edges = Vec::new();
-        collect_call_edges(&q, callee_idx, root, source, "test.py", "test:foo:1", &mut edges);
-
-        assert_eq!(edges.len(), 2);
-        let targets: Vec<&str> = edges.iter().map(|e| e.target_name.as_str()).collect();
-        assert!(targets.contains(&"bar"));
-        assert!(targets.contains(&"baz"));
-    }
-
-    #[test]
-    fn test_collect_type_ref_edges_filters_lowercase() {
-        let lang = Language::new(tree_sitter_python::LANGUAGE);
-        let q = CachedQuery::new(&lang, "(identifier) @target");
-        let target_idx = q.capture_index("target");
-
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&lang).unwrap();
-        let source = "x: int = User()";
-        let tree = parser.parse(source, None).unwrap();
-
-        let mut edges = Vec::new();
-        collect_type_ref_edges(
-            &q,
-            target_idx,
-            tree.root_node(),
-            source,
-            "test.py",
-            "test:x:1",
-            &mut edges,
-        );
-
-        let targets: Vec<&str> = edges.iter().map(|e| e.target_name.as_str()).collect();
-        assert!(targets.contains(&"User"));
-        assert!(!targets.contains(&"int"));
-        assert!(!targets.contains(&"x"));
     }
 }

--- a/src/languages/queries.rs
+++ b/src/languages/queries.rs
@@ -24,6 +24,12 @@ impl CachedQuery {
         Self { query }
     }
 
+    /// Try to compile a query, returning `None` if the pattern is invalid
+    /// (e.g. the node type doesn't exist in this grammar).
+    pub fn try_new(language: &Language, pattern: &str) -> Option<Self> {
+        Query::new(language, pattern).ok().map(|query| Self { query })
+    }
+
     /// Get the index of a named capture, or panic if it doesn't exist.
     pub fn capture_index(&self, name: &str) -> u32 {
         self.query

--- a/src/languages/queries.rs
+++ b/src/languages/queries.rs
@@ -27,7 +27,9 @@ impl CachedQuery {
     /// Try to compile a query, returning `None` if the pattern is invalid
     /// (e.g. the node type doesn't exist in this grammar).
     pub fn try_new(language: &Language, pattern: &str) -> Option<Self> {
-        Query::new(language, pattern).ok().map(|query| Self { query })
+        Query::new(language, pattern)
+            .ok()
+            .map(|query| Self { query })
     }
 
     /// Get the index of a named capture, or panic if it doesn't exist.

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -289,7 +289,7 @@ fn extract_module(
     let sym_id = symbol_id(file_path, &name, start_line);
     let sym = Symbol::new(
         &name,
-        SymbolKind::Class,
+        SymbolKind::Module,
         file_path,
         start_line,
         end_line,
@@ -755,7 +755,7 @@ end
 
         let module = result.symbols.iter().find(|s| s.name == "Authentication");
         assert!(module.is_some());
-        assert_eq!(module.unwrap().kind, SymbolKind::Class);
+        assert_eq!(module.unwrap().kind, SymbolKind::Module);
 
         let method = result.symbols.iter().find(|s| s.name == "authenticate");
         assert!(method.is_some());

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -206,7 +206,7 @@ fn extract_enum(
     symbols.push(
         Symbol::new(
             name,
-            SymbolKind::Class,
+            SymbolKind::Enum,
             file_path,
             start_line,
             node.end_position().row as u32 + 1,
@@ -240,7 +240,7 @@ fn extract_trait(
     symbols.push(
         Symbol::new(
             name,
-            SymbolKind::Class,
+            SymbolKind::Trait,
             file_path,
             start_line,
             node.end_position().row as u32 + 1,
@@ -298,7 +298,7 @@ fn extract_impl(
             edges.push(Edge::new(
                 impl_parent_id.clone(),
                 trait_n.clone(),
-                EdgeKind::Inherits,
+                EdgeKind::Implements,
                 file_path,
                 start_line,
             ));
@@ -485,7 +485,7 @@ fn extract_mod(
         symbols.push(
             Symbol::new(
                 name,
-                SymbolKind::Class,
+                SymbolKind::Module,
                 file_path,
                 start_line,
                 node.end_position().row as u32 + 1,
@@ -563,7 +563,7 @@ fn extract_type_alias(
     symbols.push(
         Symbol::new(
             name,
-            SymbolKind::Variable,
+            SymbolKind::TypeAlias,
             file_path,
             start_line,
             node.end_position().row as u32 + 1,
@@ -921,7 +921,7 @@ impl Serializable for UserService {
         let inherits: Vec<_> = result
             .edges
             .iter()
-            .filter(|e| e.kind == EdgeKind::Inherits)
+            .filter(|e| e.kind == EdgeKind::Implements)
             .collect();
         assert_eq!(inherits.len(), 1);
         assert_eq!(inherits[0].target_name, "Serializable");
@@ -941,7 +941,7 @@ pub enum Status {
 
         let e = result.symbols.iter().find(|s| s.name == "Status");
         assert!(e.is_some());
-        assert_eq!(e.unwrap().kind, SymbolKind::Class);
+        assert_eq!(e.unwrap().kind, SymbolKind::Enum);
         assert_eq!(e.unwrap().visibility, Visibility::Public);
     }
 
@@ -1145,7 +1145,7 @@ type Handler = Box<dyn Fn()>;
         );
 
         let alias = result.symbols.iter().find(|s| s.name == "Result").unwrap();
-        assert_eq!(alias.kind, SymbolKind::Variable);
+        assert_eq!(alias.kind, SymbolKind::TypeAlias);
         assert_eq!(alias.visibility, Visibility::Public);
 
         let handler = result.symbols.iter().find(|s| s.name == "Handler").unwrap();
@@ -1164,7 +1164,7 @@ pub mod auth {
         );
 
         let module = result.symbols.iter().find(|s| s.name == "auth").unwrap();
-        assert_eq!(module.kind, SymbolKind::Class);
+        assert_eq!(module.kind, SymbolKind::Module);
         assert_eq!(module.visibility, Visibility::Public);
 
         let login = result.symbols.iter().find(|s| s.name == "login").unwrap();

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -5,15 +5,18 @@ use super::{js_shared, ExtractionResult, Extractor};
 
 pub struct TypeScriptExtractor {
     parser: Parser,
+    queries: js_shared::JsQueries,
 }
 
 impl TypeScriptExtractor {
     pub fn new() -> Self {
+        let lang = Language::new(tree_sitter_typescript::LANGUAGE_TYPESCRIPT);
         let mut parser = Parser::new();
         parser
-            .set_language(&Language::new(tree_sitter_typescript::LANGUAGE_TYPESCRIPT))
+            .set_language(&lang)
             .expect("TypeScript grammar should always load");
-        Self { parser }
+        let queries = js_shared::JsQueries::new(&lang);
+        Self { parser, queries }
     }
 }
 
@@ -25,21 +28,24 @@ impl Default for TypeScriptExtractor {
 
 impl Extractor for TypeScriptExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        js_shared::extract(&mut self.parser, source, file_path)
+        js_shared::extract(&mut self.parser, &self.queries, source, file_path)
     }
 }
 
 pub struct TsxExtractor {
     parser: Parser,
+    queries: js_shared::JsQueries,
 }
 
 impl TsxExtractor {
     pub fn new() -> Self {
+        let lang = Language::new(tree_sitter_typescript::LANGUAGE_TSX);
         let mut parser = Parser::new();
         parser
-            .set_language(&Language::new(tree_sitter_typescript::LANGUAGE_TSX))
+            .set_language(&lang)
             .expect("TSX grammar should always load");
-        Self { parser }
+        let queries = js_shared::JsQueries::new(&lang);
+        Self { parser, queries }
     }
 }
 
@@ -51,7 +57,7 @@ impl Default for TsxExtractor {
 
 impl Extractor for TsxExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        js_shared::extract(&mut self.parser, source, file_path)
+        js_shared::extract(&mut self.parser, &self.queries, source, file_path)
     }
 }
 
@@ -150,11 +156,16 @@ class AdminService extends UserService implements Loggable {
             .iter()
             .filter(|e| e.kind == EdgeKind::Inherits)
             .collect();
-        assert_eq!(inherits.len(), 2);
+        assert_eq!(inherits.len(), 1);
+        assert_eq!(inherits[0].target_name, "UserService");
 
-        let targets: Vec<&str> = inherits.iter().map(|e| e.target_name.as_str()).collect();
-        assert!(targets.contains(&"UserService"));
-        assert!(targets.contains(&"Loggable"));
+        let implements: Vec<_> = result
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Implements)
+            .collect();
+        assert_eq!(implements.len(), 1);
+        assert_eq!(implements[0].target_name, "Loggable");
     }
 
     #[test]
@@ -169,6 +180,7 @@ interface Serializable extends Readable {
 
         let iface = result.symbols.iter().find(|s| s.name == "Serializable");
         assert!(iface.is_some());
+        assert_eq!(iface.unwrap().kind, SymbolKind::Interface);
 
         let inherits: Vec<_> = result
             .edges
@@ -270,7 +282,7 @@ enum Status {
 
         let e = result.symbols.iter().find(|s| s.name == "Status");
         assert!(e.is_some());
-        assert_eq!(e.unwrap().kind, SymbolKind::Class);
+        assert_eq!(e.unwrap().kind, SymbolKind::Enum);
     }
 
     #[test]
@@ -283,7 +295,7 @@ type UserId = string;
 
         let t = result.symbols.iter().find(|s| s.name == "UserId");
         assert!(t.is_some());
-        assert_eq!(t.unwrap().kind, SymbolKind::Variable);
+        assert_eq!(t.unwrap().kind, SymbolKind::TypeAlias);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,6 +90,11 @@ pub enum SymbolKind {
     Method,
     Variable,
     Import,
+    Interface,
+    Enum,
+    TypeAlias,
+    Trait,
+    Module,
 }
 
 impl SymbolKind {
@@ -100,6 +105,11 @@ impl SymbolKind {
             Self::Method => "method",
             Self::Variable => "variable",
             Self::Import => "import",
+            Self::Interface => "interface",
+            Self::Enum => "enum",
+            Self::TypeAlias => "type_alias",
+            Self::Trait => "trait",
+            Self::Module => "module",
         }
     }
 }
@@ -114,6 +124,11 @@ impl std::str::FromStr for SymbolKind {
             "method" => Ok(Self::Method),
             "variable" => Ok(Self::Variable),
             "import" => Ok(Self::Import),
+            "interface" => Ok(Self::Interface),
+            "enum" => Ok(Self::Enum),
+            "type_alias" => Ok(Self::TypeAlias),
+            "trait" => Ok(Self::Trait),
+            "module" => Ok(Self::Module),
             _ => Err(anyhow::anyhow!("unknown symbol kind: '{s}'")),
         }
     }
@@ -196,6 +211,8 @@ pub enum EdgeKind {
     Inherits,
     References,
     Raises,
+    Implements,
+    TypeOf,
 }
 
 impl EdgeKind {
@@ -206,6 +223,8 @@ impl EdgeKind {
             Self::Inherits => "inherits",
             Self::References => "references",
             Self::Raises => "raises",
+            Self::Implements => "implements",
+            Self::TypeOf => "type_of",
         }
     }
 }
@@ -220,6 +239,8 @@ impl std::str::FromStr for EdgeKind {
             "inherits" => Ok(Self::Inherits),
             "references" => Ok(Self::References),
             "raises" => Ok(Self::Raises),
+            "implements" => Ok(Self::Implements),
+            "type_of" => Ok(Self::TypeOf),
             _ => Err(anyhow::anyhow!("unknown edge kind: '{s}'")),
         }
     }


### PR DESCRIPTION
- Add tree-sitter query API helpers (queries.rs) replacing manual cursor walks
- Migrate Python and JS/TS/TSX extractors to use declarative query patterns
- Add new SymbolKind variants: Interface, Enum, TypeAlias, Trait, Module
- Add new EdgeKind variants: Implements, TypeOf
- Use correct SymbolKind across all 8 language extractors instead of lumping
  under Class/Variable (e.g. interfaces, enums, traits, modules, type aliases)
- Use EdgeKind::Implements for class-implements-interface edges (TS, Java, Rust)
- Enhance edge resolution from 3-tier to 5-tier priority:
  1. Same file match
  2. Import-path resolution (new)
  3. Same directory match
  4. Parent scope preference (new)
  5. Unique global match (excluding imports)

https://claude.ai/code/session_01G7pMZcPsspXTuk5KEZShXL