### PR TITLE
feat(lsp): add LSP-based edge resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check
+      - run: cargo check --features lsp
 
   fmt:
     name: Format
@@ -40,6 +41,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets --features lsp -- -D warnings
 
   test:
     name: Test
@@ -49,6 +51,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
+      - run: cargo test --features lsp
 
   coverage:
     name: Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "url",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,13 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
 sqlite-vec = "0.1"
 
+# LSP-based edge resolution (opt-in)
+url = { version = "2", optional = true }
+
+[features]
+default = []
+lsp = ["url"]
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Measured across 13 scenarios, 5 languages ([full benchmark suite](benchmarks/)).
 
 ### What you get immediately
 
-- **Single binary, self-contained** — `cargo install cartog` and you're done. No language server, no Docker, no config.
+- **Single binary, self-contained** — `cargo install cartog` and you're done. No Docker, no config.
 - **100% offline** — tree-sitter parsing + SQLite storage + ONNX embeddings. Your code never leaves your machine, ever.
+- **Optional LSP precision** — auto-detects language servers on PATH to boost edge resolution from ~25% to ~42-81%. Works without them, better with them.
 - **Smart search routing** — keyword search (sub-ms, symbol names) and semantic search (natural language queries) work together. Run both in parallel when unsure.
 - **Live index** — `cartog watch` auto re-indexes on file changes. Your agent always queries fresh data.
 - **MCP server** — `cartog serve` exposes 12 tools over stdio. Plug into Claude Code, Cursor, Windsurf, Zed, or any MCP-compatible agent.
@@ -61,8 +62,11 @@ Models are downloaded once to `~/.cache/cartog/models/` and run locally via ONNX
 ### From crates.io
 
 ```bash
-cargo install cartog
+cargo install cartog                    # core (heuristic resolution only)
+cargo install cartog --features lsp     # + LSP-based resolution (recommended)
 ```
+
+The `lsp` feature adds ~50KB to the binary. It auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph) and uses them to resolve edges that heuristic matching can't. No extra config needed — if a server is on PATH, it's used automatically.
 
 ### Pre-built binaries
 
@@ -117,7 +121,8 @@ cartog search auth & cartog rag search "authentication and authorization"
 
 ```bash
 # Index
-cartog index .                              # Build the graph (incremental)
+cartog index .                              # Build the graph (with LSP if available)
+cartog index . --no-lsp                     # Fast heuristic-only (~1-4s)
 cartog index . --force                      # Re-index all files
 
 # Search
@@ -211,9 +216,10 @@ graph LR
 
 1. **Index** — walks your project, parses each file with tree-sitter, extracts symbols (functions, classes, methods, imports, variables) and edges (calls, imports, inherits, raises, type references)
 2. **Store** — writes everything to a local `.cartog.db` SQLite file
-3. **Resolve** — links edges by name with scope-aware heuristic matching (same file > same directory > unique project match)
-4. **Embed** (optional) — generates vector embeddings locally with ONNX Runtime (`BAAI/bge-small-en-v1.5`), stored in sqlite-vec
-5. **Query** — instant lookups against the pre-computed graph, hybrid FTS5 + vector search with RRF merge and cross-encoder re-ranking
+3. **Resolve (heuristic)** — links edges by name with scope-aware matching (same file > import path > same directory > unique project match)
+4. **Resolve (LSP, optional)** — for edges the heuristic couldn't resolve, sends `textDocument/definition` to language servers for compiler-grade precision. Results persist in the DB.
+5. **Embed** (optional) — generates vector embeddings locally with ONNX Runtime (`BAAI/bge-small-en-v1.5`), stored in sqlite-vec
+6. **Query** — instant lookups against the pre-computed graph, hybrid FTS5 + vector search with RRF merge and cross-encoder re-ranking
 
 Re-indexing is incremental: only files with changed content hashes are re-parsed. `cartog watch` automates this on file changes.
 
@@ -309,10 +315,25 @@ Query latency (criterion benchmarks on the same fixture):
 | refs | 258-471 us |
 | impact (depth 3) | 2.7-17 ms |
 
+## Edge Resolution: Heuristic vs LSP
+
+cartog uses a two-tier resolution strategy. The heuristic pass runs instantly; LSP is optional and adds precision.
+
+| Project type | Language | Heuristic only | With LSP | Time (LSP) |
+|---------|----------|---------------|----------|------------|
+| TS microservice (230 files) | TypeScript | 37% | **81%** | 13s |
+| Vue.js SPA (739 files) | Vue/TS/JS | 31% | **72%** | 25s |
+| Rust CLI (358 files) | Rust | 25% | **44%** | 72s |
+
+Remaining unresolved edges are mostly calls to external libraries (std, node_modules, crates) — definitions outside the project boundary.
+
+**When to use LSP**: before a major refactoring, when `refs` or `impact` seem incomplete.
+**When to skip** (`--no-lsp`): day-to-day exploration, post-change verification, watch mode.
+
 ## Design Trade-offs
 
-- **Structural, not semantic** — name-based resolution (~90% accuracy), not full type analysis. Good enough for navigation; LSP can be layered on later.
-- **Self-contained** — single binary, all dependencies compiled in. No language server, no cloud service, no separate database process.
+- **Two-tier resolution** — fast heuristic pass (~1s) for daily use, optional LSP for precision refactoring. Results persist in SQLite — pay the LSP cost once.
+- **Self-contained** — single binary, all dependencies compiled in. LSP is opt-in via language servers already on your PATH.
 - **Incremental** — SHA256 hash per file, only re-indexes what changed.
 - **Local-first** — embedding models run via ONNX Runtime on your CPU. Slower than API calls, but your code stays private.
 

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -23,7 +23,7 @@ fn setup_db() -> Database {
         .join("webapp_py");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true).expect("index fixture");
+    index_directory(&db, &fixture_dir, true, false).expect("index fixture");
     db
 }
 
@@ -145,7 +145,7 @@ fn setup_java_db() -> Database {
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true).expect("index Java fixture");
+    index_directory(&db, &fixture_dir, true, false).expect("index Java fixture");
     db
 }
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -39,6 +39,11 @@ cartog/
 │   │   ├── ruby.rs          # Ruby extractor
 │   │   ├── java.rs          # Java extractor
 │   │   └── queries.rs       # Tree-sitter query API helpers (CachedQuery, scope checking)
+│   ├── lsp/                 # Optional LSP-based edge resolution (feature-gated)
+│   │   ├── mod.rs           # Public API: lsp_resolve_edges(), column detection
+│   │   ├── client.rs        # JSON-RPC over stdio (Content-Length framing)
+│   │   ├── manager.rs       # LspManager: spawn, initialize, definition, shutdown
+│   │   └── servers.rs       # Static registry: language → binary + args + languageId
 │   ├── rag/
 │   │   ├── mod.rs           # RAG module root, constants (EMBEDDING_DIM)
 │   │   ├── setup.rs         # Model download (triggers fastembed auto-download)
@@ -112,6 +117,7 @@ cartog/
 - **commands.rs**: Command handlers for all CLI commands including `rag setup/index/search` and `watch`. Formats output (human-readable or `--json`).
 - **mcp.rs**: MCP server over stdio. `CartogServer` struct with 12 `#[tool]` handlers (10 core + 2 RAG). Path validation restricts `index` to CWD subtree. Uses `spawn_blocking` for sync DB/indexer calls. Optionally spawns a background file watcher (`--watch` flag).
 - **watch.rs**: File watcher using `notify-debouncer-mini`. Debounces filesystem events, triggers incremental `index_directory()`. Optionally defers RAG embedding after a configurable delay. Used standalone (`cartog watch`) or embedded in MCP server (`cartog serve --watch`). See [spec-watch.md](spec-watch.md) for design details.
+- **lsp/mod.rs**: (Feature-gated: `lsp`) Resolves edges left unresolved by heuristics using LSP `textDocument/definition`. Spawns language servers at index time, maps responses back to cartog symbol IDs, shuts down after. Gracefully skips when no servers are available.
 - **languages/mod.rs**: Maps file extensions to extractors, defines the `Extractor` trait and shared `node_text` helper. Each extractor implements `fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult>`.
 - **languages/queries.rs**: Tree-sitter query API helpers. `CachedQuery` wraps compiled queries for reuse across files. `is_inside_nested_scope` checks if a match node is inside a nested function/class scope (used by JS/TS and Python extractors to avoid double-counting calls). Replaces manual `TreeCursor` walks with declarative query patterns for call/throw/type-ref extraction.
 - **rag/mod.rs**: RAG pipeline constants (`EMBEDDING_DIM = 384`), shared model cache directory (`model_cache_dir()` — XDG-compliant, avoids per-project model downloads), and `is_embedding_model_cached()` / `is_reranker_model_cached()` helpers for cache detection (mirrors hf-hub's `CacheRepo::get()` logic).

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -57,7 +57,7 @@
 | Model cache | `~/.cache/cartog/models` | XDG-compliant shared cache avoids downloading ~1.2 GB of models per project. Precedence: `FASTEMBED_CACHE_DIR` > `XDG_CACHE_HOME/cartog/models` > `~/.cache/cartog/models` |
 | Output format | Human default + `--json` flag (global) | Readable for humans, parseable for scripts. Both `cartog --json stats` and `cartog stats --json` work |
 | Distribution | `cargo install` + pre-built binaries | GitHub Releases for 5 targets (Linux x86/ARM, macOS x86/ARM, Windows), crates.io publish |
-| LSP | Deferred | Tree-sitter handles 90% of name resolution. LSP can be added as optional precision layer later |
+| LSP | Auto-detected (`lsp` feature) | Index-time refinement for edges unresolved by heuristics. Auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls), sends `textDocument/definition`, shuts down after. Silently skips when no server found. Disable with `--no-lsp`. Install: `cargo install cartog --features lsp` |
 | Monorepo | Deferred | Index from CWD, user can `cd` into subproject |
 
 ## RAG Pipeline Design

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -73,7 +73,7 @@ cartog pre-computes a code graph (symbols + edges) with tree-sitter and stores i
 
 6. **Only fall back to grep/read** when cartog doesn't have what you need (e.g., reading actual implementation logic, string literals, config values).
 
-7. **After making code changes**, run `cartog index .` to update the graph.
+7. **After making code changes**, run `cartog index . --no-lsp` to quickly update the graph.
 
 ## Do / Don't
 
@@ -131,10 +131,13 @@ transparently once background embedding completes.
 
 ### Index (build/rebuild)
 ```bash
-cartog index .                    # Index current directory
+cartog index .                    # Index current directory (with LSP if available)
+cartog index . --no-lsp           # Fast heuristic-only index (~1-4s)
 cartog index src/                 # Index specific directory
 cartog index . --force            # Re-index all files (ignore cache)
 ```
+
+When compiled with `--features lsp`, `cartog index .` auto-detects language servers on PATH and uses them to resolve additional edges. LSP results are **persisted in the database** — subsequent queries benefit without re-running LSP. Use `--no-lsp` for fast day-to-day indexing.
 
 ### Search (find symbols by partial name)
 ```bash
@@ -219,12 +222,16 @@ cartog watch . --rag                     # also re-embed symbols (deferred)
 cartog watch . --debounce 3 --rag-delay 30  # custom timings
 ```
 
+Watch always uses heuristic-only indexing (no LSP) for speed. Previously LSP-resolved edges are preserved in the DB.
+
 ### Serve (MCP server)
 ```bash
 cartog serve                    # MCP server over stdio
 cartog serve --watch            # with background file watcher
 cartog serve --watch --rag      # watcher + deferred RAG embedding
 ```
+
+When an agent calls `cartog_index` via MCP, LSP servers are started once and **kept warm** for the session. Subsequent index calls reuse warm servers (~2s instead of 60s). Background watch re-indexing stays heuristic-only.
 
 ## Token Budget
 
@@ -248,13 +255,36 @@ cartog --json rag search "authentication"
 
 Before changing any symbol (rename, extract, move, delete):
 
+### Phase 1: Narrow with heuristic graph (~1s)
+
 1. **Identify** — `cartog search <name>` to confirm the exact symbol name and file
 2. **Map references** — `cartog refs <name>` to find every usage
 3. **Assess blast radius** — `cartog impact <name> --depth 3` for transitive dependents
 4. **Check hierarchy** — `cartog hierarchy <name>` if it's a class (subclasses need updating too)
+
+### Phase 2: Upgrade to LSP if needed (~15-60s first call)
+
+Upgrade to LSP when the heuristic graph has gaps:
+- `refs` returns **fewer results than expected** (you know more callers exist)
+- **Ambiguous symbol** — two classes have the same method name, `impact` can't tell which is called
+- `--json` output shows `target_id: null` on edges you care about
+
+```bash
+cartog index .                   # re-index with LSP auto-detected (if compiled with lsp feature)
+cartog impact <name> --depth 3   # re-check — more edges resolved
+```
+
+If no LSP servers are on PATH, indexing silently falls back to heuristic-only.
+Use `--no-lsp` to skip LSP when you want speed over precision.
+
+> **Performance tip**: each `cartog index .` via Bash spawns LSP servers from scratch (~15-60s).
+> If you plan multiple index calls in a session (refactoring loop), use `cartog serve` as an MCP server instead — it keeps LSP servers warm across calls, making the 2nd+ index near-instant.
+
+### Phase 3: Apply and verify
+
 5. **Plan change order** — update leaf dependents first, work inward toward the source
 6. **Apply changes** — modify files
-7. **Re-index** — `cartog index .` to update the graph
+7. **Re-index** — `cartog index . --no-lsp` to quickly update the graph
 8. **Verify** — re-run `cartog refs <name>` to confirm no stale references remain
 
 ## Decision Heuristics
@@ -271,16 +301,27 @@ Before changing any symbol (rename, extract, move, delete):
 | See file dependencies | `cartog deps <file>` |
 | Get a codebase overview | `cartog map` (`--tokens N` for budget control) |
 | See what changed recently | `cartog changes` (`--commits N` for more history) |
+| Improve graph precision for a refactoring | `cartog index .` (with LSP auto-detected) |
+| Fast re-index after code changes | `cartog index . --no-lsp` |
 | Read actual implementation logic | `cat <file>` (cartog indexes structure, not content) |
 | Search for string literals / config | `grep` (cartog doesn't index these) |
 | Nothing from search or rag | Fall back to `grep` |
 
 ## Limitations
 
-- Structural/heuristic resolution, not full semantic. ~90% accuracy for cross-file references.
+- Heuristic resolution is name-based (~25% of edges resolved). With LSP enabled, ~42-81% resolved depending on language. Remaining unresolved edges are mostly calls to external libraries.
 - Currently supports: Python, TypeScript/JavaScript, Rust, Go, Ruby, Java.
 - Does not index string literals, comments (except docstrings), or config values.
-- Method resolution is name-based — `foo.bar()` resolves `bar`, not `Foo.bar` specifically.
+- Method resolution is name-based without LSP — `foo.bar()` resolves `bar`, not `Foo.bar` specifically. LSP resolves to the exact type when a language server is available.
+
+### LSP limitations
+
+- **Opt-in feature**: requires `cargo install cartog --features lsp`. Without the feature, `--no-lsp` is implied.
+- **Auto-detected**: if language servers are on PATH, they are used automatically during `cartog index`. Use `--no-lsp` to skip.
+- **Startup latency**: language servers take 15-60s to load a project on first call. Day-to-day indexing should use `--no-lsp`.
+- **CLI vs MCP**: each `cartog index .` via Bash spawns and kills LSP servers (cold start). Use `cartog serve` (MCP mode) for sessions with multiple index calls — it keeps servers warm across tool calls.
+- **Supported servers**: rust-analyzer, pyright-langserver, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls. Install hints shown when servers are missing.
+- **External crate edges stay unresolved**: LSP resolves definitions within the project. Calls to std/external crates remain unresolved regardless.
 
 ### RAG search limitations
 

--- a/skills/cartog/references/query_cookbook.md
+++ b/skills/cartog/references/query_cookbook.md
@@ -82,12 +82,34 @@ cartog callees authenticate            # What does authenticate call?
 cartog callees validate_token          # Keep going deeper
 ```
 
-### Assess refactoring scope
+### Assess refactoring scope (narrow first, LSP if needed)
+
+**Step 1 — Fast heuristic pass (~1s):**
 ```bash
 cartog search OldClassName             # Confirm exact name and file first
 cartog refs OldClassName               # All references
 cartog hierarchy OldClassName          # Subclasses to update
 cartog impact OldClassName --depth 5   # Full blast radius
+```
+
+If results look complete → proceed with refactoring.
+
+**Step 2 — Upgrade to LSP if gaps found (~15-60s):**
+
+Signs you need LSP:
+- `refs` shows fewer callers than expected
+- Two classes share the same method name and `impact` can't disambiguate
+- `--json` output has `target_id: null` on edges you care about
+
+```bash
+cartog index .                         # Re-index with LSP (auto-detected if on PATH)
+cartog impact OldClassName --depth 5   # Re-check with higher-precision graph
+```
+
+**Step 3 — After refactoring:**
+```bash
+cartog index . --no-lsp                # Fast re-index to update the graph
+cartog refs OldClassName               # Verify no stale references remain
 ```
 
 ### Anti-patterns to avoid

--- a/skills/cartog/tests/golden_examples.yaml
+++ b/skills/cartog/tests/golden_examples.yaml
@@ -101,6 +101,42 @@
     - Skipping impact analysis entirely
   tags: [routing, refactoring]
 
+- id: refactoring_lsp_escalation
+  description: When heuristic refs seem incomplete, escalate to LSP before refactoring
+  user_query: "I want to rename validate in AuthService but refs only shows 2 callers, I know there are more"
+  context: "cartog refs validate --kind calls already returned only 2 results"
+  expected:
+    tool_calls:
+      - "cartog index ."
+      - "cartog refs validate --kind calls"
+    reasoning: >
+      The user reports that heuristic refs are incomplete. The agent should
+      re-index with LSP (auto-detected) to improve edge resolution, then
+      re-run refs to see the fuller picture. Do NOT skip straight to refactoring
+      with incomplete information.
+  anti_patterns:
+    - Proceeding with refactoring without re-indexing
+    - Using cartog index . --no-lsp (defeats the purpose of LSP escalation)
+    - Using only grep to find additional callers
+  tags: [refactoring, lsp]
+
+- id: refactoring_fast_reindex_after_changes
+  description: After applying code changes, re-index fast with --no-lsp
+  user_query: "I've finished renaming the method, verify nothing is broken"
+  context: "User just applied rename changes across multiple files"
+  expected:
+    tool_calls:
+      - "cartog index . --no-lsp"
+      - "cartog refs old_method_name"
+    reasoning: >
+      After code changes, re-index quickly with --no-lsp (heuristic only, ~1s)
+      to update the graph, then verify no stale references remain. LSP is not
+      needed here — speed matters for the verify loop.
+  anti_patterns:
+    - Re-indexing with LSP (unnecessary latency for verification)
+    - Skipping re-index entirely
+  tags: [refactoring, lsp]
+
 - id: no_parallel_double_call
   description: Single rag search call, not multiple parallel searches
   user_query: "Find code related to contract management and timesheet signing"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,10 @@ pub enum Command {
         /// Force full re-index, bypassing change detection
         #[arg(long)]
         force: bool,
+
+        /// Disable LSP-based edge resolution (auto-detected by default when servers are on PATH)
+        #[arg(long)]
+        no_lsp: bool,
     },
 
     /// Show symbols and structure of a file

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -61,21 +61,30 @@ fn output<T: Serialize>(
 }
 
 /// Build or rebuild the code graph index.
-pub fn cmd_index(path: &str, force: bool, json: bool) -> Result<()> {
+pub fn cmd_index(path: &str, force: bool, lsp: bool, json: bool) -> Result<()> {
     let root = Path::new(path);
     let db = open_db()?;
 
-    let result = indexer::index_directory(&db, root, force)?;
+    let result = indexer::index_directory(&db, root, force, lsp)?;
 
     output(&result, json, None, |r| {
+        let lsp_part = if r.edges_lsp_resolved > 0 {
+            format!(
+                " ({} heuristic + {} LSP)",
+                r.edges_resolved, r.edges_lsp_resolved
+            )
+        } else {
+            String::new()
+        };
         format!(
-            "Indexed {} files ({} skipped, {} removed)\n  {} symbols, {} edges ({} resolved)\n",
+            "Indexed {} files ({} skipped, {} removed)\n  {} symbols, {} edges ({} resolved{})\n",
             r.files_indexed,
             r.files_skipped,
             r.files_removed,
             r.symbols_added,
             r.edges_added,
-            r.edges_resolved
+            r.edges_resolved + r.edges_lsp_resolved,
+            lsp_part,
         )
     })
 }
@@ -527,7 +536,7 @@ pub fn cmd_rag_index(path: &str, force: bool, json: bool) -> Result<()> {
     // First ensure the standard code graph index is up to date
     let root = Path::new(path);
     let db = open_db()?;
-    let _index_result = indexer::index_directory(&db, root, false)?;
+    let _index_result = indexer::index_directory(&db, root, false, false)?;
 
     let result = rag::indexer::index_embeddings(&db, force)?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1377,6 +1377,57 @@ impl Database {
         self.conn.execute("DELETE FROM symbol_embedding_map", [])?;
         Ok(())
     }
+
+    // ── LSP Resolution Helpers ──
+
+    /// Return all edges with `target_id IS NULL` (unresolved after heuristic pass).
+    #[cfg(feature = "lsp")]
+    pub fn unresolved_edges(&self) -> Result<Vec<crate::lsp::UnresolvedEdge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT e.id, e.target_name, e.file_path, e.line
+             FROM edges e
+             WHERE e.target_id IS NULL",
+        )?;
+
+        let rows = stmt.query_map([], |row| {
+            Ok(crate::lsp::UnresolvedEdge {
+                edge_id: row.get(0)?,
+                target_name: row.get(1)?,
+                file_path: row.get(2)?,
+                line: row.get(3)?,
+            })
+        })?;
+
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Find the tightest-enclosing symbol at a given file + line.
+    #[cfg(feature = "lsp")]
+    pub fn find_symbol_at_location(&self, file_path: &str, line: u32) -> Result<Option<String>> {
+        let id: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT id FROM symbols
+                 WHERE file_path = ?1 AND start_line <= ?2 AND end_line >= ?2
+                 ORDER BY (end_line - start_line) ASC
+                 LIMIT 1",
+                params![file_path, line],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(id)
+    }
+
+    /// Update a single edge's target_id.
+    #[cfg(feature = "lsp")]
+    pub fn update_edge_target(&self, edge_id: i64, target_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE edges SET target_id = ?1 WHERE id = ?2",
+            params![target_id, edge_id],
+        )?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -19,6 +19,12 @@ pub struct IndexResult {
     pub symbols_added: u32,
     pub edges_added: u32,
     pub edges_resolved: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub edges_lsp_resolved: u32,
+}
+
+fn is_zero(v: &u32) -> bool {
+    *v == 0
 }
 
 /// Index a directory, updating the database incrementally.
@@ -27,7 +33,7 @@ pub struct IndexResult {
 /// 1. `force = true` → re-index everything, no checks
 /// 2. Git-based → diff `last_commit..HEAD` to find changed files, skip the rest without reading
 /// 3. SHA-256 fallback → read file, hash it, compare to stored hash
-pub fn index_directory(db: &Database, root: &Path, force: bool) -> Result<IndexResult> {
+pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Result<IndexResult> {
     let mut result = IndexResult::default();
 
     let root = root.canonicalize().context("Failed to resolve root path")?;
@@ -178,6 +184,15 @@ pub fn index_directory(db: &Database, root: &Path, force: bool) -> Result<IndexR
 
     // Resolve edges
     result.edges_resolved = db.resolve_edges()?;
+
+    // LSP-based resolution for edges the heuristic couldn't resolve.
+    // Auto-detected when `lsp` feature is compiled in; silently skipped otherwise.
+    #[cfg(feature = "lsp")]
+    if lsp {
+        result.edges_lsp_resolved = crate::lsp::lsp_resolve_edges(db, &root, None)?;
+    }
+    #[cfg(not(feature = "lsp"))]
+    let _ = lsp; // suppress unused warning when feature is off
 
     // Compute in-degree centrality for all symbols
     db.compute_in_degrees()?;
@@ -539,16 +554,16 @@ mod tests {
 
         if fixtures.exists() {
             // First index
-            let r1 = index_directory(&db, &fixtures, false).unwrap();
+            let r1 = index_directory(&db, &fixtures, false, false).unwrap();
             assert!(r1.files_indexed > 0);
 
             // Second index without force — should skip all files
-            let r2 = index_directory(&db, &fixtures, false).unwrap();
+            let r2 = index_directory(&db, &fixtures, false, false).unwrap();
             assert_eq!(r2.files_indexed, 0);
             assert!(r2.files_skipped > 0);
 
             // Force re-index — should re-index all files
-            let r3 = index_directory(&db, &fixtures, true).unwrap();
+            let r3 = index_directory(&db, &fixtures, true, false).unwrap();
             assert_eq!(r3.files_indexed, r1.files_indexed);
             assert_eq!(r3.files_skipped, 0);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod db;
 pub mod indexer;
 pub mod languages;
+#[cfg(feature = "lsp")]
+pub mod lsp;
 pub mod rag;
 pub mod types;
 pub mod watch;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1,0 +1,310 @@
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+use serde_json::Value;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Minimal synchronous LSP client over stdio pipes.
+///
+/// Uses a background reader thread to avoid blocking on IO when waiting
+/// for progress notifications during server initialization.
+///
+/// Handles server-initiated requests (e.g., `window/workDoneProgress/create`)
+/// by auto-responding with `null` result, as required by the LSP spec.
+pub struct LspClient {
+    pub child: Child,
+    stdin: ChildStdin,
+    receiver: mpsc::Receiver<Value>,
+    _reader_handle: JoinHandle<()>,
+    next_id: i64,
+    timeout: Duration,
+    /// Notifications buffered during `read_response` for later consumption by `recv_until`.
+    buffered_notifications: VecDeque<Value>,
+}
+
+impl LspClient {
+    pub fn new(mut child: Child) -> Result<Self> {
+        let stdin = child.stdin.take().context("no stdin on child process")?;
+        let stdout = child.stdout.take().context("no stdout on child process")?;
+
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || reader_thread(stdout, tx));
+
+        Ok(Self {
+            child,
+            stdin,
+            receiver: rx,
+            _reader_handle: handle,
+            next_id: 1,
+            timeout: DEFAULT_TIMEOUT,
+            buffered_notifications: VecDeque::new(),
+        })
+    }
+
+    /// Send a JSON-RPC request and wait for the matching response.
+    pub fn send_request<P: Serialize>(&mut self, method: &str, params: P) -> Result<Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        self.write_message(&msg)?;
+        self.read_response(id)
+    }
+
+    /// Send a JSON-RPC notification (no response expected).
+    pub fn send_notification<P: Serialize>(&mut self, method: &str, params: P) -> Result<()> {
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        self.write_message(&msg)
+    }
+
+    /// Check if the child process is still alive.
+    pub fn is_alive(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    /// Receive messages until deadline, passing each to a callback.
+    /// Returns when the callback returns `true` (done) or deadline is reached.
+    /// Drains buffered notifications first (from prior `read_response` calls).
+    pub fn recv_until(
+        &mut self,
+        deadline: Instant,
+        mut on_message: impl FnMut(&Value) -> bool,
+    ) -> bool {
+        // Drain notifications buffered during read_response
+        while let Some(msg) = self.buffered_notifications.pop_front() {
+            if on_message(&msg) {
+                return true;
+            }
+        }
+
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+
+            match self
+                .receiver
+                .recv_timeout(remaining.min(Duration::from_millis(500)))
+            {
+                Ok(msg) => {
+                    // Auto-respond to server-initiated requests
+                    if is_server_request(&msg) {
+                        let _ = self.auto_respond(&msg);
+                        continue;
+                    }
+                    if on_message(&msg) {
+                        return true;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => return false,
+            }
+        }
+    }
+
+    fn write_message(&mut self, msg: &Value) -> Result<()> {
+        let body = serde_json::to_string(msg)?;
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+        self.stdin.write_all(header.as_bytes())?;
+        self.stdin.write_all(body.as_bytes())?;
+        self.stdin.flush()?;
+        Ok(())
+    }
+
+    fn read_response(&mut self, expected_id: i64) -> Result<Value> {
+        let deadline = Instant::now() + self.timeout;
+
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                bail!("timeout waiting for response to request {expected_id}");
+            }
+
+            let msg = match self.receiver.recv_timeout(remaining) {
+                Ok(msg) => msg,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    bail!("timeout waiting for response to request {expected_id}");
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    bail!("LSP server disconnected");
+                }
+            };
+
+            // Server-initiated request — auto-respond per LSP spec
+            if is_server_request(&msg) {
+                let _ = self.auto_respond(&msg);
+                continue;
+            }
+
+            // Server notification — buffer for later consumption by recv_until
+            if is_notification(&msg) {
+                self.buffered_notifications.push_back(msg);
+                continue;
+            }
+
+            // Response with matching ID — return it
+            if let Some(id) = msg.get("id") {
+                if id.as_i64() == Some(expected_id) {
+                    if let Some(error) = msg.get("error") {
+                        let message = error
+                            .get("message")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or("unknown LSP error");
+                        bail!("LSP error: {message}");
+                    }
+                    return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
+                }
+            }
+            // Response with wrong ID — discard (shouldn't happen in practice)
+        }
+    }
+
+    /// Respond to a server-initiated request with `result: null`.
+    fn auto_respond(&mut self, request: &Value) -> Result<()> {
+        let id = request.get("id").cloned().unwrap_or(Value::Null);
+        self.write_message(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": null,
+        }))
+    }
+}
+
+/// A server-initiated request has both `id` and `method`.
+fn is_server_request(msg: &Value) -> bool {
+    msg.get("id").is_some() && msg.get("method").is_some()
+}
+
+/// A notification has `method` but no `id`.
+fn is_notification(msg: &Value) -> bool {
+    msg.get("method").is_some() && msg.get("id").is_none()
+}
+
+/// Background thread that reads LSP messages and sends them to the channel.
+fn reader_thread(stdout: ChildStdout, tx: mpsc::Sender<Value>) {
+    let mut reader = BufReader::new(stdout);
+
+    loop {
+        let msg = match read_message(&mut reader) {
+            Ok(msg) => msg,
+            Err(_) => break,
+        };
+        if tx.send(msg).is_err() {
+            break;
+        }
+    }
+}
+
+fn read_message(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
+    let content_length = read_headers(reader)?;
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body)?;
+    serde_json::from_slice(&body).context("invalid JSON in LSP message")
+}
+
+fn read_headers(reader: &mut BufReader<ChildStdout>) -> Result<usize> {
+    let mut content_length = None;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        reader.read_line(&mut line)?;
+
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+
+        if let Some(value) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(value.trim().parse::<usize>()?);
+        }
+    }
+
+    content_length.context("missing Content-Length header in LSP message")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_server_request() {
+        let req =
+            serde_json::json!({"id": 1, "method": "window/workDoneProgress/create", "params": {}});
+        assert!(is_server_request(&req));
+    }
+
+    #[test]
+    fn test_is_notification() {
+        let notif = serde_json::json!({"method": "$/progress", "params": {}});
+        assert!(is_notification(&notif));
+        assert!(!is_server_request(&notif));
+    }
+
+    #[test]
+    fn test_response_is_neither() {
+        let resp = serde_json::json!({"id": 1, "result": null});
+        assert!(!is_server_request(&resp));
+        assert!(!is_notification(&resp));
+    }
+
+    #[test]
+    fn test_jsonrpc_request_format() {
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "textDocument/definition",
+            "params": { "textDocument": { "uri": "file:///test.rs" } },
+        });
+        let body = serde_json::to_string(&msg).unwrap();
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+        let full = format!("{header}{body}");
+
+        assert!(full.starts_with("Content-Length: "));
+        assert!(full.contains("\r\n\r\n"));
+        let parts: Vec<&str> = full.splitn(2, "\r\n\r\n").collect();
+        let parsed: Value = serde_json::from_str(parts[1]).unwrap();
+        assert_eq!(parsed["method"], "textDocument/definition");
+    }
+
+    #[test]
+    fn test_jsonrpc_response_parsing() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": { "uri": "file:///foo.rs", "range": {} },
+        });
+
+        assert!(response.get("error").is_none());
+        let result = response.get("result").unwrap();
+        assert_eq!(result["uri"], "file:///foo.rs");
+    }
+
+    #[test]
+    fn test_jsonrpc_error_response() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32600, "message": "Invalid Request" },
+        });
+
+        let error = response.get("error").unwrap();
+        let message = error.get("message").and_then(|m| m.as_str()).unwrap();
+        assert_eq!(message, "Invalid Request");
+    }
+}

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -1,0 +1,481 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+use super::client::LspClient;
+use super::servers::{find_servers, is_binary_available};
+
+/// Max seconds to wait for an LSP server to finish loading its project model.
+const READY_TIMEOUT_SECS: u64 = 60;
+
+/// Seconds to wait for $/progress notifications before switching to probe-based detection.
+const PROGRESS_DETECT_SECS: u64 = 5;
+
+/// Manages running LSP server instances, one per language.
+pub struct LspManager {
+    root: PathBuf,
+    clients: HashMap<String, (LspClient, &'static str)>, // (client, language_id)
+}
+
+impl LspManager {
+    pub fn new(root: &Path) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            clients: HashMap::new(),
+        }
+    }
+
+    /// Ensure the manager's root matches the given path.
+    /// If different, shut down all servers (they were initialized for a different project root).
+    pub fn ensure_root(&mut self, root: &Path) {
+        if self.root != root {
+            tracing::info!("LSP: project root changed, restarting servers");
+            self.shutdown_all();
+            self.root = root.to_path_buf();
+        }
+    }
+
+    /// Start a language server for the given cartog language.
+    /// Returns Ok(()) if started successfully, Err if server not available or failed to init.
+    pub fn start(&mut self, language: &str) -> Result<()> {
+        if self.clients.contains_key(language) {
+            return Ok(());
+        }
+
+        let candidates = find_servers(language);
+        if candidates.is_empty() {
+            bail!("no LSP server configured for {language}");
+        }
+
+        // Try each candidate in order, use the first one available on PATH
+        let spec = candidates.iter().find(|s| is_binary_available(s.binary));
+
+        let spec = match spec {
+            Some(s) => s,
+            None => {
+                // Show install hints for all candidates
+                let hints: Vec<_> = candidates
+                    .iter()
+                    .map(|s| format!("{}: {}", s.binary, s.install_hint))
+                    .collect();
+                bail!(
+                    "no LSP server found on PATH. Install one of:\n  {}",
+                    hints.join("\n  ")
+                );
+            }
+        };
+
+        let child = Command::new(spec.binary)
+            .args(spec.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .current_dir(&self.root)
+            .spawn()
+            .with_context(|| format!("failed to spawn {}", spec.binary))?;
+
+        let mut client = LspClient::new(child)?;
+
+        tracing::info!("LSP: waiting for {} to load project...", spec.binary);
+        self.initialize(&mut client)?;
+
+        self.clients
+            .insert(language.to_string(), (client, spec.language_id));
+        Ok(())
+    }
+
+    /// Send textDocument/definition and return the target location.
+    pub fn definition(
+        &mut self,
+        language: &str,
+        file_path: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<DefinitionLocation>> {
+        let (client, _) = self
+            .clients
+            .get_mut(language)
+            .with_context(|| format!("no running LSP client for {language}"))?;
+
+        let uri = path_to_uri(&self.root.join(file_path));
+
+        let result = client.send_request(
+            "textDocument/definition",
+            serde_json::json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+            }),
+        )?;
+
+        parse_definition_response(&result, &self.root)
+    }
+
+    /// Notify the server that a file is open (required before definition requests).
+    pub fn open_file(&mut self, language: &str, file_path: &str, content: &str) -> Result<()> {
+        let (client, language_id) = self
+            .clients
+            .get_mut(language)
+            .with_context(|| format!("no running LSP client for {language}"))?;
+
+        let uri = path_to_uri(&self.root.join(file_path));
+
+        client.send_notification(
+            "textDocument/didOpen",
+            serde_json::json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language_id,
+                    "version": 1,
+                    "text": content,
+                },
+            }),
+        )
+    }
+
+    /// Notify the server that a file is closed (frees server-side resources).
+    pub fn close_file(&mut self, language: &str, file_path: &str) -> Result<()> {
+        let (client, _) = self
+            .clients
+            .get_mut(language)
+            .with_context(|| format!("no running LSP client for {language}"))?;
+
+        let uri = path_to_uri(&self.root.join(file_path));
+
+        client.send_notification(
+            "textDocument/didClose",
+            serde_json::json!({
+                "textDocument": { "uri": uri },
+            }),
+        )
+    }
+
+    /// Check if the client for a language is still alive.
+    pub fn is_alive(&mut self, language: &str) -> bool {
+        self.clients
+            .get_mut(language)
+            .is_some_and(|(c, _)| c.is_alive())
+    }
+
+    /// Gracefully shut down all running servers.
+    pub fn shutdown_all(&mut self) {
+        for (lang, (mut client, _)) in self.clients.drain() {
+            if let Err(e) = client.send_request("shutdown", Value::Null) {
+                tracing::debug!("shutdown failed for {lang}: {e:#}");
+                let _ = client.child.kill();
+                let _ = client.child.wait();
+                continue;
+            }
+            let _ = client.send_notification("exit", Value::Null);
+
+            // Poll for graceful exit, kill if it takes too long
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                match client.child.try_wait() {
+                    Ok(Some(_)) => break, // exited
+                    Ok(None) if std::time::Instant::now() < deadline => {
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                    }
+                    _ => {
+                        tracing::debug!("{lang} server did not exit, killing");
+                        let _ = client.child.kill();
+                        let _ = client.child.wait();
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn initialize(&self, client: &mut LspClient) -> Result<()> {
+        let root_uri = path_to_uri(&self.root);
+
+        let _result = client.send_request(
+            "initialize",
+            serde_json::json!({
+                "processId": std::process::id(),
+                "rootUri": root_uri,
+                "capabilities": {
+                    "window": {
+                        "workDoneProgress": true
+                    },
+                    "textDocument": {
+                        "definition": { "dynamicRegistration": false }
+                    }
+                },
+            }),
+        )?;
+
+        client.send_notification("initialized", serde_json::json!({}))?;
+
+        // Two-strategy readiness detection:
+        // 1. Progress-based: wait for $/progress begin→end lifecycle (rust-analyzer)
+        // 2. Probe-based fallback: if no progress within 5s, poll with definition requests
+        self.wait_until_ready(client)?;
+
+        Ok(())
+    }
+
+    /// Wait for the server to be ready.
+    ///
+    /// **Strategy 1 — Progress notifications** (servers like rust-analyzer):
+    /// Track `$/progress` begin/end scopes. Ready when all scopes close + 2s quiesce.
+    ///
+    /// **Strategy 2 — Skip** (servers like typescript-language-server):
+    /// If no `$/progress` arrives within 5s, proceed immediately. These servers
+    /// respond to definition requests while loading (returning null for unloaded files).
+    fn wait_until_ready(&self, client: &mut LspClient) -> Result<()> {
+        let start = std::time::Instant::now();
+        let deadline = start + std::time::Duration::from_secs(READY_TIMEOUT_SECS);
+
+        // Phase 1: try progress-based detection
+        if let Some(elapsed) = self.wait_via_progress(client, deadline)? {
+            tracing::info!("LSP: ready ({elapsed:.1}s)");
+            return Ok(());
+        }
+
+        // No progress support — proceed immediately (server handles requests while loading)
+        if let Some(elapsed) = self.wait_no_progress() {
+            tracing::info!("LSP: no progress support, proceeding after {elapsed:.0}s");
+        }
+        Ok(())
+    }
+
+    /// Wait for $/progress scopes to complete. Returns `Some(elapsed)` if ready,
+    /// `None` if no progress was received within the first 5s (caller should fallback).
+    fn wait_via_progress(
+        &self,
+        client: &mut LspClient,
+        deadline: std::time::Instant,
+    ) -> Result<Option<f32>> {
+        let start = std::time::Instant::now();
+
+        // Phase 1: wait up to PROGRESS_DETECT_SECS for any progress notification
+        let detect_deadline = start + std::time::Duration::from_secs(PROGRESS_DETECT_SECS);
+        let mut seen_any = false;
+
+        client.recv_until(detect_deadline, |msg| {
+            if msg.get("method").and_then(|m| m.as_str()) == Some("$/progress") {
+                seen_any = true;
+                return true; // got one — move to phase 2
+            }
+            false
+        });
+
+        if !seen_any {
+            return Ok(None); // no progress support — caller should fallback
+        }
+
+        // Phase 2: track all progress scopes until completion
+        let mut active_scopes: u32 = 1; // we already saw one begin
+        let mut all_done_at: Option<std::time::Instant> = None;
+        let quiesce = std::time::Duration::from_secs(2);
+        let mut seen_titles = std::collections::HashSet::new();
+
+        // Process the first notification we already received (it's in the buffer)
+        // — actually recv_until consumed it via callback. We counted it as active_scopes=1.
+
+        let done = client.recv_until(deadline, |msg| {
+            let method = msg.get("method").and_then(|m| m.as_str());
+            if method != Some("$/progress") {
+                return all_done_at.is_some_and(|t| t.elapsed() >= quiesce);
+            }
+
+            let value = match msg.get("params").and_then(|p| p.get("value")) {
+                Some(v) => v,
+                None => return false,
+            };
+
+            match value.get("kind").and_then(|k| k.as_str()) {
+                Some("begin") => {
+                    let title = value
+                        .get("title")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("loading");
+                    if seen_titles.insert(title.to_string()) {
+                        tracing::info!("LSP: {title}...");
+                    }
+                    active_scopes += 1;
+                    all_done_at = None;
+                }
+                Some("report") => {
+                    if let Some(msg) = value.get("message").and_then(|m| m.as_str()) {
+                        tracing::debug!("LSP: {msg}");
+                    }
+                }
+                Some("end") => {
+                    active_scopes = active_scopes.saturating_sub(1);
+                    tracing::debug!("LSP: scope ended (active={active_scopes})");
+                    if active_scopes == 0 {
+                        all_done_at = Some(std::time::Instant::now());
+                    }
+                }
+                _ => {}
+            }
+            all_done_at.is_some_and(|t| t.elapsed() >= quiesce)
+        });
+
+        let elapsed = start.elapsed().as_secs_f32();
+        if done {
+            Ok(Some(elapsed))
+        } else {
+            tracing::info!("LSP: still loading after {elapsed:.0}s, proceeding anyway");
+            Ok(Some(elapsed))
+        }
+    }
+
+    /// Fallback for servers without `$/progress` support (e.g., typescript-language-server).
+    /// These servers respond to definition requests immediately even while loading,
+    /// returning null for unloaded files. No point in probing — proceed directly.
+    fn wait_no_progress(&self) -> Option<f32> {
+        Some(PROGRESS_DETECT_SECS as f32)
+    }
+}
+
+impl Drop for LspManager {
+    fn drop(&mut self) {
+        self.shutdown_all();
+    }
+}
+
+/// Parsed definition location from an LSP response.
+#[derive(Debug)]
+pub struct DefinitionLocation {
+    /// Relative file path within project root.
+    pub file_path: String,
+    /// 1-based line number.
+    pub line: u32,
+}
+
+fn path_to_uri(path: &Path) -> String {
+    url::Url::from_file_path(path)
+        .map(|u| u.to_string())
+        .unwrap_or_else(|_| format!("file://{}", path.display()))
+}
+
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    url::Url::parse(uri)
+        .ok()
+        .and_then(|u| u.to_file_path().ok())
+}
+
+/// Parse a textDocument/definition response into a location.
+/// Handles both single Location and Location[] responses.
+fn parse_definition_response(result: &Value, root: &Path) -> Result<Option<DefinitionLocation>> {
+    let location = if result.is_array() {
+        result.get(0)
+    } else if result.get("uri").is_some() {
+        Some(result)
+    } else {
+        None
+    };
+
+    let Some(loc) = location else {
+        return Ok(None);
+    };
+
+    let uri = loc
+        .get("uri")
+        .and_then(|u| u.as_str())
+        .context("missing uri in Location")?;
+
+    let abs_path = match uri_to_path(uri) {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+
+    // Must be within project root
+    let rel_path = match abs_path.strip_prefix(root) {
+        Ok(rel) => rel.to_string_lossy().to_string(),
+        Err(_) => {
+            tracing::debug!("definition outside root: {uri}");
+            return Ok(None);
+        }
+    };
+
+    let line = loc
+        .get("range")
+        .and_then(|r| r.get("start"))
+        .and_then(|s| s.get("line"))
+        .and_then(|l| l.as_u64())
+        .unwrap_or(0) as u32
+        + 1; // LSP 0-based → cartog 1-based
+
+    Ok(Some(DefinitionLocation {
+        file_path: rel_path,
+        line,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_to_uri() {
+        assert_eq!(
+            path_to_uri(Path::new("/home/user/project")),
+            "file:///home/user/project"
+        );
+    }
+
+    #[test]
+    fn test_uri_to_path() {
+        let p = uri_to_path("file:///home/user/project/src/main.rs").unwrap();
+        assert_eq!(p, PathBuf::from("/home/user/project/src/main.rs"));
+    }
+
+    #[test]
+    fn test_uri_to_path_non_file() {
+        assert!(uri_to_path("https://example.com").is_none());
+    }
+
+    #[test]
+    fn test_parse_definition_single_location() {
+        let root = Path::new("/project");
+        let result = serde_json::json!({
+            "uri": "file:///project/src/auth.rs",
+            "range": { "start": { "line": 10, "character": 4 }, "end": { "line": 10, "character": 20 } },
+        });
+
+        let loc = parse_definition_response(&result, root).unwrap().unwrap();
+        assert_eq!(loc.file_path, "src/auth.rs");
+        assert_eq!(loc.line, 11); // 0-based → 1-based
+    }
+
+    #[test]
+    fn test_parse_definition_array() {
+        let root = Path::new("/project");
+        let result = serde_json::json!([
+            {
+                "uri": "file:///project/src/auth.rs",
+                "range": { "start": { "line": 5, "character": 0 }, "end": { "line": 5, "character": 10 } },
+            }
+        ]);
+
+        let loc = parse_definition_response(&result, root).unwrap().unwrap();
+        assert_eq!(loc.file_path, "src/auth.rs");
+        assert_eq!(loc.line, 6);
+    }
+
+    #[test]
+    fn test_parse_definition_null() {
+        let root = Path::new("/project");
+        let result = Value::Null;
+
+        assert!(parse_definition_response(&result, root).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_parse_definition_outside_root() {
+        let root = Path::new("/project");
+        let result = serde_json::json!({
+            "uri": "file:///other/src/lib.rs",
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+        });
+
+        assert!(parse_definition_response(&result, root).unwrap().is_none());
+    }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,0 +1,263 @@
+pub mod client;
+pub mod manager;
+pub mod servers;
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::db::Database;
+use crate::languages::detect_language;
+
+use manager::LspManager;
+
+/// Resolve edges that heuristic resolution left unresolved, using LSP servers.
+///
+/// If `shared_manager` is provided, reuses existing LSP servers (warm start).
+/// Otherwise creates a temporary manager that is dropped after resolution.
+///
+/// Returns the number of edges resolved by LSP.
+pub fn lsp_resolve_edges(
+    db: &Database,
+    root: &Path,
+    shared_manager: Option<&mut LspManager>,
+) -> Result<u32> {
+    let unresolved = db.unresolved_edges()?;
+
+    if unresolved.is_empty() {
+        return Ok(0);
+    }
+
+    // Group by language (derived from file extension)
+    let mut by_language: HashMap<String, Vec<UnresolvedEdge>> = HashMap::new();
+    for edge in unresolved {
+        let path = Path::new(&edge.file_path);
+        if let Some(lang) = detect_language(path) {
+            by_language.entry(lang.to_string()).or_default().push(edge);
+        }
+    }
+
+    if by_language.is_empty() {
+        return Ok(0);
+    }
+
+    // Use shared manager if provided, otherwise create a temporary one
+    let mut owned_manager;
+    let manager: &mut LspManager = match shared_manager {
+        Some(m) => {
+            m.ensure_root(root);
+            m
+        }
+        None => {
+            owned_manager = LspManager::new(root);
+            &mut owned_manager
+        }
+    };
+
+    let mut resolved = 0u32;
+    let mut any_server_started = false;
+
+    for (language, edges) in &by_language {
+        match manager.start(language) {
+            Ok(()) => {
+                any_server_started = true;
+            }
+            Err(e) => {
+                tracing::info!("LSP: {language} — {e:#} ({} unresolved edges)", edges.len());
+                continue;
+            }
+        }
+
+        // Group edges by file for batched didOpen
+        let mut by_file: HashMap<&str, Vec<&UnresolvedEdge>> = HashMap::new();
+        for edge in edges {
+            by_file.entry(&edge.file_path).or_default().push(edge);
+        }
+
+        tracing::info!(
+            "LSP: resolving {} unresolved {language} edges across {} files...",
+            edges.len(),
+            by_file.len()
+        );
+
+        for (file_path, file_edges) in by_file {
+            let abs_path = root.join(file_path);
+            let content = match std::fs::read_to_string(&abs_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::debug!("cannot read {file_path}: {e}");
+                    continue;
+                }
+            };
+
+            if let Err(e) = manager.open_file(language, file_path, &content) {
+                tracing::debug!("didOpen failed for {file_path}: {e:#}");
+                if !manager.is_alive(language) {
+                    tracing::warn!("{language} server died during didOpen");
+                    break;
+                }
+                continue;
+            }
+
+            let lines: Vec<&str> = content.lines().collect();
+
+            for edge in file_edges {
+                let col = match find_column_in_line(&lines, edge.line, &edge.target_name) {
+                    Some(c) => c,
+                    None => continue,
+                };
+
+                let lsp_line = edge.line.saturating_sub(1); // cartog 1-based → LSP 0-based
+
+                match manager.definition(language, file_path, lsp_line, col) {
+                    Ok(Some(loc)) => {
+                        match db.find_symbol_at_location(&loc.file_path, loc.line) {
+                            Ok(Some(symbol_id)) => {
+                                match db.update_edge_target(edge.edge_id, &symbol_id) {
+                                    Ok(()) => resolved += 1,
+                                    Err(e) => tracing::debug!(
+                                        "failed to update edge {}: {e:#}",
+                                        edge.edge_id
+                                    ),
+                                }
+                            }
+                            Ok(None) => {
+                                tracing::debug!(
+                                    "no cartog symbol at {}:{}",
+                                    loc.file_path,
+                                    loc.line
+                                );
+                            }
+                            Err(e) => return Err(e), // DB errors propagate
+                        }
+                    }
+                    Ok(None) => {} // LSP couldn't resolve either
+                    Err(e) => {
+                        tracing::debug!(
+                            "definition failed for {} at {file_path}:{}: {e:#}",
+                            edge.target_name,
+                            edge.line
+                        );
+                        if !manager.is_alive(language) {
+                            tracing::warn!("{language} server died, skipping remaining edges");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Close the file to free server memory
+            let _ = manager.close_file(language, file_path);
+        }
+    }
+
+    if !any_server_started {
+        tracing::debug!("LSP: no servers found on PATH, skipping");
+    } else if resolved > 0 {
+        tracing::info!("LSP: resolved {resolved} additional edges");
+    } else {
+        tracing::info!("LSP: no additional edges resolved");
+    }
+
+    // manager.shutdown_all() called via Drop
+    Ok(resolved)
+}
+
+/// An unresolved edge from the database.
+pub struct UnresolvedEdge {
+    pub edge_id: i64,
+    pub target_name: String,
+    pub file_path: String,
+    pub line: u32,
+}
+
+/// Find the column (0-based UTF-16 offset) of `target_name` in the given source line.
+/// Uses word-boundary matching to avoid matching inside longer identifiers.
+/// LSP positions use UTF-16 code units by default.
+fn find_column_in_line(lines: &[&str], line_1based: u32, target_name: &str) -> Option<u32> {
+    let idx = line_1based.checked_sub(1)? as usize;
+    let line = lines.get(idx)?;
+
+    let mut start = 0;
+    while let Some(offset) = line[start..].find(target_name) {
+        let abs_offset = start + offset;
+        let end_offset = abs_offset + target_name.len();
+
+        let before_ok = abs_offset == 0
+            || !line.as_bytes()[abs_offset - 1].is_ascii_alphanumeric()
+                && line.as_bytes()[abs_offset - 1] != b'_';
+
+        let after_ok = end_offset >= line.len()
+            || !line.as_bytes()[end_offset].is_ascii_alphanumeric()
+                && line.as_bytes()[end_offset] != b'_';
+
+        if before_ok && after_ok {
+            return Some(line[..abs_offset].encode_utf16().count() as u32);
+        }
+
+        start = abs_offset + 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_column_basic() {
+        let lines = vec!["    result = validate_token(tok)"];
+        assert_eq!(find_column_in_line(&lines, 1, "validate_token"), Some(13));
+    }
+
+    #[test]
+    fn test_find_column_multiple_occurrences_takes_first() {
+        let lines = vec!["foo(foo)"];
+        assert_eq!(find_column_in_line(&lines, 1, "foo"), Some(0));
+    }
+
+    #[test]
+    fn test_find_column_qualified_name() {
+        let lines = vec!["self.validate_token()"];
+        assert_eq!(find_column_in_line(&lines, 1, "validate_token"), Some(5));
+    }
+
+    #[test]
+    fn test_find_column_not_found() {
+        let lines = vec!["something_else()"];
+        assert_eq!(find_column_in_line(&lines, 1, "validate_token"), None);
+    }
+
+    #[test]
+    fn test_find_column_line_out_of_range() {
+        let lines = vec!["one line"];
+        assert_eq!(find_column_in_line(&lines, 5, "one"), None);
+    }
+
+    #[test]
+    fn test_find_column_zero_line() {
+        let lines = vec!["one line"];
+        assert_eq!(find_column_in_line(&lines, 0, "one"), None);
+    }
+
+    #[test]
+    fn test_find_column_word_boundary_skips_substring() {
+        // "id" inside "validate_id" should be skipped, match the standalone "id"
+        let lines = vec!["validate_id(id)"];
+        assert_eq!(find_column_in_line(&lines, 1, "id"), Some(12));
+    }
+
+    #[test]
+    fn test_find_column_word_boundary_at_start() {
+        let lines = vec!["id = 5"];
+        assert_eq!(find_column_in_line(&lines, 1, "id"), Some(0));
+    }
+
+    #[test]
+    fn test_find_column_word_boundary_no_standalone() {
+        // "id" only appears inside "valid" — no word-boundary match
+        let lines = vec!["valid()"];
+        assert_eq!(find_column_in_line(&lines, 1, "id"), None);
+    }
+}

--- a/src/lsp/servers.rs
+++ b/src/lsp/servers.rs
@@ -1,0 +1,127 @@
+/// Specification for a language server binary.
+pub struct ServerSpec {
+    /// cartog language name (matches `detect_language()` output)
+    pub language: &'static str,
+    /// Executable name to look up on PATH
+    pub binary: &'static str,
+    /// Command-line arguments to start in stdio mode
+    pub args: &'static [&'static str],
+    /// LSP `languageId` for `textDocument/didOpen`
+    pub language_id: &'static str,
+    /// Install hint shown when binary is not found
+    pub install_hint: &'static str,
+}
+
+pub const SERVERS: &[ServerSpec] = &[
+    ServerSpec {
+        language: "rust",
+        binary: "rust-analyzer",
+        args: &[],
+        language_id: "rust",
+        install_hint: "rustup component add rust-analyzer",
+    },
+    ServerSpec {
+        language: "python",
+        binary: "pyright-langserver",
+        args: &["--stdio"],
+        language_id: "python",
+        install_hint: "npm i -g pyright",
+    },
+    ServerSpec {
+        language: "typescript",
+        binary: "typescript-language-server",
+        args: &["--stdio"],
+        language_id: "typescript",
+        install_hint: "npm i -g typescript-language-server typescript",
+    },
+    ServerSpec {
+        language: "tsx",
+        binary: "typescript-language-server",
+        args: &["--stdio"],
+        language_id: "typescriptreact",
+        install_hint: "npm i -g typescript-language-server typescript",
+    },
+    ServerSpec {
+        language: "javascript",
+        binary: "typescript-language-server",
+        args: &["--stdio"],
+        language_id: "javascript",
+        install_hint: "npm i -g typescript-language-server typescript",
+    },
+    ServerSpec {
+        language: "go",
+        binary: "gopls",
+        args: &["serve"],
+        language_id: "go",
+        install_hint: "go install golang.org/x/tools/gopls@latest",
+    },
+    ServerSpec {
+        language: "ruby",
+        binary: "ruby-lsp",
+        args: &[],
+        language_id: "ruby",
+        install_hint: "gem install ruby-lsp (requires Ruby >= 3.2)",
+    },
+    ServerSpec {
+        language: "ruby",
+        binary: "solargraph",
+        args: &["stdio"],
+        language_id: "ruby",
+        install_hint: "gem install solargraph (requires Ruby >= 3.1)",
+    },
+    ServerSpec {
+        language: "java",
+        binary: "jdtls",
+        args: &[],
+        language_id: "java",
+        install_hint: "https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
+    },
+];
+
+/// Find all server specs for a cartog language name, in priority order.
+pub fn find_servers(language: &str) -> Vec<&'static ServerSpec> {
+    SERVERS.iter().filter(|s| s.language == language).collect()
+}
+
+/// Check if a binary is available on PATH.
+pub fn is_binary_available(binary: &str) -> bool {
+    std::process::Command::new("which")
+        .arg(binary)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_servers_rust() {
+        let specs = find_servers("rust");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].binary, "rust-analyzer");
+        assert_eq!(specs[0].language_id, "rust");
+    }
+
+    #[test]
+    fn test_find_servers_unknown_language() {
+        assert!(find_servers("cobol").is_empty());
+    }
+
+    #[test]
+    fn test_find_servers_tsx_uses_typescript_server() {
+        let specs = find_servers("tsx");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].binary, "typescript-language-server");
+    }
+
+    #[test]
+    fn test_find_servers_ruby_has_two_candidates() {
+        let specs = find_servers("ruby");
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].binary, "ruby-lsp");
+        assert_eq!(specs[1].binary, "solargraph");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod mcp;
 pub use cartog::db;
 pub use cartog::indexer;
 pub use cartog::languages;
+#[cfg(feature = "lsp")]
+pub use cartog::lsp;
 pub use cartog::rag;
 pub use cartog::types;
 pub use cartog::watch;
@@ -46,7 +48,11 @@ fn main() -> Result<()> {
     let token_budget = if cli.json { None } else { cli.tokens };
 
     match cli.command {
-        Command::Index { path, force } => commands::cmd_index(&path, force, cli.json),
+        Command::Index {
+            path,
+            force,
+            no_lsp,
+        } => commands::cmd_index(&path, force, !no_lsp, cli.json),
         Command::Outline { file } => commands::cmd_outline(&file, cli.json, token_budget),
         Command::Callees { name } => commands::cmd_callees(&name, cli.json, token_budget),
         Command::Impact { name, depth } => {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -226,6 +226,9 @@ pub struct CartogServer {
     /// Canonicalized CWD captured at server start to avoid repeated syscalls.
     /// Wrapped in `Arc` so clones (required by `#[derive(Clone)]`) are cheap.
     cwd: Arc<Path>,
+    /// Persistent LSP manager for warm server reuse across index calls.
+    #[cfg(feature = "lsp")]
+    lsp_manager: Arc<Mutex<crate::lsp::manager::LspManager>>,
 }
 
 #[tool_router]
@@ -239,6 +242,8 @@ impl CartogServer {
         Ok(Self {
             tool_router: Self::tool_router(),
             db: Arc::new(Mutex::new(db)),
+            #[cfg(feature = "lsp")]
+            lsp_manager: Arc::new(Mutex::new(crate::lsp::manager::LspManager::new(&cwd))),
             cwd: Arc::from(cwd),
         })
     }
@@ -255,14 +260,45 @@ impl CartogServer {
         let force = params.force;
         let db = Arc::clone(&self.db);
         let cwd = Arc::clone(&self.cwd);
+        #[cfg(feature = "lsp")]
+        let lsp_manager = Arc::clone(&self.lsp_manager);
 
         tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "indexing directory");
 
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
-            let result = indexer::index_directory(&db, &validated, force)
-                .map_err(|e| mcp_err(format!("indexing failed: {e}")))?;
+            // Phase 1: heuristic indexing (hold DB lock briefly)
+            #[allow(unused_mut)]
+            let mut result = {
+                let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+                indexer::index_directory(&db, &validated, force, false)
+                    .map_err(|e| mcp_err(format!("indexing failed: {e}")))?
+                // db lock released here
+            };
+
+            // Phase 2: LSP resolution (holds both locks during LSP IO).
+            // This blocks other tool calls for the duration of LSP resolution.
+            // Acceptable because MCP serves a single agent session with sequential tool calls.
+            // Future optimization: collect LSP results without DB lock, batch-write after.
+            #[cfg(feature = "lsp")]
+            {
+                let mut mgr = lsp_manager
+                    .lock()
+                    .map_err(|_| mcp_err("LSP manager lock poisoned"))?;
+                let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+                match crate::lsp::lsp_resolve_edges(&db, &validated, Some(&mut mgr)) {
+                    Ok(n) => {
+                        result.edges_lsp_resolved = n;
+                        if n > 0 {
+                            let _ = db.compute_in_degrees();
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("LSP resolution failed: {e:#}");
+                    }
+                }
+                // db + mgr locks released here
+            }
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -606,7 +642,7 @@ impl CartogServer {
             let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
 
             // Ensure the code graph index is up to date first
-            let _ = indexer::index_directory(&db, &validated, false)
+            let _ = indexer::index_directory(&db, &validated, false, false)
                 .map_err(|e| mcp_err(format!("code graph indexing failed: {e}")))?;
 
             let result = rag::indexer::index_embeddings(&db, force)

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -139,7 +139,7 @@ fn watch_loop(
     );
 
     // Initial incremental index to ensure DB is current
-    match indexer::index_directory(&db, root, false) {
+    match indexer::index_directory(&db, root, false, false) {
         Ok(r) => info!(
             files = r.files_indexed,
             skipped = r.files_skipped,
@@ -190,7 +190,7 @@ fn watch_loop(
                         count = events.len(),
                         "file change events received, re-indexing"
                     );
-                    match indexer::index_directory(&db, root, false) {
+                    match indexer::index_directory(&db, root, false, false) {
                         Ok(r) => {
                             if r.files_indexed > 0 || r.files_removed > 0 {
                                 info!(

--- a/tests/rag_relevancy.rs
+++ b/tests/rag_relevancy.rs
@@ -94,7 +94,7 @@ fn setup_db() -> Database {
         .join("webapp_py");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true).expect("index fixture");
+    index_directory(&db, &fixture_dir, true, false).expect("index fixture");
     db
 }
 
@@ -256,7 +256,7 @@ fn setup_java_db() -> Database {
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true).expect("index Java fixture");
+    index_directory(&db, &fixture_dir, true, false).expect("index Java fixture");
     db
 }
 


### PR DESCRIPTION
## Summary

- Auto-detect language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls) and use `textDocument/definition` to resolve edges that heuristic resolution couldn't
- Feature-gated behind `cargo install cartog --features lsp`
- MCP server keeps LSP servers warm across tool calls (persistent LspManager)
- CLI creates and drops servers per run; use `--no-lsp` to skip

### Edge resolution improvement

| Project type | Language | Heuristic only | With LSP |
|---|---|---|---|
| TS microservice (230 files) | TypeScript | 37% | **81%** |
| Vue.js SPA (739 files) | Vue/TS/JS | 31% | **72%** |
| Rust CLI (358 files) | Rust | 25% | **44%** |

### Key design decisions

- Index-time only — queries stay pure SQLite
- Two readiness strategies: `$/progress` tracking (rust-analyzer) and immediate proceed (typescript-language-server)
- Graceful degradation: missing servers logged with install hints
- Auto-responds to server-initiated requests (`window/workDoneProgress/create`)
- Word-boundary-aware column detection, UTF-16 position encoding, proper URI encoding

## Test plan

- [x] `cargo test` — 328 pass (default features, no regression)
- [x] `cargo test --features lsp` — 354 pass (26 new LSP unit tests)
- [x] `cargo clippy` — clean on both feature configurations
- [x] `cargo fmt --check` — clean
- [x] Manual: `cartog index .` on Rust, TypeScript, Vue projects — consistent results across runs
- [x] Manual: `cartog index . --no-lsp` — fast path works, no LSP overhead
- [x] Manual: missing servers show install hints
- [ ] CI: verify `--features lsp` jobs pass on ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)