### PR TITLE
feat: add `config` command to display current configuration

### DIFF
--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -153,6 +153,9 @@ pub enum Command {
     /// Index statistics summary
     Stats,
 
+    /// Display the current configuration
+    Config,
+
     /// Search symbols by name (case-insensitive prefix + substring match)
     Search {
         /// Query string to match against symbol names

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -673,8 +673,16 @@ pub fn cmd_rag_search(
 }
 
 /// Display the current configuration with default-value indicators.
-pub fn cmd_config(config: &CartogConfig, db_path: &Path, json: bool) -> Result<()> {
-    let config_file = crate::config::local_config_path();
+pub fn cmd_config(
+    config: &CartogConfig,
+    config_path: Option<&Path>,
+    db_path: &Path,
+    json: bool,
+) -> Result<()> {
+    use crate::config::{
+        DEFAULT_EMBEDDING_PROVIDER, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL,
+        DEFAULT_RERANKER_PROVIDER,
+    };
 
     let embed = config.embedding.as_ref();
     let ollama = embed.and_then(|e| e.ollama.as_ref());
@@ -682,13 +690,15 @@ pub fn cmd_config(config: &CartogConfig, db_path: &Path, json: bool) -> Result<(
     let reranker = config.reranker.as_ref();
 
     let display = ConfigDisplay {
-        config_file: config_file.map(|p| p.to_string_lossy().into_owned()),
+        config_file: config_path.map(|p| p.to_string_lossy().into_owned()),
         db_path: db_path.to_string_lossy().into_owned(),
         embedding: EmbeddingDisplay {
             provider: ValueDisplay {
-                value: embed.map_or("local".into(), |e| e.provider().to_string()),
+                value: embed.map_or(DEFAULT_EMBEDDING_PROVIDER.into(), |e| {
+                    e.provider().to_string()
+                }),
                 is_default: embed.map_or(true, |e| e.provider.is_none()),
-                default: "local".into(),
+                default: DEFAULT_EMBEDDING_PROVIDER.into(),
             },
             model: embed.and_then(|e| e.model.clone()),
             dimension: embed.and_then(|e| e.dimension),
@@ -698,24 +708,25 @@ pub fn cmd_config(config: &CartogConfig, db_path: &Path, json: bool) -> Result<(
             },
             ollama: OllamaDisplay {
                 base_url: ValueDisplay {
-                    value: ollama.map_or("http://localhost:11434".into(), |o| {
-                        o.base_url().to_string()
-                    }),
+                    value: ollama
+                        .map_or(DEFAULT_OLLAMA_BASE_URL.into(), |o| o.base_url().to_string()),
                     is_default: ollama.map_or(true, |o| o.base_url.is_none()),
-                    default: "http://localhost:11434".into(),
+                    default: DEFAULT_OLLAMA_BASE_URL.into(),
                 },
                 model: ValueDisplay {
-                    value: ollama.map_or("nomic-embed-text".into(), |o| o.model().to_string()),
+                    value: ollama.map_or(DEFAULT_OLLAMA_MODEL.into(), |o| o.model().to_string()),
                     is_default: ollama.map_or(true, |o| o.model.is_none()),
-                    default: "nomic-embed-text".into(),
+                    default: DEFAULT_OLLAMA_MODEL.into(),
                 },
             },
         },
         reranker: RerankerDisplay {
             provider: ValueDisplay {
-                value: reranker.map_or("local".into(), |r| r.provider().to_string()),
+                value: reranker.map_or(DEFAULT_RERANKER_PROVIDER.into(), |r| {
+                    r.provider().to_string()
+                }),
                 is_default: reranker.map_or(true, |r| r.provider.is_none()),
-                default: "local".into(),
+                default: DEFAULT_RERANKER_PROVIDER.into(),
             },
         },
     };
@@ -744,53 +755,63 @@ fn format_optional(v: &Option<String>) -> &str {
 }
 
 fn format_config_human(d: &ConfigDisplay) -> String {
+    use std::fmt::Write;
     let mut out = String::new();
 
-    out.push_str(&format!(
-        "Config file: {}\n",
+    let _ = writeln!(
+        out,
+        "Config file: {}",
         d.config_file.as_deref().unwrap_or("none")
-    ));
-    out.push_str(&format!("Database:    {}\n", d.db_path));
+    );
+    let _ = writeln!(out, "Database:    {}", d.db_path);
 
-    out.push_str("\n[embedding]\n");
-    out.push_str(&format!(
-        "  provider:          {}\n",
+    let _ = writeln!(out, "\n[embedding]");
+    let _ = writeln!(
+        out,
+        "  provider:          {}",
         format_value(&d.embedding.provider)
-    ));
-    out.push_str(&format!(
-        "  model:             {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  model:             {}",
         format_optional(&d.embedding.model)
-    ));
-    out.push_str(&format!(
-        "  dimension:         {}\n",
-        d.embedding.dimension.map_or("–".into(), |d| d.to_string())
-    ));
+    );
+    let _ = writeln!(
+        out,
+        "  dimension:         {}",
+        d.embedding.dimension.map_or("–".into(), |v| v.to_string())
+    );
 
-    out.push_str("\n[embedding.local]\n");
-    out.push_str(&format!(
-        "  query_prefix:      {}\n",
+    let _ = writeln!(out, "\n[embedding.local]");
+    let _ = writeln!(
+        out,
+        "  query_prefix:      {}",
         format_optional(&d.embedding.local.query_prefix)
-    ));
-    out.push_str(&format!(
-        "  document_prefix:   {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  document_prefix:   {}",
         format_optional(&d.embedding.local.document_prefix)
-    ));
+    );
 
-    out.push_str("\n[embedding.ollama]\n");
-    out.push_str(&format!(
-        "  base_url:          {}\n",
+    let _ = writeln!(out, "\n[embedding.ollama]");
+    let _ = writeln!(
+        out,
+        "  base_url:          {}",
         format_value(&d.embedding.ollama.base_url)
-    ));
-    out.push_str(&format!(
-        "  model:             {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  model:             {}",
         format_value(&d.embedding.ollama.model)
-    ));
+    );
 
-    out.push_str("\n[reranker]\n");
-    out.push_str(&format!(
-        "  provider:          {}\n",
+    let _ = writeln!(out, "\n[reranker]");
+    let _ = writeln!(
+        out,
+        "  provider:          {}",
         format_value(&d.reranker.provider)
-    ));
+    );
 
     out
 }

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::cli::{EdgeKindFilter, SymbolKindFilter};
+use crate::config::CartogConfig;
 use cartog_core::{EdgeKind, SymbolKind};
 use cartog_db::{Database, MAX_SEARCH_LIMIT};
 use cartog_indexer as indexer;
@@ -669,6 +670,170 @@ pub fn cmd_rag_search(
         }
         out
     })
+}
+
+/// Display the current configuration with default-value indicators.
+pub fn cmd_config(config: &CartogConfig, db_path: &Path, json: bool) -> Result<()> {
+    let config_file = crate::config::local_config_path();
+
+    let embed = config.embedding.as_ref();
+    let ollama = embed.and_then(|e| e.ollama.as_ref());
+    let local = embed.and_then(|e| e.local.as_ref());
+    let reranker = config.reranker.as_ref();
+
+    let display = ConfigDisplay {
+        config_file: config_file.map(|p| p.to_string_lossy().into_owned()),
+        db_path: db_path.to_string_lossy().into_owned(),
+        embedding: EmbeddingDisplay {
+            provider: ValueDisplay {
+                value: embed.map_or("local".into(), |e| e.provider().to_string()),
+                is_default: embed.map_or(true, |e| e.provider.is_none()),
+                default: "local".into(),
+            },
+            model: embed.and_then(|e| e.model.clone()),
+            dimension: embed.and_then(|e| e.dimension),
+            local: LocalEmbeddingDisplay {
+                query_prefix: local.and_then(|l| l.query_prefix.clone()),
+                document_prefix: local.and_then(|l| l.document_prefix.clone()),
+            },
+            ollama: OllamaDisplay {
+                base_url: ValueDisplay {
+                    value: ollama.map_or("http://localhost:11434".into(), |o| {
+                        o.base_url().to_string()
+                    }),
+                    is_default: ollama.map_or(true, |o| o.base_url.is_none()),
+                    default: "http://localhost:11434".into(),
+                },
+                model: ValueDisplay {
+                    value: ollama.map_or("nomic-embed-text".into(), |o| o.model().to_string()),
+                    is_default: ollama.map_or(true, |o| o.model.is_none()),
+                    default: "nomic-embed-text".into(),
+                },
+            },
+        },
+        reranker: RerankerDisplay {
+            provider: ValueDisplay {
+                value: reranker.map_or("local".into(), |r| r.provider().to_string()),
+                is_default: reranker.map_or(true, |r| r.provider.is_none()),
+                default: "local".into(),
+            },
+        },
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&display)?);
+    } else {
+        print!("{}", format_config_human(&display));
+    }
+    Ok(())
+}
+
+fn format_value(v: &ValueDisplay) -> String {
+    if v.is_default {
+        format!("{} (default)", v.value)
+    } else {
+        format!("{} (default: {})", v.value, v.default)
+    }
+}
+
+fn format_optional(v: &Option<String>) -> &str {
+    match v {
+        Some(s) => s.as_str(),
+        None => "–",
+    }
+}
+
+fn format_config_human(d: &ConfigDisplay) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!(
+        "Config file: {}\n",
+        d.config_file.as_deref().unwrap_or("none")
+    ));
+    out.push_str(&format!("Database:    {}\n", d.db_path));
+
+    out.push_str("\n[embedding]\n");
+    out.push_str(&format!(
+        "  provider:          {}\n",
+        format_value(&d.embedding.provider)
+    ));
+    out.push_str(&format!(
+        "  model:             {}\n",
+        format_optional(&d.embedding.model)
+    ));
+    out.push_str(&format!(
+        "  dimension:         {}\n",
+        d.embedding.dimension.map_or("–".into(), |d| d.to_string())
+    ));
+
+    out.push_str("\n[embedding.local]\n");
+    out.push_str(&format!(
+        "  query_prefix:      {}\n",
+        format_optional(&d.embedding.local.query_prefix)
+    ));
+    out.push_str(&format!(
+        "  document_prefix:   {}\n",
+        format_optional(&d.embedding.local.document_prefix)
+    ));
+
+    out.push_str("\n[embedding.ollama]\n");
+    out.push_str(&format!(
+        "  base_url:          {}\n",
+        format_value(&d.embedding.ollama.base_url)
+    ));
+    out.push_str(&format!(
+        "  model:             {}\n",
+        format_value(&d.embedding.ollama.model)
+    ));
+
+    out.push_str("\n[reranker]\n");
+    out.push_str(&format!(
+        "  provider:          {}\n",
+        format_value(&d.reranker.provider)
+    ));
+
+    out
+}
+
+#[derive(Serialize)]
+struct ConfigDisplay {
+    config_file: Option<String>,
+    db_path: String,
+    embedding: EmbeddingDisplay,
+    reranker: RerankerDisplay,
+}
+
+#[derive(Serialize)]
+struct EmbeddingDisplay {
+    provider: ValueDisplay,
+    model: Option<String>,
+    dimension: Option<usize>,
+    local: LocalEmbeddingDisplay,
+    ollama: OllamaDisplay,
+}
+
+#[derive(Serialize)]
+struct LocalEmbeddingDisplay {
+    query_prefix: Option<String>,
+    document_prefix: Option<String>,
+}
+
+#[derive(Serialize)]
+struct OllamaDisplay {
+    base_url: ValueDisplay,
+    model: ValueDisplay,
+}
+
+#[derive(Serialize)]
+struct RerankerDisplay {
+    provider: ValueDisplay,
+}
+
+#[derive(Serialize)]
+struct ValueDisplay {
+    value: String,
+    is_default: bool,
+    default: String,
 }
 
 /// Watch for file changes and auto-re-index.

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -36,9 +36,13 @@ pub struct EmbeddingConfig {
     pub ollama: Option<OllamaConfig>,
 }
 
+pub const DEFAULT_EMBEDDING_PROVIDER: &str = "local";
+
 impl EmbeddingConfig {
     pub fn provider(&self) -> &str {
-        self.provider.as_deref().unwrap_or("local")
+        self.provider
+            .as_deref()
+            .unwrap_or(DEFAULT_EMBEDDING_PROVIDER)
     }
 }
 
@@ -58,13 +62,16 @@ pub struct OllamaConfig {
     pub model: Option<String>,
 }
 
+pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434";
+pub const DEFAULT_OLLAMA_MODEL: &str = "nomic-embed-text";
+
 impl OllamaConfig {
     pub fn base_url(&self) -> &str {
-        self.base_url.as_deref().unwrap_or("http://localhost:11434")
+        self.base_url.as_deref().unwrap_or(DEFAULT_OLLAMA_BASE_URL)
     }
 
     pub fn model(&self) -> &str {
-        self.model.as_deref().unwrap_or("nomic-embed-text")
+        self.model.as_deref().unwrap_or(DEFAULT_OLLAMA_MODEL)
     }
 }
 
@@ -74,9 +81,13 @@ pub struct RerankerConfig {
     pub provider: Option<String>,
 }
 
+pub const DEFAULT_RERANKER_PROVIDER: &str = "local";
+
 impl RerankerConfig {
     pub fn provider(&self) -> &str {
-        self.provider.as_deref().unwrap_or("local")
+        self.provider
+            .as_deref()
+            .unwrap_or(DEFAULT_RERANKER_PROVIDER)
     }
 }
 
@@ -111,15 +122,20 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
 }
 
 /// Load the local project config from `.cartog.toml`.
-pub fn load_config() -> CartogConfig {
-    local_config_path()
-        .and_then(|p| read_config(&p))
-        .unwrap_or_default()
+/// Returns the parsed config and the path it was loaded from (if any).
+pub fn load_config() -> (CartogConfig, Option<PathBuf>) {
+    match local_config_path() {
+        Some(p) => {
+            let cfg = read_config(&p).unwrap_or_default();
+            (cfg, Some(p))
+        }
+        None => (CartogConfig::default(), None),
+    }
 }
 
 /// Path to the local project config: `.cartog.toml` found by walking up from
 /// cwd to the git root. Returns `None` if no such file exists.
-pub fn local_config_path() -> Option<PathBuf> {
+fn local_config_path() -> Option<PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
     loop {
         let candidate = dir.join(".cartog.toml");

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -119,7 +119,7 @@ pub fn load_config() -> CartogConfig {
 
 /// Path to the local project config: `.cartog.toml` found by walking up from
 /// cwd to the git root. Returns `None` if no such file exists.
-fn local_config_path() -> Option<PathBuf> {
+pub fn local_config_path() -> Option<PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
     loop {
         let candidate = dir.join(".cartog.toml");

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> Result<()> {
         }
         Command::Deps { file } => commands::cmd_deps(&db_path, &file, cli.json, token_budget),
         Command::Stats => commands::cmd_stats(&db_path, cli.json),
+        Command::Config => commands::cmd_config(&cartog_config, &db_path, cli.json),
         Command::Search {
             query,
             kind,

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Resolve database path: --db / CARTOG_DB > .cartog.toml > git root > cwd
-    let cartog_config = config::load_config();
+    let (cartog_config, config_path) = config::load_config();
     let db_path = config::resolve_db_path(cli.db.clone(), &cartog_config);
     let provider_config = config::to_provider_config(&cartog_config);
 
@@ -62,7 +62,9 @@ fn main() -> Result<()> {
         }
         Command::Deps { file } => commands::cmd_deps(&db_path, &file, cli.json, token_budget),
         Command::Stats => commands::cmd_stats(&db_path, cli.json),
-        Command::Config => commands::cmd_config(&cartog_config, &db_path, cli.json),
+        Command::Config => {
+            commands::cmd_config(&cartog_config, config_path.as_deref(), &db_path, cli.json)
+        }
         Command::Search {
             query,
             kind,


### PR DESCRIPTION
## Summary

- Add a new `cartog config` CLI command that displays the currently loaded configuration
- Shows default value indicators: `(default)` when using built-in default, `(default: <value>)` when overridden
- Supports both human-readable and `--json` output formats
- Extract default constants (`DEFAULT_EMBEDDING_PROVIDER`, `DEFAULT_OLLAMA_BASE_URL`, etc.) in `config.rs` as single source of truth
- Return config file path from `load_config()` to avoid redundant filesystem walks

## Test plan

- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p cartog` — 31/31 passing
- [x] Manual: `cartog config` with no `.cartog.toml` shows all defaults
- [x] Manual: `cartog config` with overrides shows `(default: <value>)` annotations
- [x] Manual: `cartog config --json` outputs structured JSON with `is_default` flags

https://claude.ai/code/session_01DmKR4MZKxMdfJ4GKGaAqT8