### PR TITLE
feat(config): configurable database path via TOML, CLI flag, and env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,9 @@ dependencies = [
  "sha2",
  "sqlite-vec",
  "streaming-iterator",
+ "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
@@ -2335,6 +2337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2673,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3454,6 +3499,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ tree-sitter-go = "0.25"
 tree-sitter-ruby = "0.23"
 tree-sitter-java = "0.23"
 rusqlite = { version = "0.39", features = ["bundled"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = { version = "0.8", default-features = false, features = ["parse"] }
 walkdir = "2"
 sha2 = "0.10"
 notify = "8"
@@ -48,6 +49,7 @@ lsp = ["url"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3"
 
 [[bench]]
 name = "queries"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ sudo mv cartog /usr/local/bin/
 # Windows (x86_64) — download .zip from releases page
 ```
 
+## Configuration
+
+The database path is resolved automatically — no config needed for standard use:
+
+1. **`--db` flag / `CARTOG_DB` env var** — explicit override (highest priority)
+2. **`.cartog.toml`** at the git root — project-specific config
+3. **Auto git-root detection** — DB placed at the root of the git repository
+4. **cwd fallback** — `.cartog.db` in the current directory
+
+```bash
+# Override database location
+cartog --db /tmp/myproject.db index .
+CARTOG_DB=~/.local/share/cartog/proj.db cartog search foo
+
+# --db is global — applies to all subcommands
+cartog --db /tmp/x.db stats
+```
+
+**`.cartog.toml`** (optional, place at project root):
+```toml
+[database]
+path = "~/.local/share/cartog/myproject.db"
+```
+
+Useful when indexing from a parent directory across multiple projects, or when storing the DB outside the repo. See [`docs/usage.md`](docs/usage.md) for details.
+
 ## Search: Keyword, Semantic, or Both
 
 cartog offers two search modes that complement each other:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,6 +12,49 @@ cargo build --release
 cargo install --path .
 ```
 
+## Configuration
+
+cartog resolves the database path using the following priority (highest wins):
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | `--db` flag or `CARTOG_DB` env var | `cartog --db /tmp/proj.db index .` |
+| 2 | `.cartog.toml` in the project | `[database]\npath = "..."` |
+| 3 | Auto git-root detection | DB placed at the root of the git repo |
+| 4 | Current directory fallback | `.cartog.db` in cwd |
+
+### Project config: `.cartog.toml`
+
+Place `.cartog.toml` at the root of your project (or commit it to version control):
+
+```toml
+[database]
+# Absolute path, or use ~ for home directory expansion
+path = "~/.local/share/cartog/myproject.db"
+```
+
+This is useful when:
+- Indexing from a parent directory that contains multiple projects
+- Storing the DB outside the repo (e.g., to avoid committing it)
+- Sharing a consistent DB location across team members via `.cartog.toml`
+
+### Override examples
+
+```bash
+# Explicit flag (highest priority)
+cartog --db /tmp/myproj.db index .
+cartog --db /tmp/myproj.db search foo
+
+# Environment variable
+CARTOG_DB=~/.local/share/cartog/myproject.db cartog index .
+
+# --db applies globally to all subcommands
+cartog --db /tmp/x.db stats
+cartog --db /tmp/x.db map
+```
+
+---
+
 ## Commands
 
 ### `cartog index <path>`

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -162,6 +162,25 @@ transparently once background embedding completes.
 > **First run**: tier 2 downloads ~1.2GB of ONNX models (cached in `~/.cache/cartog/models/`).
 > This may take a few minutes — do not abort. Subsequent runs are instant.
 
+## Database Location
+
+The index is stored in a SQLite database. cartog resolves the path automatically:
+
+| Priority | Source |
+|----------|--------|
+| 1 | `--db <path>` flag or `CARTOG_DB` env var |
+| 2 | `.cartog.toml` → `[database] path = "..."` at git root |
+| 3 | Auto git-root: DB placed at the root of the current git repository |
+| 4 | `.cartog.db` in the current directory (fallback) |
+
+For most projects, no configuration is needed — running `cartog index .` from any subdirectory will place the DB at the git root automatically.
+
+```bash
+# Override examples
+cartog --db /tmp/myproject.db index .
+CARTOG_DB=~/.local/share/cartog/proj.db cartog index .
+```
+
 ## Commands Reference
 
 ### Index (build/rebuild)

--- a/skills/cartog/scripts/ensure_indexed.sh
+++ b/skills/cartog/scripts/ensure_indexed.sh
@@ -14,8 +14,37 @@ set -euo pipefail
 # Phase 3 adds vector/semantic matching in the background without blocking the agent.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DB_FILE=".cartog.db"
-LOCK_DIR="/tmp/cartog-rag-index.lock"
+LOCK_DIR="${CARTOG_LOCK_DIR:-/tmp/cartog-rag-index.lock}"
+
+# Resolve the database path using the same priority as the Rust binary:
+#   1. CARTOG_DB env var (explicit override)
+#   2. .cartog.toml database.path (local project config)
+#   3. Git root detection (walk up from cwd to find .git, place DB there)
+#   4. cwd fallback (.cartog.db in the current directory)
+if [ -n "${CARTOG_DB:-}" ]; then
+    DB_FILE="$CARTOG_DB"
+else
+    # Check .cartog.toml for database.path
+    TOML_DB=""
+    GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || true
+    for _dir in "." "$GIT_ROOT"; do
+        [ -n "$_dir" ] && [ -f "$_dir/.cartog.toml" ] && {
+            TOML_DB="$(sed -n '/^\[database\]/,/^\[/{s/^path[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p;}' "$_dir/.cartog.toml" 2>/dev/null)" || true
+            [ -n "$TOML_DB" ] && break
+        }
+    done
+    if [ -n "$TOML_DB" ]; then
+        # Expand leading ~/
+        case "$TOML_DB" in
+            "~/"*) DB_FILE="${HOME}${TOML_DB#\~}" ;;
+            *)     DB_FILE="$TOML_DB" ;;
+        esac
+    elif [ -n "$GIT_ROOT" ]; then
+        DB_FILE="${GIT_ROOT}/.cartog.db"
+    else
+        DB_FILE=".cartog.db"
+    fi
+fi
 REPO="jrollin/cartog"
 VERSION_CACHE="${HOME}/.cache/cartog/latest_version"
 VERSION_TTL=86400  # 24 hours

--- a/skills/cartog/tests/test_ensure_indexed.sh
+++ b/skills/cartog/tests/test_ensure_indexed.sh
@@ -22,12 +22,18 @@ setup() {
     # log file tracks command invocations in order
     export CARTOG_TEST_LOG="$TEST_DIR/commands.log"
     : > "$CARTOG_TEST_LOG"
-    # Clean up lock from any previous test
-    rmdir /tmp/cartog-rag-index.lock 2>/dev/null || true
+    # Use per-test lock directory to avoid cross-test interference
+    export CARTOG_LOCK_DIR="$TEST_DIR/rag-index.lock"
 }
 
 teardown() {
-    rmdir /tmp/cartog-rag-index.lock 2>/dev/null || true
+    # Wait for any background rag index to finish and release lock
+    local i=0
+    while [ -d "${CARTOG_LOCK_DIR:-}" ] && [ "$i" -lt 20 ]; do
+        sleep 0.1
+        i=$((i + 1))
+    done
+    rmdir "${CARTOG_LOCK_DIR:-}" 2>/dev/null || true
     [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
 }
 
@@ -171,8 +177,8 @@ test_phase_order() {
     create_mock_cartog
 
     run_ensure_indexed > /dev/null
-    # Wait briefly for background process to log
-    sleep 0.3
+    # Wait for background rag index to log (mock sleeps 0.1s)
+    sleep 0.5
 
     local line1 line2 line3
     line1=$(sed -n '1p' "$CARTOG_TEST_LOG")
@@ -252,7 +258,7 @@ test_lock_prevents_concurrent_rag_index() {
     create_mock_cartog
 
     # Pre-create the lock directory to simulate an already-running rag index
-    mkdir /tmp/cartog-rag-index.lock
+    mkdir "$CARTOG_LOCK_DIR"
 
     local output
     output=$(run_ensure_indexed)
@@ -275,7 +281,7 @@ test_lock_cleaned_after_rag_index() {
     # Wait for background rag index to finish (mock sleeps 0.1s)
     sleep 0.5
 
-    if [ ! -d /tmp/cartog-rag-index.lock ]; then
+    if [ ! -d "$CARTOG_LOCK_DIR" ]; then
         echo "  PASS: lock directory cleaned up after completion"
         PASS=$((PASS + 1))
     else
@@ -287,14 +293,12 @@ test_lock_cleaned_after_rag_index() {
 
 test_stale_lock_removed() {
     echo "TEST: stale lock (>1 hour) is removed and rag index proceeds"
-    # Wait for any background rag index from previous tests to finish and release lock
-    sleep 0.5
     setup
     create_mock_cartog
 
     # Create a lock directory and backdate it to 2 hours ago
-    mkdir /tmp/cartog-rag-index.lock
-    touch -t "$(date -v-2H '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '2 hours ago' '+%Y%m%d%H%M.%S' 2>/dev/null)" /tmp/cartog-rag-index.lock
+    mkdir "$CARTOG_LOCK_DIR"
+    touch -t "$(date -v-2H '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '2 hours ago' '+%Y%m%d%H%M.%S' 2>/dev/null)" "$CARTOG_LOCK_DIR"
 
     local output
     output=$(run_ensure_indexed)
@@ -417,6 +421,136 @@ test_fetch_failure_continues() {
     teardown
 }
 
+# --- .cartog.toml DB path resolution tests ---
+
+# Helper: run ensure_indexed with a patched script that prints DB_FILE before
+# executing phases. This avoids sourcing issues with set -euo pipefail.
+run_ensure_indexed_print_db() {
+    local workdir="$1"
+    shift
+    (
+        export PATH="$TEST_DIR/bin:$PATH"
+        export HOME="$TEST_DIR/home"
+        mkdir -p "$HOME"
+        "$@"
+        cd "$workdir"
+        # Patch the script: insert an echo after DB_FILE resolution (just before REPO=)
+        sed 's/^REPO=/echo "DB_FILE=$DB_FILE"\nREPO=/' "$ENSURE_SCRIPT" | bash 2>&1
+    )
+}
+
+test_toml_cwd_database_path() {
+    echo "TEST: .cartog.toml in cwd sets DB_FILE from database.path"
+    setup
+    create_mock_cartog
+    create_mock_curl "0.6.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir"
+    cat > "$workdir/.cartog.toml" <<'TOML'
+[database]
+path = "/custom/my.db"
+TOML
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir")
+
+    assert_contains "uses toml path" "DB_FILE=/custom/my.db" "$output"
+    teardown
+}
+
+test_toml_git_root_database_path() {
+    echo "TEST: .cartog.toml at git root sets DB_FILE"
+    setup
+    create_mock_cartog
+    create_mock_curl "0.6.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir/subdir"
+
+    cat > "$TEST_DIR/bin/git" <<MOCK
+#!/usr/bin/env bash
+if [ "\$1" = "rev-parse" ] && [ "\$2" = "--show-toplevel" ]; then
+    echo "$workdir"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/git"
+
+    cat > "$workdir/.cartog.toml" <<'TOML'
+[database]
+path = "/root-level/cartog.db"
+TOML
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir/subdir")
+
+    assert_contains "uses git root toml" "DB_FILE=/root-level/cartog.db" "$output"
+    teardown
+}
+
+test_toml_tilde_expansion() {
+    echo "TEST: .cartog.toml path with ~/ expands to HOME"
+    setup
+    create_mock_cartog
+    create_mock_curl "0.6.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir"
+    cat > "$workdir/.cartog.toml" <<'TOML'
+[database]
+path = "~/projects/my.db"
+TOML
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir")
+
+    assert_contains "tilde expanded" "DB_FILE=$TEST_DIR/home/projects/my.db" "$output"
+    teardown
+}
+
+test_cartog_db_env_overrides_toml() {
+    echo "TEST: CARTOG_DB env var overrides .cartog.toml"
+    setup
+    create_mock_cartog
+    create_mock_curl "0.6.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir"
+    cat > "$workdir/.cartog.toml" <<'TOML'
+[database]
+path = "/toml/path.db"
+TOML
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir" export CARTOG_DB="/env/override.db")
+
+    assert_contains "env overrides toml" "DB_FILE=/env/override.db" "$output"
+    teardown
+}
+
+test_no_toml_falls_back_to_git_root() {
+    echo "TEST: no .cartog.toml falls back to git root"
+    setup
+    create_mock_cartog
+    create_mock_curl "0.6.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir"
+
+    cat > "$TEST_DIR/bin/git" <<MOCK
+#!/usr/bin/env bash
+if [ "\$1" = "rev-parse" ] && [ "\$2" = "--show-toplevel" ]; then
+    echo "$workdir"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/git"
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir")
+
+    assert_contains "falls back to git root" "DB_FILE=$workdir/.cartog.db" "$output"
+    teardown
+}
+
 # --- run all tests ---
 
 echo "=== ensure_indexed.sh unit tests ==="
@@ -453,6 +587,16 @@ echo ""
 test_newer_installed_no_notice
 echo ""
 test_fetch_failure_continues
+echo ""
+test_toml_cwd_database_path
+echo ""
+test_toml_git_root_database_path
+echo ""
+test_toml_tilde_expansion
+echo ""
+test_cartog_db_env_overrides_toml
+echo ""
+test_no_toml_falls_back_to_git_root
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::types::{EdgeKind, SymbolKind};
@@ -17,6 +19,11 @@ pub struct Cli {
     /// Limit human-readable output to approximately N tokens (ignored with --json)
     #[arg(long, global = true)]
     pub tokens: Option<u32>,
+
+    /// Path to the cartog database (overrides .cartog.toml and auto-detection).
+    /// Can also be set via the CARTOG_DB environment variable.
+    #[arg(long, global = true, value_name = "PATH", env = "CARTOG_DB")]
+    pub db: Option<PathBuf>,
 }
 
 /// Filter for symbol kinds in the search command.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,14 +5,14 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::cli::{EdgeKindFilter, SymbolKindFilter};
-use crate::db::{Database, DB_FILE, MAX_SEARCH_LIMIT};
+use crate::db::{Database, MAX_SEARCH_LIMIT};
 use crate::indexer;
 use crate::rag;
 use crate::types::{EdgeKind, SymbolKind};
 use crate::watch::{self, WatchConfig};
 
-fn open_db() -> Result<Database> {
-    Database::open(DB_FILE).context("Failed to open cartog database")
+fn open_db(path: &Path) -> Result<Database> {
+    Database::open(path).context("Failed to open cartog database")
 }
 
 /// Estimate token count from a string using chars/4 approximation.
@@ -61,9 +61,9 @@ fn output<T: Serialize>(
 }
 
 /// Build or rebuild the code graph index.
-pub fn cmd_index(path: &str, force: bool, lsp: bool, json: bool) -> Result<()> {
+pub fn cmd_index(db_path: &Path, path: &str, force: bool, lsp: bool, json: bool) -> Result<()> {
     let root = Path::new(path);
-    let db = open_db()?;
+    let db = open_db(db_path)?;
 
     let result = indexer::index_directory(&db, root, force, lsp)?;
 
@@ -90,8 +90,13 @@ pub fn cmd_index(path: &str, force: bool, lsp: bool, json: bool) -> Result<()> {
 }
 
 /// Show symbols and structure of a file.
-pub fn cmd_outline(file: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_outline(
+    db_path: &Path,
+    file: &str,
+    json: bool,
+    token_budget: Option<u32>,
+) -> Result<()> {
+    let db = open_db(db_path)?;
     let symbols = db.outline(file)?;
     let file = file.to_string();
 
@@ -125,8 +130,13 @@ pub fn cmd_outline(file: &str, json: bool, token_budget: Option<u32>) -> Result<
 }
 
 /// Find what a symbol calls.
-pub fn cmd_callees(name: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_callees(
+    db_path: &Path,
+    name: &str,
+    json: bool,
+    token_budget: Option<u32>,
+) -> Result<()> {
+    let db = open_db(db_path)?;
     let edges = db.callees(name)?;
     let name = name.to_string();
 
@@ -148,8 +158,14 @@ pub fn cmd_callees(name: &str, json: bool, token_budget: Option<u32>) -> Result<
 }
 
 /// Transitive impact analysis — what breaks if this changes?
-pub fn cmd_impact(name: &str, depth: u32, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_impact(
+    db_path: &Path,
+    name: &str,
+    depth: u32,
+    json: bool,
+    token_budget: Option<u32>,
+) -> Result<()> {
+    let db = open_db(db_path)?;
     let results = db.impact(name, depth)?;
     let name = name.to_string();
 
@@ -185,12 +201,13 @@ pub fn cmd_impact(name: &str, depth: u32, json: bool, token_budget: Option<u32>)
 
 /// All references to a symbol (calls, imports, inherits, references, raises).
 pub fn cmd_refs(
+    db_path: &Path,
     name: &str,
     kind: Option<EdgeKindFilter>,
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db()?;
+    let db = open_db(db_path)?;
     let kind_filter = kind.map(EdgeKind::from);
     let results = db.refs(name, kind_filter)?;
     let name = name.to_string();
@@ -230,8 +247,13 @@ pub fn cmd_refs(
 }
 
 /// Show inheritance hierarchy for a class.
-pub fn cmd_hierarchy(name: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_hierarchy(
+    db_path: &Path,
+    name: &str,
+    json: bool,
+    token_budget: Option<u32>,
+) -> Result<()> {
+    let db = open_db(db_path)?;
     let pairs = db.hierarchy(name)?;
     let name = name.to_string();
 
@@ -259,8 +281,8 @@ pub fn cmd_hierarchy(name: &str, json: bool, token_budget: Option<u32>) -> Resul
 }
 
 /// File-level import dependencies.
-pub fn cmd_deps(file: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_deps(db_path: &Path, file: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
+    let db = open_db(db_path)?;
     let edges = db.file_deps(file)?;
     let file = file.to_string();
 
@@ -282,6 +304,7 @@ pub fn cmd_deps(file: &str, json: bool, token_budget: Option<u32>) -> Result<()>
 
 /// Search for symbols by name (case-insensitive prefix + substring match).
 pub fn cmd_search(
+    db_path: &Path,
     query: &str,
     kind: Option<SymbolKindFilter>,
     file: Option<&str>,
@@ -289,7 +312,7 @@ pub fn cmd_search(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db()?;
+    let db = open_db(db_path)?;
     let kind_filter = kind.map(crate::types::SymbolKind::from);
     let limit = limit.min(MAX_SEARCH_LIMIT);
     let symbols = db.search(query, kind_filter, file, limit)?;
@@ -314,8 +337,8 @@ pub fn cmd_search(
 }
 
 /// Index statistics summary.
-pub fn cmd_stats(json: bool) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_stats(db_path: &Path, json: bool) -> Result<()> {
+    let db = open_db(db_path)?;
     let stats = db.stats()?;
 
     output(&stats, json, None, |stats| {
@@ -343,8 +366,8 @@ pub fn cmd_stats(json: bool) -> Result<()> {
 }
 
 /// Token-budget-aware codebase summary: file tree + top symbols ranked by centrality.
-pub fn cmd_map(tokens: u32, json: bool) -> Result<()> {
-    let db = open_db()?;
+pub fn cmd_map(db_path: &Path, tokens: u32, json: bool) -> Result<()> {
+    let db = open_db(db_path)?;
     let files = db.all_files()?;
 
     if files.is_empty() {
@@ -434,12 +457,13 @@ pub fn cmd_map(tokens: u32, json: bool) -> Result<()> {
 
 /// Show symbols affected by recent git changes.
 pub fn cmd_changes(
+    db_path: &Path,
     commits: u32,
     kind: Option<SymbolKindFilter>,
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db()?;
+    let db = open_db(db_path)?;
     let root = std::env::current_dir()?;
 
     let changed_files = indexer::git_recently_changed_files(&root, commits)?;
@@ -532,10 +556,10 @@ pub fn cmd_rag_setup(json: bool) -> Result<()> {
 }
 
 /// Build embedding index for semantic search.
-pub fn cmd_rag_index(path: &str, force: bool, json: bool) -> Result<()> {
+pub fn cmd_rag_index(db_path: &Path, path: &str, force: bool, json: bool) -> Result<()> {
     // First ensure the standard code graph index is up to date
     let root = Path::new(path);
-    let db = open_db()?;
+    let db = open_db(db_path)?;
     let _index_result = indexer::index_directory(&db, root, false, false)?;
 
     let result = rag::indexer::index_embeddings(&db, force)?;
@@ -550,13 +574,14 @@ pub fn cmd_rag_index(path: &str, force: bool, json: bool) -> Result<()> {
 
 /// Semantic search over code symbols.
 pub fn cmd_rag_search(
+    db_path: &Path,
     query: &str,
     kind: Option<SymbolKindFilter>,
     limit: u32,
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db()?;
+    let db = open_db(db_path)?;
     let kind_filter = kind.map(crate::types::SymbolKind::from);
 
     let search_result = rag::search::hybrid_search(&db, query, limit, kind_filter)?;
@@ -609,13 +634,20 @@ pub fn cmd_rag_search(
 }
 
 /// Watch for file changes and auto-re-index.
-pub fn cmd_watch(path: &str, debounce: u64, rag: bool, rag_delay: u64) -> Result<()> {
+pub fn cmd_watch(
+    db_path: &Path,
+    path: &str,
+    debounce: u64,
+    rag: bool,
+    rag_delay: u64,
+) -> Result<()> {
     let mut config = WatchConfig::new(PathBuf::from(path));
     config.debounce = Duration::from_secs(debounce);
     config.rag = rag;
     config.rag_delay = Duration::from_secs(rag_delay);
 
-    watch::run_watch(config, DB_FILE)
+    let db_path_str = db_path.to_string_lossy();
+    watch::run_watch(config, &db_path_str)
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,118 @@
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+/// Top-level cartog configuration, loaded from `.cartog.toml`.
+///
+/// Priority (highest to lowest):
+/// 1. `--db` CLI flag / `CARTOG_DB` env var  (handled in main)
+/// 2. `.cartog.toml` at git root or cwd      (`database.path`)
+/// 3. Auto git-root detection                (no config needed)
+/// 4. cwd fallback
+#[derive(Debug, Default, Deserialize)]
+pub struct CartogConfig {
+    pub database: Option<DatabaseConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct DatabaseConfig {
+    /// Filesystem path to the cartog SQLite database. Supports `~` expansion.
+    pub path: Option<String>,
+}
+
+/// Load the local project config from `.cartog.toml`.
+pub fn load_config() -> CartogConfig {
+    local_config_path()
+        .and_then(|p| read_config(&p))
+        .unwrap_or_default()
+}
+
+/// Path to the local project config: `.cartog.toml` found by walking up from
+/// cwd to the git root. Returns `None` if no such file exists.
+fn local_config_path() -> Option<PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
+    loop {
+        let candidate = dir.join(".cartog.toml");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        // Stop searching once we reach the git root without finding a config.
+        if dir.join(".git").exists() {
+            return None;
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
+fn read_config(path: &Path) -> Option<CartogConfig> {
+    let text = std::fs::read_to_string(path).ok()?;
+    match toml::from_str::<CartogConfig>(&text) {
+        Ok(cfg) => Some(cfg),
+        Err(e) => {
+            // Use eprintln rather than tracing — tracing may not be initialised yet.
+            eprintln!("cartog: warning: failed to parse {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+/// Expand a leading `~/` to the user's home directory.
+pub fn expand_tilde(p: PathBuf) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_expand_tilde_with_home() {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| "/tmp".into());
+        let expanded = expand_tilde(PathBuf::from("~/foo/bar"));
+        assert_eq!(expanded, PathBuf::from(home).join("foo/bar"));
+    }
+
+    #[test]
+    fn test_expand_tilde_no_tilde() {
+        let p = PathBuf::from("/absolute/path");
+        assert_eq!(expand_tilde(p.clone()), p);
+    }
+
+    #[test]
+    fn test_read_config_valid_toml() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        fs::write(&cfg_path, "[database]\npath = \"/tmp/test.db\"\n").unwrap();
+        let cfg = read_config(&cfg_path).expect("should parse");
+        assert_eq!(
+            cfg.database.as_ref().unwrap().path.as_deref(),
+            Some("/tmp/test.db")
+        );
+    }
+
+    #[test]
+    fn test_read_config_missing_file_returns_none() {
+        let result = read_config(Path::new("/nonexistent/path/config.toml"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_config_empty_toml_returns_default() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        fs::write(&cfg_path, "").unwrap();
+        let cfg = read_config(&cfg_path).expect("empty toml is valid");
+        assert!(cfg.database.is_none());
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -120,6 +120,104 @@ pub const DB_FILE: &str = ".cartog.db";
 /// Enforced here and referenced by CLI and MCP layers.
 pub const MAX_SEARCH_LIMIT: u32 = 100;
 
+/// Resolve the database path using the following priority:
+///
+/// 1. `explicit` — from `--db` flag or `CARTOG_DB` env var (already merged by clap)
+/// 2. `config.database.path` — from `.cartog.toml` at git root / cwd
+/// 3. Auto git-root detection — walk up from cwd to `.git`, place DB there
+/// 4. cwd fallback — `.cartog.db` in the current directory
+pub fn resolve_db_path(
+    explicit: Option<std::path::PathBuf>,
+    config: &crate::config::CartogConfig,
+) -> std::path::PathBuf {
+    use crate::config::expand_tilde;
+
+    // 1. Explicit override (--db / CARTOG_DB)
+    if let Some(p) = explicit {
+        return expand_tilde(p);
+    }
+
+    // 2. Local project config
+    if let Some(path_str) = config.database.as_ref().and_then(|d| d.path.as_deref()) {
+        return expand_tilde(std::path::PathBuf::from(path_str));
+    }
+
+    // 3. Walk up to git root
+    if let Ok(mut dir) = std::env::current_dir() {
+        loop {
+            if dir.join(".git").exists() {
+                return dir.join(DB_FILE);
+            }
+            if !dir.pop() {
+                break;
+            }
+        }
+    }
+
+    // 4. Fallback: DB_FILE relative to cwd
+    std::path::PathBuf::from(DB_FILE)
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+    use crate::config::{CartogConfig, DatabaseConfig};
+
+    fn config_with_path(p: &str) -> CartogConfig {
+        CartogConfig {
+            database: Some(DatabaseConfig {
+                path: Some(p.to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn test_resolve_explicit_wins_over_config() {
+        let cfg = config_with_path("/config/path.db");
+        let result = resolve_db_path(Some(std::path::PathBuf::from("/explicit/path.db")), &cfg);
+        assert_eq!(result, std::path::PathBuf::from("/explicit/path.db"));
+    }
+
+    #[test]
+    fn test_resolve_config_path_used_when_no_explicit() {
+        let cfg = config_with_path("/config/proj.db");
+        let result = resolve_db_path(None, &cfg);
+        assert_eq!(result, std::path::PathBuf::from("/config/proj.db"));
+    }
+
+    #[test]
+    fn test_resolve_fallback_when_no_config_and_no_git() {
+        // In a temp dir with no .git and no config, should fall back to DB_FILE
+        let dir = tempfile::TempDir::new().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let result = resolve_db_path(None, &CartogConfig::default());
+        std::env::set_current_dir(original).unwrap();
+
+        assert_eq!(result, std::path::PathBuf::from(DB_FILE));
+    }
+
+    #[test]
+    fn test_resolve_git_root_detection() {
+        // Create a temp dir structure: root/.git, root/subdir/
+        let dir = tempfile::TempDir::new().unwrap();
+        let canonical_root = dir.path().canonicalize().unwrap();
+        let git_dir = dir.path().join(".git");
+        std::fs::create_dir(&git_dir).unwrap();
+        let subdir = dir.path().join("subdir");
+        std::fs::create_dir(&subdir).unwrap();
+
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&subdir).unwrap();
+
+        let result = resolve_db_path(None, &CartogConfig::default());
+        std::env::set_current_dir(original).unwrap();
+
+        assert_eq!(result, canonical_root.join(DB_FILE));
+    }
+}
+
 /// Split a symbol name into lowercase words for FTS5 indexing.
 ///
 /// Handles camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod db;
 pub mod indexer;
 pub mod languages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod mcp;
 
 // Re-export lib modules as crate-level so commands/cli/mcp can use crate::db, etc.
+pub use cartog::config;
 pub use cartog::db;
 pub use cartog::indexer;
 pub use cartog::languages;
@@ -19,6 +20,10 @@ use cli::{Cli, Command, RagCommand};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Resolve database path: --db / CARTOG_DB > .cartog.toml > git root > cwd
+    let cartog_config = config::load_config();
+    let db_path = db::resolve_db_path(cli.db.clone(), &cartog_config);
 
     let is_serve = matches!(cli.command, Command::Serve { .. });
     let is_watch = matches!(cli.command, Command::Watch { .. });
@@ -52,41 +57,55 @@ fn main() -> Result<()> {
             path,
             force,
             no_lsp,
-        } => commands::cmd_index(&path, force, !no_lsp, cli.json),
-        Command::Outline { file } => commands::cmd_outline(&file, cli.json, token_budget),
-        Command::Callees { name } => commands::cmd_callees(&name, cli.json, token_budget),
+        } => commands::cmd_index(&db_path, &path, force, !no_lsp, cli.json),
+        Command::Outline { file } => commands::cmd_outline(&db_path, &file, cli.json, token_budget),
+        Command::Callees { name } => commands::cmd_callees(&db_path, &name, cli.json, token_budget),
         Command::Impact { name, depth } => {
-            commands::cmd_impact(&name, depth, cli.json, token_budget)
+            commands::cmd_impact(&db_path, &name, depth, cli.json, token_budget)
         }
-        Command::Refs { name, kind } => commands::cmd_refs(&name, kind, cli.json, token_budget),
-        Command::Hierarchy { name } => commands::cmd_hierarchy(&name, cli.json, token_budget),
-        Command::Deps { file } => commands::cmd_deps(&file, cli.json, token_budget),
-        Command::Stats => commands::cmd_stats(cli.json),
+        Command::Refs { name, kind } => {
+            commands::cmd_refs(&db_path, &name, kind, cli.json, token_budget)
+        }
+        Command::Hierarchy { name } => {
+            commands::cmd_hierarchy(&db_path, &name, cli.json, token_budget)
+        }
+        Command::Deps { file } => commands::cmd_deps(&db_path, &file, cli.json, token_budget),
+        Command::Stats => commands::cmd_stats(&db_path, cli.json),
         Command::Search {
             query,
             kind,
             file,
             limit,
-        } => commands::cmd_search(&query, kind, file.as_deref(), limit, cli.json, token_budget),
-        Command::Map { tokens } => commands::cmd_map(tokens, cli.json),
+        } => commands::cmd_search(
+            &db_path,
+            &query,
+            kind,
+            file.as_deref(),
+            limit,
+            cli.json,
+            token_budget,
+        ),
+        Command::Map { tokens } => commands::cmd_map(&db_path, tokens, cli.json),
         Command::Changes { commits, kind } => {
-            commands::cmd_changes(commits, kind, cli.json, token_budget)
+            commands::cmd_changes(&db_path, commits, kind, cli.json, token_budget)
         }
         Command::Watch {
             path,
             debounce,
             rag,
             rag_delay,
-        } => commands::cmd_watch(&path, debounce, rag, rag_delay),
+        } => commands::cmd_watch(&db_path, &path, debounce, rag, rag_delay),
         Command::Serve { watch, rag } => {
             let runtime = tokio::runtime::Runtime::new()?;
-            runtime.block_on(mcp::run_server(watch, rag))
+            runtime.block_on(mcp::run_server(&db_path, watch, rag))
         }
         Command::Rag(rag_cmd) => match rag_cmd {
             RagCommand::Setup => commands::cmd_rag_setup(cli.json),
-            RagCommand::Index { path, force } => commands::cmd_rag_index(&path, force, cli.json),
+            RagCommand::Index { path, force } => {
+                commands::cmd_rag_index(&db_path, &path, force, cli.json)
+            }
             RagCommand::Search { query, kind, limit } => {
-                commands::cmd_rag_search(&query, kind, limit, cli.json, token_budget)
+                commands::cmd_rag_search(&db_path, &query, kind, limit, cli.json, token_budget)
             }
         },
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -13,7 +13,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use crate::db::{Database, DB_FILE, MAX_SEARCH_LIMIT};
+use crate::db::{Database, MAX_SEARCH_LIMIT};
 use crate::indexer;
 use crate::rag;
 use crate::types::EdgeKind;
@@ -233,9 +233,9 @@ pub struct CartogServer {
 
 #[tool_router]
 impl CartogServer {
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new(db_path: &std::path::Path) -> anyhow::Result<Self> {
         let db =
-            Database::open(DB_FILE).map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
+            Database::open(db_path).map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
         let cwd = std::env::current_dir()
             .and_then(|p| p.canonicalize())
             .map_err(|e| anyhow::anyhow!("cannot determine CWD: {e}"))?;
@@ -733,15 +733,16 @@ impl ServerHandler for CartogServer {
 ///
 /// When `watch` is true, a background file watcher keeps the index fresh.
 /// When `rag` is true (requires `watch`), embeddings are also auto-updated.
-pub async fn run_server(watch: bool, rag: bool) -> anyhow::Result<()> {
+pub async fn run_server(db_path: &std::path::Path, watch: bool, rag: bool) -> anyhow::Result<()> {
     info!("starting cartog MCP server v{}", env!("CARGO_PKG_VERSION"));
 
     // Optionally spawn a background file watcher
+    let db_path_str = db_path.to_string_lossy().into_owned();
     let _watch_handle: Option<WatchHandle> = if watch {
         let cwd = std::env::current_dir()?;
         let mut config = WatchConfig::new(cwd);
         config.rag = rag;
-        match watch::spawn_watch(config, DB_FILE) {
+        match watch::spawn_watch(config, &db_path_str) {
             Ok(handle) => {
                 info!(rag, "background file watcher started");
                 Some(handle)
@@ -755,7 +756,7 @@ pub async fn run_server(watch: bool, rag: bool) -> anyhow::Result<()> {
         None
     };
 
-    let server = CartogServer::new()?;
+    let server = CartogServer::new(db_path)?;
     let service = server.serve(stdio()).await?;
     service.waiting().await?;
 


### PR DESCRIPTION
## Summary

- Add configurable database path with 4-level priority: `--db` flag / `CARTOG_DB` env var > `.cartog.toml` > git-root auto-detection > cwd fallback
- New `src/config.rs` module for loading `.cartog.toml` with `[database] path` and `~` expansion
- Shell script `ensure_indexed.sh` updated to parse `.cartog.toml` (full parity with Rust binary)
- Fix flaky lock tests by using per-test `CARTOG_LOCK_DIR`

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` (default + lsp feature) clean
- [x] `cargo test` — 337 passed
- [x] `cargo test --features lsp` — 363 passed
- [x] `make check-skill` — 30 + 13 passed (includes 5 new TOML resolution tests)
- [x] `make check-fixtures` — all 5 languages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)