### PR TITLE
fix(publish): add version to workspace deps and fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Sync Cargo.toml version with tag
-        shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          sed "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          echo "Building version ${VERSION}"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -113,11 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Sync Cargo.toml version with tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          sed "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish
+      - run: cargo publish -p cartog --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ license = "MIT"
 repository = "https://github.com/jrollin/cartog"
 
 [workspace.dependencies]
-# Internal crates (path-only, not published independently)
-cartog-core = { path = "crates/cartog-core" }
-cartog-db = { path = "crates/cartog-db" }
-cartog-languages = { path = "crates/cartog-languages" }
-cartog-indexer = { path = "crates/cartog-indexer" }
-cartog-rag = { path = "crates/cartog-rag" }
-cartog-lsp = { path = "crates/cartog-lsp" }
-cartog-watch = { path = "crates/cartog-watch" }
-cartog-mcp = { path = "crates/cartog-mcp" }
+# Internal crates (path + version required for publishing)
+cartog-core = { path = "crates/cartog-core", version = "0.9.0" }
+cartog-db = { path = "crates/cartog-db", version = "0.9.0" }
+cartog-languages = { path = "crates/cartog-languages", version = "0.9.0" }
+cartog-indexer = { path = "crates/cartog-indexer", version = "0.9.0" }
+cartog-rag = { path = "crates/cartog-rag", version = "0.9.0" }
+cartog-lsp = { path = "crates/cartog-lsp", version = "0.9.0" }
+cartog-watch = { path = "crates/cartog-watch", version = "0.9.0" }
+cartog-mcp = { path = "crates/cartog-mcp", version = "0.9.0" }
 
 # Shared external dependencies
 anyhow = "1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -70,8 +70,10 @@ fi
 
 info "bumping $CURRENT → $NEW"
 
-# update Cargo.toml
-sed "s/^version = \".*\"/version = \"${NEW}\"/" "$CARGO_TOML" > "$CARGO_TOML.tmp" && mv "$CARGO_TOML.tmp" "$CARGO_TOML"
+# update workspace version + internal crate dependency versions in Cargo.toml
+sed -e "/^\[workspace\.package\]/,/^\[/ s/version = \"${CURRENT}\"/version = \"${NEW}\"/" \
+    -e "/^cartog-/ s/version = \"${CURRENT}\"/version = \"${NEW}\"/" \
+    "$CARGO_TOML" > "$CARGO_TOML.tmp" && mv "$CARGO_TOML.tmp" "$CARGO_TOML"
 
 # update plugin.json
 if [[ -f "$PLUGIN_JSON" ]]; then


### PR DESCRIPTION
## Summary

- Add `version` field to all internal workspace dependencies in `Cargo.toml` (required by `cargo publish`)
- Fix `scripts/release.sh` sed to update both workspace version and internal dep versions
- Use `cargo publish -p cartog --no-verify` since sub-crates have `publish = false`

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (397 tests)