### PR TITLE
feat(skill): add version check and version-aware install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,10 @@ check-java: ## Validate Java fixtures (javac)
 
 # --- Skill tests ---
 
-check-skill: ## Run skill tests (ensure_indexed.sh unit tests)
+check-skill: ## Run skill tests (ensure_indexed.sh + install.sh unit tests)
 	@echo "==> Checking skill tests..."
 	@bash skills/cartog/tests/test_ensure_indexed.sh
+	@bash skills/cartog/tests/test_install.sh
 
 eval-skill: ## Run LLM-as-judge skill evaluation (requires claude CLI)
 	bash skills/cartog/tests/eval.sh

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -374,7 +374,7 @@ Or install manually:
 cp -r skills/cartog ~/.claude/skills/
 ```
 
-At session start, run the setup script (3-phase: blocking index + model download, background RAG embedding). First run downloads ~1.2GB of ONNX models and may take a few minutes — subsequent runs are instant:
+At session start, run the setup script (version check + 3-phase: blocking index + model download, background RAG embedding). Checks for newer cartog versions (cached, at most once per 24h). First run downloads ~1.2GB of ONNX models and may take a few minutes — subsequent runs are instant:
 
 ```bash
 bash scripts/ensure_indexed.sh
@@ -385,10 +385,11 @@ bash scripts/ensure_indexed.sh
 | File | Purpose |
 |------|---------|
 | [`SKILL.md`](../skills/cartog/SKILL.md) | Behavioral instructions, commands, and workflows |
-| [`scripts/install.sh`](../skills/cartog/scripts/install.sh) | Automated installation (pre-built binary or cargo install) |
-| [`scripts/ensure_indexed.sh`](../skills/cartog/scripts/ensure_indexed.sh) | 3-phase setup: blocking index + rag setup, background rag index |
+| [`scripts/install.sh`](../skills/cartog/scripts/install.sh) | Automated installation (pre-built binary or cargo install), accepts optional version arg |
+| [`scripts/ensure_indexed.sh`](../skills/cartog/scripts/ensure_indexed.sh) | Version check + 3-phase setup: blocking index + rag setup, background rag index |
 | [`tests/golden_examples.yaml`](../skills/cartog/tests/golden_examples.yaml) | Behavioral test scenarios (expected tool calls per query) |
 | [`tests/test_ensure_indexed.sh`](../skills/cartog/tests/test_ensure_indexed.sh) | Bash unit tests for ensure_indexed.sh |
+| [`tests/test_install.sh`](../skills/cartog/tests/test_install.sh) | Bash unit tests for install.sh |
 | [`tests/eval.sh`](../skills/cartog/tests/eval.sh) | LLM-as-judge evaluation via `claude` CLI |
 | [`references/query_cookbook.md`](../skills/cartog/references/query_cookbook.md) | Recipes for common navigation patterns |
 | [`references/supported_languages.md`](../skills/cartog/references/supported_languages.md) | Language support matrix |
@@ -408,7 +409,8 @@ cartog serve --watch --rag    # auto-re-index + auto-embed
 All clients need `cartog` on your `PATH` first:
 
 ```bash
-cargo install cartog
+cargo install cartog            # latest version
+cargo install cartog@0.7.0      # specific version
 ```
 
 #### Claude Code

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -99,9 +99,16 @@ Before first use, ensure cartog is installed and indexed:
 # Install if missing
 command -v cartog || bash scripts/install.sh
 
-# Run the setup script (handles all 3 phases)
+# Run the setup script (handles version check + 3 indexing phases)
 bash scripts/ensure_indexed.sh
 ```
+
+The setup script checks for newer cartog versions (cached, at most once per 24h).
+If an update is available it prints a notice like:
+```
+New cartog version available: 0.7.0 (installed: 0.6.1). Update with: bash scripts/install.sh 0.7.0
+```
+When you see this notice, ask the user if they want to update before continuing. If they agree, run the suggested command, then re-run `bash scripts/ensure_indexed.sh`.
 
 ### Search quality tiers
 

--- a/skills/cartog/scripts/ensure_indexed.sh
+++ b/skills/cartog/scripts/ensure_indexed.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # Ensure the cartog index exists and is up to date.
 # Run this at the start of a coding session.
 #
-# Three phases:
+# Four phases:
+#   0. Version check (cached, non-blocking — notifies if a newer release exists)
 #   1. Code graph index (blocking, fast — incremental, < 1s for unchanged codebases)
 #   2. Model download (blocking, one-time — enables cross-encoder reranker on FTS5 results)
 #   3. RAG embedding (background — vector search becomes available when done)
@@ -12,8 +13,62 @@ set -euo pipefail
 # After phase 2, `cartog rag search` already works (FTS5 + reranker).
 # Phase 3 adds vector/semantic matching in the background without blocking the agent.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DB_FILE=".cartog.db"
 LOCK_DIR="/tmp/cartog-rag-index.lock"
+REPO="jrollin/cartog"
+VERSION_CACHE="${HOME}/.cache/cartog/latest_version"
+VERSION_TTL=86400  # 24 hours
+
+# Phase 0: Check for newer cartog version (non-blocking)
+check_update() {
+    local installed
+    installed="$(cartog --version 2>/dev/null | sed -E 's/^cartog //')" || return 0
+    [ -n "$installed" ] || return 0
+
+    local latest=""
+    local now
+    now=$(date +%s)
+
+    if [ -f "$VERSION_CACHE" ]; then
+        local cached_version cached_ts
+        cached_version="$(cut -d' ' -f1 "$VERSION_CACHE" 2>/dev/null)" || true
+        cached_ts="$(cut -d' ' -f2 "$VERSION_CACHE" 2>/dev/null)" || true
+        if [ -n "$cached_ts" ] && [ $(( now - cached_ts )) -le "$VERSION_TTL" ]; then
+            latest="$cached_version"
+        fi
+    fi
+
+    if [ -z "$latest" ]; then
+        local tag
+        tag="$(curl -fsSL --max-time 5 "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+            | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')" || return 0
+        [ -n "$tag" ] || return 0
+        latest="$tag"
+        mkdir -p "$(dirname "$VERSION_CACHE")"
+        echo "$latest $now" > "$VERSION_CACHE"
+    fi
+
+    if version_gt "$latest" "$installed"; then
+        echo "New cartog version available: $latest (installed: $installed). Update with: bash $SCRIPT_DIR/install.sh $latest"
+    fi
+}
+
+version_gt() {
+    local IFS=.
+    local -a a b
+    read -ra a <<< "$1"
+    read -ra b <<< "$2"
+    local i
+    for ((i=0; i<${#a[@]}; i++)); do
+        local ai="${a[i]:-0}" bi="${b[i]:-0}"
+        if [ "$ai" -gt "$bi" ] 2>/dev/null; then return 0; fi
+        if [ "$ai" -lt "$bi" ] 2>/dev/null; then return 1; fi
+    done
+    return 1
+}
+
+check_update || true
 
 # Phase 1: Code graph index (always fast, incremental)
 if [ ! -f "$DB_FILE" ]; then

--- a/skills/cartog/scripts/install.sh
+++ b/skills/cartog/scripts/install.sh
@@ -8,10 +8,19 @@ set -euo pipefail
 REPO="jrollin/cartog"
 MIN_RUST_MAJOR=1
 MIN_RUST_MINOR=70
+REQUESTED_VERSION="${1:-}"
 
 if command -v cartog &>/dev/null; then
-    echo "cartog is already installed: $(cartog --version)"
-    exit 0
+    local_version="$(cartog --version | sed -E 's/^cartog //')"
+    if [ -z "$REQUESTED_VERSION" ]; then
+        echo "cartog is already installed: cartog $local_version"
+        exit 0
+    fi
+    if [ "$local_version" = "$REQUESTED_VERSION" ]; then
+        echo "cartog $REQUESTED_VERSION already installed."
+        exit 0
+    fi
+    echo "Upgrading cartog from $local_version to $REQUESTED_VERSION..."
 fi
 
 has_cmd() { command -v "$1" &>/dev/null; }
@@ -69,18 +78,22 @@ install_from_github() {
     fi
 
     local target="$1"
-    local latest_tag
+    local tag
 
-    latest_tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')"
-    if [ -z "$latest_tag" ]; then
-        return 1
+    if [ -n "$REQUESTED_VERSION" ]; then
+        tag="v${REQUESTED_VERSION}"
+    else
+        tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')"
+        if [ -z "$tag" ]; then
+            return 1
+        fi
     fi
 
-    local url="https://github.com/${REPO}/releases/download/${latest_tag}/cartog-${target}.tar.gz"
+    local url="https://github.com/${REPO}/releases/download/${tag}/cartog-${target}.tar.gz"
     local install_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
     mkdir -p "$install_dir"
 
-    echo "Downloading cartog ${latest_tag} for ${target}..."
+    echo "Downloading cartog ${tag} for ${target}..."
     if curl -fsSL "$url" | tar xz -C "$install_dir"; then
         chmod +x "${install_dir}/cartog"
         echo "cartog installed to ${install_dir}/cartog"
@@ -142,5 +155,9 @@ if ! check_rust_version; then
 fi
 
 echo "Installing cartog via cargo..."
-cargo install cartog
+if [ -n "$REQUESTED_VERSION" ]; then
+    cargo install "cartog@${REQUESTED_VERSION}"
+else
+    cargo install cartog
+fi
 verify_install

--- a/skills/cartog/tests/test_ensure_indexed.sh
+++ b/skills/cartog/tests/test_ensure_indexed.sh
@@ -86,8 +86,13 @@ assert_file_exists() {
 create_mock_cartog() {
     local exit_rag_setup="${1:-0}"
     local rag_setup_stderr="${2:-}"
+    local mock_version="${3:-0.6.1}"
     cat > "$TEST_DIR/bin/cartog" <<MOCK
 #!/usr/bin/env bash
+if [ "\$1" = "--version" ]; then
+    echo "cartog $mock_version"
+    exit 0
+fi
 echo "\$@" >> "$CARTOG_TEST_LOG"
 
 # Simulate different subcommands
@@ -106,12 +111,28 @@ MOCK
     chmod +x "$TEST_DIR/bin/cartog"
 }
 
-# Run ensure_indexed.sh with mocked cartog, in a temp workdir
+# Create a mock curl that returns a fake GitHub release response
+create_mock_curl() {
+    local latest_version="${1:-0.7.0}"
+    local exit_code="${2:-0}"
+    cat > "$TEST_DIR/bin/curl" <<MOCK
+#!/usr/bin/env bash
+if [ "$exit_code" -ne 0 ]; then
+    exit $exit_code
+fi
+echo '{ "tag_name": "v$latest_version" }'
+MOCK
+    chmod +x "$TEST_DIR/bin/curl"
+}
+
+# Run ensure_indexed.sh with mocked cartog and curl, in a temp workdir
 run_ensure_indexed() {
     local workdir="$TEST_DIR/workdir"
     mkdir -p "$workdir"
     (
         export PATH="$TEST_DIR/bin:$PATH"
+        export HOME="$TEST_DIR/home"
+        mkdir -p "$HOME"
         cd "$workdir"
         bash "$ENSURE_SCRIPT" 2>&1
     )
@@ -266,6 +287,8 @@ test_lock_cleaned_after_rag_index() {
 
 test_stale_lock_removed() {
     echo "TEST: stale lock (>1 hour) is removed and rag index proceeds"
+    # Wait for any background rag index from previous tests to finish and release lock
+    sleep 0.5
     setup
     create_mock_cartog
 
@@ -299,6 +322,101 @@ test_output_messages() {
     teardown
 }
 
+# --- version check tests ---
+
+test_no_cache_triggers_fetch() {
+    echo "TEST: no cache file triggers GitHub API fetch and creates cache"
+    setup
+    create_mock_cartog 0 "" "0.6.1"
+    create_mock_curl "0.7.0"
+
+    local output
+    output=$(run_ensure_indexed)
+
+    assert_contains "prints update notice" "New cartog version available: 0.7.0 (installed: 0.6.1)" "$output"
+    assert_file_exists "cache file created" "$TEST_DIR/home/.cache/cartog/latest_version"
+    teardown
+}
+
+test_fresh_cache_skips_fetch() {
+    echo "TEST: fresh cache (<24h) skips GitHub API fetch"
+    setup
+    create_mock_cartog 0 "" "0.6.1"
+    # Do NOT create mock curl — if curl is called, the test would fail or use real curl
+    # Instead, pre-populate cache and create a curl that would return a different version
+    create_mock_curl "0.9.0"
+    mkdir -p "$TEST_DIR/home/.cache/cartog"
+    echo "0.7.0 $(date +%s)" > "$TEST_DIR/home/.cache/cartog/latest_version"
+
+    local output
+    output=$(run_ensure_indexed)
+
+    # Should use cached 0.7.0, not the curl 0.9.0
+    assert_contains "uses cached version" "New cartog version available: 0.7.0 (installed: 0.6.1)" "$output"
+    teardown
+}
+
+test_stale_cache_triggers_fetch() {
+    echo "TEST: stale cache (>24h) triggers fresh GitHub API fetch"
+    setup
+    create_mock_cartog 0 "" "0.6.1"
+    create_mock_curl "0.8.0"
+    mkdir -p "$TEST_DIR/home/.cache/cartog"
+    local old_ts=$(( $(date +%s) - 90000 ))  # 25 hours ago
+    echo "0.7.0 $old_ts" > "$TEST_DIR/home/.cache/cartog/latest_version"
+
+    local output
+    output=$(run_ensure_indexed)
+
+    # Should fetch fresh and get 0.8.0 from mock curl
+    assert_contains "uses fetched version" "New cartog version available: 0.8.0 (installed: 0.6.1)" "$output"
+    teardown
+}
+
+test_same_version_no_notice() {
+    echo "TEST: same version prints no update notice"
+    setup
+    create_mock_cartog 0 "" "0.7.0"
+    create_mock_curl "0.7.0"
+
+    local output
+    output=$(run_ensure_indexed)
+
+    assert_not_contains "no update notice" "New cartog version available" "$output"
+    teardown
+}
+
+test_newer_installed_no_notice() {
+    echo "TEST: installed version newer than latest prints no notice"
+    setup
+    create_mock_cartog 0 "" "0.8.0"
+    create_mock_curl "0.7.0"
+
+    local output
+    output=$(run_ensure_indexed)
+
+    assert_not_contains "no update notice" "New cartog version available" "$output"
+    teardown
+}
+
+test_fetch_failure_continues() {
+    echo "TEST: GitHub API failure silently continues to indexing"
+    setup
+    create_mock_cartog 0 "" "0.6.1"
+    create_mock_curl "" 1
+
+    local output
+    output=$(run_ensure_indexed)
+    sleep 0.3
+
+    assert_not_contains "no update notice" "New cartog version available" "$output"
+    # Indexing should still proceed
+    local line1
+    line1=$(sed -n '1p' "$CARTOG_TEST_LOG")
+    assert_eq "indexing still runs" "index ." "$line1"
+    teardown
+}
+
 # --- run all tests ---
 
 echo "=== ensure_indexed.sh unit tests ==="
@@ -323,6 +441,18 @@ echo ""
 test_stale_lock_removed
 echo ""
 test_output_messages
+echo ""
+test_no_cache_triggers_fetch
+echo ""
+test_fresh_cache_skips_fetch
+echo ""
+test_stale_cache_triggers_fetch
+echo ""
+test_same_version_no_notice
+echo ""
+test_newer_installed_no_notice
+echo ""
+test_fetch_failure_continues
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/skills/cartog/tests/test_install.sh
+++ b/skills/cartog/tests/test_install.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit tests for install.sh
+# Uses mocked cartog, curl, and cargo to verify install behavior.
+#
+# Usage: bash skills/cartog/tests/test_install.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$SKILL_DIR/scripts/install.sh"
+
+PASS=0
+FAIL=0
+TEST_DIR=""
+
+# --- helpers ---
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    mkdir -p "$TEST_DIR/bin"
+}
+
+teardown() {
+    [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected to contain: $needle"
+        echo "    actual: $haystack"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "  FAIL: $label"
+        echo "    expected NOT to contain: $needle"
+        echo "    actual: $haystack"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+create_mock_cartog() {
+    local version="${1:-0.6.1}"
+    cat > "$TEST_DIR/bin/cartog" <<MOCK
+#!/usr/bin/env bash
+echo "cartog $version"
+MOCK
+    chmod +x "$TEST_DIR/bin/cartog"
+}
+
+create_mock_curl() {
+    local log_file="$TEST_DIR/curl.log"
+    cat > "$TEST_DIR/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> LOGFILE
+echo '{ "tag_name": "v0.9.0" }'
+MOCK
+    sed -i'' -e "s|LOGFILE|$log_file|" "$TEST_DIR/bin/curl"
+    chmod +x "$TEST_DIR/bin/curl"
+}
+
+create_mock_tar() {
+    cat > "$TEST_DIR/bin/tar" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+    chmod +x "$TEST_DIR/bin/tar"
+}
+
+create_mock_cargo() {
+    local log_file="$TEST_DIR/cargo.log"
+    cat > "$TEST_DIR/bin/cargo" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> LOGFILE
+exit 0
+MOCK
+    sed -i'' -e "s|LOGFILE|$log_file|" "$TEST_DIR/bin/cargo"
+    chmod +x "$TEST_DIR/bin/cargo"
+}
+
+run_install() {
+    (
+        # Use restricted PATH: test bin + essential system dirs only
+        export PATH="$TEST_DIR/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        export CARGO_HOME="$TEST_DIR/cargo_home"
+        mkdir -p "$CARGO_HOME/bin"
+        bash "$INSTALL_SCRIPT" "$@" 2>&1
+    )
+}
+
+# --- tests ---
+
+test_no_arg_already_installed_exits_early() {
+    echo "TEST: no arg + already installed → exits early"
+    setup
+    create_mock_cartog "0.6.1"
+
+    local output exit_code=0
+    output=$(run_install) || exit_code=$?
+
+    assert_eq "exits 0" "0" "$exit_code"
+    assert_contains "shows already installed" "already installed" "$output"
+    teardown
+}
+
+test_version_arg_same_version_exits_early() {
+    echo "TEST: version arg + same version → exits early"
+    setup
+    create_mock_cartog "0.7.0"
+
+    local output exit_code=0
+    output=$(run_install "0.7.0") || exit_code=$?
+
+    assert_eq "exits 0" "0" "$exit_code"
+    assert_contains "shows already at version" "0.7.0 already installed" "$output"
+    teardown
+}
+
+test_version_arg_different_version_reinstalls() {
+    echo "TEST: version arg + different version → reinstalls"
+    setup
+    create_mock_cartog "0.6.1"
+    create_mock_curl
+    create_mock_tar
+
+    local output exit_code=0
+    output=$(run_install "0.7.0") || exit_code=$?
+
+    assert_contains "shows upgrading" "Upgrading cartog from 0.6.1 to 0.7.0" "$output"
+    teardown
+}
+
+test_version_arg_uses_tag_url() {
+    echo "TEST: version arg → uses v{version} tag URL (not /releases/latest)"
+    setup
+    create_mock_cartog "0.6.1"
+    create_mock_curl
+    create_mock_tar
+
+    run_install "0.7.0" > /dev/null 2>&1 || true
+
+    local curl_log="$TEST_DIR/curl.log"
+    if [ -f "$curl_log" ]; then
+        local curl_args
+        curl_args=$(cat "$curl_log")
+        assert_not_contains "does not query /releases/latest" "releases/latest" "$curl_args"
+        assert_contains "uses v0.7.0 tag in URL" "v0.7.0" "$curl_args"
+    else
+        echo "  PASS: curl not called for API (direct tag URL used)"
+        PASS=$((PASS + 1))
+        # Verify the download URL would have the tag — check output
+    fi
+    teardown
+}
+
+test_no_arg_not_installed_installs_latest() {
+    echo "TEST: no arg + not installed → installs latest"
+    setup
+    # No mock cartog — simulates not installed
+    create_mock_curl
+    create_mock_tar
+
+    local output exit_code=0
+    output=$(run_install) || exit_code=$?
+
+    assert_contains "downloads from github" "Downloading cartog" "$output"
+    teardown
+}
+
+test_cargo_fallback_with_version() {
+    echo "TEST: version arg + no binary available → cargo install cartog@version"
+    setup
+    # Mock cartog at different version to trigger upgrade path
+    create_mock_cartog "0.6.1"
+    # curl that fails (no pre-built binary)
+    cat > "$TEST_DIR/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/curl"
+    create_mock_cargo
+    # Mock rustc for version check
+    cat > "$TEST_DIR/bin/rustc" <<'MOCK'
+#!/usr/bin/env bash
+echo "rustc 1.77.0 (aedd173a2 2024-03-17)"
+MOCK
+    chmod +x "$TEST_DIR/bin/rustc"
+
+    run_install "0.7.0" > /dev/null 2>&1 || true
+
+    local cargo_log="$TEST_DIR/cargo.log"
+    if [ -f "$cargo_log" ]; then
+        local cargo_args
+        cargo_args=$(cat "$cargo_log")
+        assert_contains "cargo install with version" "cartog@0.7.0" "$cargo_args"
+    else
+        echo "  FAIL: cargo was not called"
+        FAIL=$((FAIL + 1))
+    fi
+    teardown
+}
+
+test_no_curl_no_cargo_fails() {
+    echo "TEST: no curl + no cargo → error and exit 1"
+    setup
+    # Shadow curl and tar with failing stubs so download path fails,
+    # and no cargo mock so the fallback also fails
+    cat > "$TEST_DIR/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/curl"
+
+    local output exit_code=0
+    output=$(run_install) || exit_code=$?
+
+    assert_eq "exits 1" "1" "$exit_code"
+    assert_contains "shows error" "cargo not found" "$output"
+    teardown
+}
+
+test_rust_version_too_old_fails() {
+    echo "TEST: Rust version too old → error and exit 1"
+    setup
+    # curl that fails (no pre-built binary)
+    cat > "$TEST_DIR/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/curl"
+    # cargo present but rustc too old
+    create_mock_cargo
+    cat > "$TEST_DIR/bin/rustc" <<'MOCK'
+#!/usr/bin/env bash
+echo "rustc 1.50.0 (cb75ad5db 2021-02-10)"
+MOCK
+    chmod +x "$TEST_DIR/bin/rustc"
+
+    local output exit_code=0
+    output=$(run_install) || exit_code=$?
+
+    assert_eq "exits 1" "1" "$exit_code"
+    assert_contains "shows rust too old" "Rust toolchain too old" "$output"
+    teardown
+}
+
+# --- run all tests ---
+
+echo "=== install.sh unit tests ==="
+echo ""
+
+test_no_arg_already_installed_exits_early
+echo ""
+test_version_arg_same_version_exits_early
+echo ""
+test_version_arg_different_version_reinstalls
+echo ""
+test_version_arg_uses_tag_url
+echo ""
+test_no_arg_not_installed_installs_latest
+echo ""
+test_cargo_fallback_with_version
+echo ""
+test_no_curl_no_cargo_fails
+echo ""
+test_rust_version_too_old_fails
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,7 +18,7 @@ fn open_db() -> Result<Database> {
 /// Estimate token count from a string using chars/4 approximation.
 #[cfg(test)]
 fn estimate_tokens(s: &str) -> u32 {
-    (s.len() as u32 + 3) / 4
+    (s.len() as u32).div_ceil(4)
 }
 
 /// Truncate a string to fit within a token budget, appending a truncation notice.


### PR DESCRIPTION
## Summary

- **ensure_indexed.sh**: new Phase 0 checks for newer cartog releases via cached GitHub API call (24h TTL), prints non-blocking update notice with actionable install command. Silent on network failure.
- **install.sh**: accepts optional version argument (`bash scripts/install.sh 0.7.0`) to install a specific release. Uses direct tag URL, cargo fallback supports versioned install.
- **SKILL.md**: documents update notice behavior and instructs agent to ask user before upgrading.

## Test plan

- [x] 25 ensure_indexed.sh tests pass (6 new version check tests)
- [x] 13 install.sh tests pass (new test file)
- [x] `make check-skill` green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [ ] Manual: verify update notice on a machine with an older cartog version
- [ ] Manual: verify `bash scripts/install.sh <version>` upgrades correctly