### PR TITLE
feat(rag): multi-provider embeddings with bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ cargo clippy --all-targets -- -D warnings  # lint
 
 Always run `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` before committing.
 
+```bash
+cargo check --no-default-features -p cartog-rag     # verify builds without ONNX
+cargo check --features provider-ollama -p cartog-rag # verify Ollama feature
+```
+
 ### Integrity checks
 
 ```bash
@@ -125,4 +130,6 @@ After implementation, mark checklist items complete — the spec stays as a desi
 - **AST-aware embeddings**: significant body lines (skip blanks/comments/braces) for better vector search recall
 - **Embedding format versioning**: auto-detects embedding strategy changes, triggers re-embed on next `rag index`
 - **Schema versioning**: metadata-based migration system for DB schema evolution
+- **Pluggable embedding providers**: local ONNX (default) and Ollama, configured via `.cartog.toml`
+- **Feature flags**: `provider-local` (default), `provider-ollama`
 - **Pending**: Java extractor improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "sqlite-vec",
+ "tempfile",
  "tracing",
 ]
 
@@ -308,7 +309,9 @@ dependencies = [
  "cartog-core",
  "cartog-db",
  "fastembed",
+ "reqwest",
  "serde",
+ "serde_json",
  "tracing",
 ]
 
@@ -2151,6 +2154,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ ctrlc = "3"
 clap = { version = "4", features = ["derive", "env"] }
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 url = "2"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Indexes both **code** (functions, classes, methods) and **Markdown documents** (
 
 Models are downloaded once to `~/.cache/cartog/models/` and run locally via ONNX Runtime. No API keys, no network calls at query time.
 
+> **Using Ollama instead?** Configure `.cartog.toml` with `[embedding] provider = "ollama"` and skip `rag setup` — models are managed by Ollama. See [Configuration](#configuration).
+
 ## Install
 
 ### From crates.io
@@ -66,6 +68,7 @@ Models are downloaded once to `~/.cache/cartog/models/` and run locally via ONNX
 ```bash
 cargo install cartog                    # core (heuristic resolution only)
 cargo install cartog --features lsp     # + LSP-based resolution (recommended)
+cargo install cartog --features ollama-embedding  # + Ollama embedding support
 ```
 
 The `lsp` feature adds ~50KB to the binary. It auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph) and uses them to resolve edges that heuristic matching can't. No extra config needed — if a server is on PATH, it's used automatically.
@@ -116,6 +119,18 @@ cartog --db /tmp/x.db stats
 ```toml
 [database]
 path = "~/.local/share/cartog/myproject.db"
+
+# Embedding provider (optional — defaults to local ONNX)
+[embedding]
+provider = "ollama"          # "local" (default) or "ollama"
+model = "nomic-embed-text"
+
+[embedding.ollama]
+base_url = "http://localhost:11434"
+
+# Reranker (optional — defaults to local cross-encoder)
+[reranker]
+provider = "none"            # "local" (default) or "none"
 ```
 
 Useful when indexing from a parent directory across multiple projects, or when storing the DB outside the repo. See [`docs/usage.md`](docs/usage.md) for details.
@@ -246,7 +261,7 @@ graph LR
 2. **Store** — writes everything to a local `.cartog.db` SQLite file
 3. **Resolve (heuristic)** — links edges by name with scope-aware matching (same file > import path > same directory > unique project match)
 4. **Resolve (LSP, optional)** — for edges the heuristic couldn't resolve, sends `textDocument/definition` to language servers for compiler-grade precision. Results persist in the DB.
-5. **Embed** (optional) — generates vector embeddings locally with ONNX Runtime (`BAAI/bge-small-en-v1.5`), stored in sqlite-vec
+5. **Embed** (optional) — generates vector embeddings via configurable provider (local ONNX or Ollama), stored in sqlite-vec
 6. **Query** — instant lookups against the pre-computed graph, hybrid FTS5 + vector search with RRF merge and cross-encoder re-ranking
 
 Re-indexing is incremental: git diff + SHA-256 skips unchanged files, and Merkle-tree diffing within changed files updates only modified symbols. `cartog watch` automates this on file changes.
@@ -364,7 +379,7 @@ Remaining unresolved edges are mostly calls to external libraries (std, node_mod
 - **Two-tier resolution** — fast heuristic pass (~1s) for daily use, optional LSP for precision refactoring. Results persist in SQLite — pay the LSP cost once.
 - **Self-contained** — single binary, all dependencies compiled in. LSP is opt-in via language servers already on your PATH.
 - **Incremental** — git diff + SHA256 per file, Merkle-tree diff per symbol. Stable IDs survive line movements.
-- **Local-first** — embedding models run via ONNX Runtime on your CPU. Slower than API calls, but your code stays private.
+- **Local-first** — embedding models run locally via ONNX Runtime by default. Alternatively, use Ollama for GPU acceleration. Either way, your code stays private — no external API calls.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cartog
+# Cartog
 
 [![CI](https://github.com/jrollin/cartog/actions/workflows/ci.yml/badge.svg)](https://github.com/jrollin/cartog/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/jrollin/cartog/branch/main/graph/badge.svg)](https://codecov.io/gh/jrollin/cartog)
@@ -9,30 +9,36 @@
 
 **Map your codebase. Navigate by graph, not grep.**
 
-cartog gives your AI coding agent a pre-computed code graph — symbols, calls, imports, inheritance — so it queries structure in 1-2 calls instead of 6+. Everything runs locally: no API calls, no cloud, no data leaves your machine.
+Cartog pre-computes a code graph — symbols, calls, imports, inheritance — and lets you query it in microseconds. Use it from the CLI, as an MCP server for AI agents, or both. Everything runs locally: no API calls, no cloud, no data leaves your machine.
 
-## Why cartog
+> **[Documentation site →](https://jrollin.github.io/cartog/)**
 
-| | grep/cat workflow | cartog |
+## Why Cartog
+
+| | grep/cat/find | Cartog |
 |---|---|---|
-| **Tokens per query** | ~1,700 | ~280 (**83% fewer**) |
+| **Query latency** | multi-step | 8-450 μs |
 | **Recall** (completeness) | 78% | 97% |
-| **Query latency** | multi-step | 8-450 us |
-| **Privacy** | n/a | **100% local** — no remote calls |
 | **Transitive analysis** | impossible | `impact --depth 3` traces callers-of-callers |
-
-Where cartog shines most: tracing call chains (88% token reduction, 35% grep recall vs 100% cartog), finding callers (95% reduction), and type references (93% reduction).
+| **Semantic search** | no | local ONNX / Ollama |
+| **Privacy** | local | **100% local** — no remote calls |
 
 Measured across 13 scenarios, 5 languages ([full benchmark suite](benchmarks/)).
 
-### What you get immediately
+### What you get
 
 - **Single binary, self-contained** — `cargo install cartog` and you're done. No Docker, no config.
-- **100% offline** — tree-sitter parsing + SQLite storage + ONNX embeddings. Your code never leaves your machine, ever.
-- **Optional LSP precision** — auto-detects language servers on PATH to boost edge resolution from ~25% to ~42-81%. Works without them, better with them.
-- **Smart search routing** — keyword search (sub-ms, symbol names) and semantic search (natural language queries) work together. Run both in parallel when unsure.
-- **Live index** — `cartog watch` auto re-indexes on file changes. Your agent always queries fresh data.
+- **100% local** — tree-sitter parsing + SQLite storage + local embeddings. Your code never leaves your machine.
+- **Dual search** — keyword search (sub-ms, symbol names) and semantic search (natural language). Configurable embedding providers (local ONNX or [Ollama](https://ollama.com)).
+- **Impact analysis** — `cartog impact --depth 3` traces callers-of-callers. Know the blast radius before you change anything.
+- **Live index** — `cartog watch` auto re-indexes on file changes. Always query fresh data.
+- **Optional LSP precision** — auto-detects language servers on PATH to boost edge resolution from ~25% to ~42-81%.
+
+### For LLM agents
+
 - **MCP server** — `cartog serve` exposes 12 tools over stdio. Plug into Claude Code, Cursor, Windsurf, Zed, or any MCP-compatible agent.
+- **Agent skill** — teaches your agent when and how to use Cartog. Search routing, refactoring workflows, fallback heuristics.
+- **Token efficient** — 83% fewer tokens per query vs grep/cat workflows. One `refs` call replaces 6+ discovery steps.
 
 ![cartog demo](docs/demo.gif)
 
@@ -318,11 +324,11 @@ The skill teaches your AI agent **when and how** to use cartog — including sea
 
 ## Privacy
 
-cartog is designed for air-gapped and privacy-conscious environments:
+Cartog is designed for air-gapped and privacy-conscious environments:
 
 - **Parsing**: tree-sitter runs in-process, no external calls
 - **Storage**: SQLite file in your project directory (`.cartog.db`)
-- **Embeddings**: ONNX Runtime inference, models cached locally (`~/.cache/cartog/models/`)
+- **Embeddings**: local ONNX by default (`~/.cache/cartog/models/`), or Ollama on localhost — no external API calls either way
 - **Re-ranking**: cross-encoder runs locally via ONNX, no API
 - **MCP server**: communicates over stdio only, no network sockets
 - **No telemetry**, no analytics, no phone-home of any kind
@@ -383,7 +389,8 @@ Remaining unresolved edges are mostly calls to external libraries (std, node_mod
 
 ## Documentation
 
-- [Usage](docs/usage.md)
+- **[Documentation site](https://jrollin.github.io/cartog/)** — quick start, CLI reference, configuration, MCP setup
+- [Usage](docs/usage.md) — full CLI reference and integration guides
 - [Product Overview](docs/product.md)
 - [Technology Stack](docs/tech.md)
 - [Project Structure](docs/structure.md)

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Symbol {
     pub id: String,
     pub name: String,
@@ -198,7 +198,7 @@ impl std::fmt::Display for Visibility {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Edge {
     pub source_id: String,
     pub target_name: String,
@@ -286,7 +286,6 @@ pub struct FileInfo {
     pub num_symbols: u32,
 }
 
-/// Result of a recent-changes query: changed files and their indexed symbols.
 #[derive(Debug, Clone, Serialize)]
 pub struct ChangesResult {
     pub changed_files: Vec<String>,

--- a/crates/cartog-db/Cargo.toml
+++ b/crates/cartog-db/Cargo.toml
@@ -14,3 +14,6 @@ rusqlite = { workspace = true }
 serde = { workspace = true }
 sqlite-vec = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/cartog-db/README.md
+++ b/crates/cartog-db/README.md
@@ -19,7 +19,7 @@ Four core tables plus four RAG-specific tables:
 - **`symbol_content`** — raw source code per symbol (for FTS and embedding)
 - **`symbol_fts`** — FTS5 virtual table over symbol names and content (BM25 ranking)
 - **`symbol_embedding_map`** — maps integer rowids (for sqlite-vec) to symbol IDs
-- **`symbol_vec`** — sqlite-vec virtual table with 384-dim float32 vectors for KNN search
+- **`symbol_vec`** — sqlite-vec virtual table with float32 vectors for KNN search. The vector dimension is configurable via `.cartog.toml` (default: 384). When the configured dimension changes, the vector table is automatically recreated.
 
 ### Edge resolution (6-tier heuristic)
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -428,11 +428,13 @@ impl Database {
 
     /// Remove all symbols, edges, and RAG data for a file (before re-indexing it).
     pub fn clear_file_data(&self, path: &str) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
         self.clear_rag_data_for_file(path)?;
         self.conn
             .execute("DELETE FROM edges WHERE file_path = ?1", params![path])?;
         self.conn
             .execute("DELETE FROM symbols WHERE file_path = ?1", params![path])?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -535,14 +537,13 @@ impl Database {
 
     /// Delete a single symbol and cascade to edges, content, and embeddings.
     pub fn delete_symbol(&self, id: &str) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
         self.conn
             .execute("DELETE FROM edges WHERE source_id = ?1", params![id])?;
-        // Also clean up edges that target this symbol
         self.conn.execute(
             "UPDATE edges SET target_id = NULL WHERE target_id = ?1",
             params![id],
         )?;
-        // Clean RAG data — delete vector embedding BEFORE removing the map entry
         let _ = self.conn.execute(
             "DELETE FROM symbol_vec WHERE rowid IN \
              (SELECT id FROM symbol_embedding_map WHERE symbol_id = ?1)",
@@ -558,6 +559,7 @@ impl Database {
         );
         self.conn
             .execute("DELETE FROM symbols WHERE id = ?1", params![id])?;
+        tx.commit()?;
         Ok(())
     }
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -283,11 +283,20 @@ fn handle_embedding_dimension(conn: &Connection, requested_dim: usize) -> Result
         )
         .ok();
 
+    // When the caller passes the default dimension and a different dimension is
+    // already stored, preserve the stored one. This avoids non-RAG commands
+    // (which don't know the real provider dimension) from silently wiping a
+    // vector index created by an Ollama provider with auto-detected dimension.
+    let effective_dim = match stored_dim {
+        Some(old) if requested_dim == DEFAULT_EMBEDDING_DIM && old != DEFAULT_EMBEDDING_DIM => old,
+        _ => requested_dim,
+    };
+
     if let Some(old_dim) = stored_dim {
-        if old_dim != requested_dim {
+        if old_dim != effective_dim {
             tracing::warn!(
                 old = old_dim,
-                new = requested_dim,
+                new = effective_dim,
                 "Embedding dimension changed — clearing vector index. Run `cartog rag index` to re-embed."
             );
             conn.execute("DROP TABLE IF EXISTS symbol_vec", [])
@@ -297,12 +306,12 @@ fn handle_embedding_dimension(conn: &Connection, requested_dim: usize) -> Result
         }
     }
 
-    conn.execute_batch(&rag_vec_schema(requested_dim))
+    conn.execute_batch(&rag_vec_schema(effective_dim))
         .context("Failed to create sqlite-vec table")?;
 
     conn.execute(
         "INSERT OR REPLACE INTO metadata (key, value) VALUES ('embedding_dimension', ?1)",
-        params![requested_dim.to_string()],
+        params![effective_dim.to_string()],
     )
     .context("Failed to store embedding dimension")?;
 
@@ -3266,6 +3275,63 @@ mod tests {
         {
             let db = Database::open(&db_path, 384).unwrap();
             assert_eq!(db.embedding_count().unwrap(), 1);
+        }
+    }
+
+    #[test]
+    fn test_default_dim_preserves_stored_non_default() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // First open with non-default dimension (e.g. Ollama auto-detected 768)
+        {
+            let db = Database::open(&db_path, 768).unwrap();
+            let sym = Symbol::new("baz", SymbolKind::Function, "c.py", 1, 10, 0, 100, None);
+            db.insert_symbol(&sym).unwrap();
+            db.upsert_symbol_content(&sym.id, "baz", "def baz():", "header")
+                .unwrap();
+            let eid = db.get_or_create_embedding_id(&sym.id).unwrap();
+            let bytes = vec![0u8; 768 * 4];
+            db.insert_embeddings(&[(eid, bytes)]).unwrap();
+        }
+
+        // Reopen with DEFAULT_EMBEDDING_DIM (384) — must preserve 768-dim embeddings
+        {
+            let db = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+            assert_eq!(db.embedding_count().unwrap(), 1);
+            let stored: i64 = db
+                .conn
+                .query_row(
+                    "SELECT CAST(value AS INTEGER) FROM metadata WHERE key = 'embedding_dimension'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(stored, 768);
+        }
+    }
+
+    #[test]
+    fn test_explicit_non_default_dim_wipes_different_stored() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // First open with 768
+        {
+            let db = Database::open(&db_path, 768).unwrap();
+            let sym = Symbol::new("qux", SymbolKind::Function, "d.py", 1, 10, 0, 100, None);
+            db.insert_symbol(&sym).unwrap();
+            db.upsert_symbol_content(&sym.id, "qux", "def qux():", "header")
+                .unwrap();
+            let eid = db.get_or_create_embedding_id(&sym.id).unwrap();
+            let bytes = vec![0u8; 768 * 4];
+            db.insert_embeddings(&[(eid, bytes)]).unwrap();
+        }
+
+        // Reopen with explicit 1536 — this IS a real dimension change, must wipe
+        {
+            let db = Database::open(&db_path, 1536).unwrap();
+            assert_eq!(db.embedding_count().unwrap(), 0);
         }
     }
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -340,8 +340,8 @@ impl Database {
             .context("Failed to create schema")?;
         conn.execute_batch(RAG_SCHEMA)
             .context("Failed to create RAG schema")?;
-        handle_embedding_dimension(&conn, embedding_dim)?;
         migrate(&conn);
+        handle_embedding_dimension(&conn, embedding_dim)?;
         Ok(Self { conn })
     }
 
@@ -1320,29 +1320,31 @@ impl Database {
         if symbol_ids.is_empty() {
             return Ok(result);
         }
-        let placeholders: Vec<&str> = symbol_ids.iter().map(|_| "?").collect();
-        let sql = format!(
-            "SELECT symbol_id, content, header FROM symbol_content WHERE symbol_id IN ({})",
-            placeholders.join(",")
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<Box<dyn rusqlite::types::ToSql>> = symbol_ids
-            .iter()
-            .map(|id| Box::new(id.clone()) as Box<dyn rusqlite::types::ToSql>)
-            .collect();
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            params.iter().map(|p| p.as_ref()).collect();
-        let rows = stmt
-            .query_map(param_refs.as_slice(), |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                ))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        for (id, content, header) in rows {
-            result.insert(id, (content, header));
+        for chunk in symbol_ids.chunks(Self::FILE_CHUNK_SIZE) {
+            let placeholders: Vec<&str> = chunk.iter().map(|_| "?").collect();
+            let sql = format!(
+                "SELECT symbol_id, content, header FROM symbol_content WHERE symbol_id IN ({})",
+                placeholders.join(",")
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params: Vec<Box<dyn rusqlite::types::ToSql>> = chunk
+                .iter()
+                .map(|id| Box::new(id.clone()) as Box<dyn rusqlite::types::ToSql>)
+                .collect();
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            let rows = stmt
+                .query_map(param_refs.as_slice(), |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            for (id, content, header) in rows {
+                result.insert(id, (content, header));
+            }
         }
         Ok(result)
     }
@@ -1412,23 +1414,26 @@ impl Database {
         if embedding_ids.is_empty() {
             return Ok(Vec::new());
         }
-        // Use a temporary approach for variable-length IN clause
-        let placeholders: Vec<String> = embedding_ids.iter().map(|_| "?".to_string()).collect();
-        let sql = format!(
-            "SELECT id, symbol_id FROM symbol_embedding_map WHERE id IN ({})",
-            placeholders.join(",")
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<Box<dyn rusqlite::types::ToSql>> = embedding_ids
-            .iter()
-            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
-            .collect();
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            params.iter().map(|p| p.as_ref()).collect();
-        let rows = stmt
-            .query_map(param_refs.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        Ok(rows)
+        let mut all_results = Vec::with_capacity(embedding_ids.len());
+        for chunk in embedding_ids.chunks(Self::FILE_CHUNK_SIZE) {
+            let placeholders: Vec<String> = chunk.iter().map(|_| "?".to_string()).collect();
+            let sql = format!(
+                "SELECT id, symbol_id FROM symbol_embedding_map WHERE id IN ({})",
+                placeholders.join(",")
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params: Vec<Box<dyn rusqlite::types::ToSql>> = chunk
+                .iter()
+                .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+                .collect();
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            let rows = stmt
+                .query_map(param_refs.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            all_results.extend(rows);
+        }
+        Ok(all_results)
     }
 
     // ── RAG: Vector Storage (sqlite-vec) ──

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -118,9 +118,13 @@ CREATE TABLE IF NOT EXISTS symbol_embedding_map (
 CREATE INDEX IF NOT EXISTS idx_embedding_map_symbol ON symbol_embedding_map(symbol_id);
 "#;
 
-/// SQL to create the sqlite-vec virtual table (must run after sqlite-vec extension is loaded).
-const RAG_VEC_SCHEMA: &str =
-    "CREATE VIRTUAL TABLE IF NOT EXISTS symbol_vec USING vec0(embedding float[384])";
+/// Default embedding dimension (BGE-small-en-v1.5).
+pub const DEFAULT_EMBEDDING_DIM: usize = 384;
+
+/// SQL to create the sqlite-vec virtual table with the given embedding dimension.
+fn rag_vec_schema(dim: usize) -> String {
+    format!("CREATE VIRTUAL TABLE IF NOT EXISTS symbol_vec USING vec0(embedding float[{dim}])")
+}
 
 /// Default database filename, stored in the project root.
 pub const DB_FILE: &str = ".cartog.db";
@@ -268,9 +272,50 @@ fn migrate(conn: &Connection) {
     }
 }
 
+/// Check stored embedding dimension against requested dimension.
+/// If they differ, drop the vector table and clear the embedding map.
+fn handle_embedding_dimension(conn: &Connection, requested_dim: usize) -> Result<()> {
+    let stored_dim: Option<usize> = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM metadata WHERE key = 'embedding_dimension'",
+            [],
+            |row| row.get::<_, i64>(0).map(|v| v as usize),
+        )
+        .ok();
+
+    if let Some(old_dim) = stored_dim {
+        if old_dim != requested_dim {
+            tracing::warn!(
+                old = old_dim,
+                new = requested_dim,
+                "Embedding dimension changed — clearing vector index. Run `cartog rag index` to re-embed."
+            );
+            conn.execute("DROP TABLE IF EXISTS symbol_vec", [])
+                .context("Failed to drop old vector table during dimension migration")?;
+            conn.execute("DELETE FROM symbol_embedding_map", [])
+                .context("Failed to clear embedding map during dimension migration")?;
+        }
+    }
+
+    conn.execute_batch(&rag_vec_schema(requested_dim))
+        .context("Failed to create sqlite-vec table")?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('embedding_dimension', ?1)",
+        params![requested_dim.to_string()],
+    )
+    .context("Failed to store embedding dimension")?;
+
+    Ok(())
+}
+
 impl Database {
     /// Open or create the database at the given path.
-    pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self> {
+    ///
+    /// `embedding_dim` sets the vector dimension for the sqlite-vec table.
+    /// If the stored dimension differs from the requested one, the vector index
+    /// is cleared and recreated (a re-index via `cartog rag index` is needed).
+    pub fn open(path: impl AsRef<std::path::Path>, embedding_dim: usize) -> Result<Self> {
         register_sqlite_vec();
         let conn = Connection::open(path.as_ref()).context("Failed to open database")?;
         conn.execute_batch(
@@ -286,8 +331,7 @@ impl Database {
             .context("Failed to create schema")?;
         conn.execute_batch(RAG_SCHEMA)
             .context("Failed to create RAG schema")?;
-        conn.execute_batch(RAG_VEC_SCHEMA)
-            .context("Failed to create sqlite-vec table")?;
+        handle_embedding_dimension(&conn, embedding_dim)?;
         migrate(&conn);
         Ok(Self { conn })
     }
@@ -300,7 +344,7 @@ impl Database {
         conn.execute_batch("PRAGMA foreign_keys=ON;")?;
         conn.execute_batch(SCHEMA)?;
         conn.execute_batch(RAG_SCHEMA)?;
-        conn.execute_batch(RAG_VEC_SCHEMA)?;
+        conn.execute_batch(&rag_vec_schema(DEFAULT_EMBEDDING_DIM))?;
         migrate(&conn);
         Ok(Self { conn })
     }
@@ -3154,5 +3198,79 @@ mod tests {
         // foo should still have in_degree = 2 (recomputed correctly)
         let results = db.search("foo", None, None, 10).unwrap();
         assert_eq!(results[0].in_degree, 2);
+    }
+
+    // ── Embedding dimension migration tests ──
+
+    #[test]
+    fn test_open_stores_embedding_dimension() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        let db = Database::open(&db_path, 384).unwrap();
+        let stored: String = db
+            .get_metadata("embedding_dimension")
+            .unwrap()
+            .expect("dimension should be stored");
+        assert_eq!(stored, "384");
+    }
+
+    #[test]
+    fn test_open_with_different_dimension_clears_embeddings() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // First open with 384-dim
+        {
+            let db = Database::open(&db_path, 384).unwrap();
+            let sym = Symbol::new("foo", SymbolKind::Function, "a.py", 1, 10, 0, 100, None);
+            db.insert_symbol(&sym).unwrap();
+            db.upsert_symbol_content(&sym.id, "foo", "def foo():", "header")
+                .unwrap();
+            let eid = db.get_or_create_embedding_id(&sym.id).unwrap();
+            let bytes = vec![0u8; 384 * 4];
+            db.insert_embeddings(&[(eid, bytes)]).unwrap();
+            assert_eq!(db.embedding_count().unwrap(), 1);
+        }
+
+        // Reopen with 768-dim — should auto-wipe embeddings
+        {
+            let db = Database::open(&db_path, 768).unwrap();
+            assert_eq!(db.embedding_count().unwrap(), 0);
+            let stored: String = db
+                .get_metadata("embedding_dimension")
+                .unwrap()
+                .expect("dimension should be updated");
+            assert_eq!(stored, "768");
+        }
+    }
+
+    #[test]
+    fn test_open_same_dimension_preserves_embeddings() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // First open
+        {
+            let db = Database::open(&db_path, 384).unwrap();
+            let sym = Symbol::new("bar", SymbolKind::Function, "b.py", 1, 10, 0, 100, None);
+            db.insert_symbol(&sym).unwrap();
+            db.upsert_symbol_content(&sym.id, "bar", "def bar():", "header")
+                .unwrap();
+            let eid = db.get_or_create_embedding_id(&sym.id).unwrap();
+            let bytes = vec![0u8; 384 * 4];
+            db.insert_embeddings(&[(eid, bytes)]).unwrap();
+        }
+
+        // Reopen with same dimension — embeddings preserved
+        {
+            let db = Database::open(&db_path, 384).unwrap();
+            assert_eq!(db.embedding_count().unwrap(), 1);
+        }
+    }
+
+    #[test]
+    fn test_default_embedding_dim_constant() {
+        assert_eq!(DEFAULT_EMBEDDING_DIM, 384);
     }
 }

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -918,7 +918,7 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT id, name, kind, file_path, start_line, end_line,
                     start_byte, end_byte, parent_id, signature, visibility,
-                    is_async, docstring, in_degree,
+                    is_async, docstring, in_degree, content_hash, subtree_hash,
                     (CASE
                        WHEN LOWER(name) = LOWER(?1)                    THEN 0
                        WHEN LOWER(name) LIKE LOWER(?2) || '%' ESCAPE '\\' THEN 1
@@ -947,7 +947,6 @@ impl Database {
                       file_path, start_line
              LIMIT ?5",
         )?;
-        // in_degree is column 13, rank is column 14 — row_to_symbol reads 0–13
         // ?1 = raw query (exact equality), ?2 = escaped query (LIKE patterns), ?3 = kind, ?4 = file, ?5 = limit
         let rows = stmt
             .query_map(
@@ -1019,7 +1018,7 @@ impl Database {
                 "SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind, e.file_path, e.line,
                         s.id, s.name, s.kind, s.file_path, s.start_line, s.end_line,
                         s.start_byte, s.end_byte, s.parent_id, s.signature, s.visibility,
-                        s.is_async, s.docstring, s.in_degree
+                        s.is_async, s.docstring, s.in_degree, s.content_hash, s.subtree_hash
                  FROM edges e
                  LEFT JOIN symbols s ON e.source_id = s.id
                  LEFT JOIN symbols sym2 ON e.target_id = sym2.id
@@ -1035,7 +1034,7 @@ impl Database {
                 "SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind, e.file_path, e.line,
                         s.id, s.name, s.kind, s.file_path, s.start_line, s.end_line,
                         s.start_byte, s.end_byte, s.parent_id, s.signature, s.visibility,
-                        s.is_async, s.docstring, s.in_degree
+                        s.is_async, s.docstring, s.in_degree, s.content_hash, s.subtree_hash
                  FROM edges e
                  LEFT JOIN symbols s ON e.source_id = s.id
                  LEFT JOIN symbols sym2 ON e.target_id = sym2.id

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -74,6 +74,7 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
 
     for entry in WalkDir::new(&root)
         .follow_links(true)
+        .max_depth(50)
         .into_iter()
         .filter_entry(|e| !is_ignored(e))
     {
@@ -372,9 +373,10 @@ fn dedup_symbol_ids(symbols: &mut [Symbol], edges: &mut [cartog_core::Edge]) {
         if *count > 1 {
             let old_id = sym.id.clone();
             sym.id = format!("{}:{}", old_id, count);
-            renames.insert(format!("{}@{}", old_id, count), sym.id.clone());
-            // Track by position for parent_id fixup
-            renames.insert(old_id, sym.id.clone());
+            // Only insert if not already present — keeps the *first* renamed ID
+            // for edge fixup, avoiding the 3+ collision overwrite bug where
+            // the last rename would silently win.
+            renames.entry(old_id).or_insert_with(|| sym.id.clone());
         }
     }
 
@@ -382,14 +384,12 @@ fn dedup_symbol_ids(symbols: &mut [Symbol], edges: &mut [cartog_core::Edge]) {
         return;
     }
 
-    // Fix up edge source_ids that reference renamed symbols
     for edge in edges.iter_mut() {
         if let Some(new_id) = renames.get(&edge.source_id) {
             edge.source_id = new_id.clone();
         }
     }
 
-    // Fix up parent_ids that reference renamed symbols
     for sym in symbols.iter_mut() {
         if let Some(ref pid) = sym.parent_id {
             if let Some(new_id) = renames.get(pid) {

--- a/crates/cartog-lsp/src/client.rs
+++ b/crates/cartog-lsp/src/client.rs
@@ -224,7 +224,10 @@ fn read_headers(reader: &mut BufReader<ChildStdout>) -> Result<usize> {
 
     loop {
         line.clear();
-        reader.read_line(&mut line)?;
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            bail!("LSP server closed stdout (EOF)");
+        }
 
         if line == "\r\n" || line == "\n" {
             break;

--- a/crates/cartog-mcp/README.md
+++ b/crates/cartog-mcp/README.md
@@ -46,7 +46,7 @@ All user-supplied paths are validated against the project root:
 
 | Export | Description |
 |--------|-------------|
-| `run_server()` | Start the MCP server over stdio (async) |
+| `run_server()` | Start the MCP server over stdio (async). Accepts `EmbeddingProviderConfig` and threads it through to all RAG operations (indexing and search). |
 
 ## Crate dependencies
 

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -232,6 +232,8 @@ pub struct CartogServer {
     /// Canonicalized CWD captured at server start to avoid repeated syscalls.
     /// Wrapped in `Arc` so clones (required by `#[derive(Clone)]`) are cheap.
     cwd: Arc<Path>,
+    /// RAG provider configuration (embedding + reranker).
+    rag_config: Arc<rag::EmbeddingProviderConfig>,
     /// Persistent LSP manager for warm server reuse across index calls.
     #[cfg(feature = "lsp")]
     lsp_manager: Arc<Mutex<cartog_lsp::manager::LspManager>>,
@@ -239,15 +241,19 @@ pub struct CartogServer {
 
 #[tool_router]
 impl CartogServer {
-    pub fn new(db_path: &std::path::Path) -> anyhow::Result<Self> {
-        let db =
-            Database::open(db_path).map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
+    pub fn new(
+        db_path: &std::path::Path,
+        rag_config: rag::EmbeddingProviderConfig,
+    ) -> anyhow::Result<Self> {
+        let db = Database::open(db_path, rag_config.resolved_dimension())
+            .map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
         let cwd = std::env::current_dir()
             .and_then(|p| p.canonicalize())
             .map_err(|e| anyhow::anyhow!("cannot determine CWD: {e}"))?;
         Ok(Self {
             tool_router: Self::tool_router(),
             db: Arc::new(Mutex::new(db)),
+            rag_config: Arc::new(rag_config),
             #[cfg(feature = "lsp")]
             lsp_manager: Arc::new(Mutex::new(cartog_lsp::manager::LspManager::new(&cwd))),
             cwd: Arc::from(cwd),
@@ -640,6 +646,7 @@ impl CartogServer {
         let force = params.force;
         let db = Arc::clone(&self.db);
         let cwd = Arc::clone(&self.cwd);
+        let rag_config = Arc::clone(&self.rag_config);
 
         tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
@@ -651,7 +658,9 @@ impl CartogServer {
             let _ = indexer::index_directory(&db, &validated, false, false)
                 .map_err(|e| mcp_err(format!("code graph indexing failed: {e}")))?;
 
-            let result = rag::indexer::index_embeddings(&db, force)
+            let mut provider = rag::create_embedding_provider(&rag_config)
+                .map_err(|e| mcp_err(format!("failed to load embedding model: {e}")))?;
+            let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force)
                 .map_err(|e| mcp_err(format!("embedding indexing failed: {e}")))?;
 
             let json = serde_json::to_string_pretty(&result)
@@ -674,6 +683,7 @@ impl CartogServer {
         let kind_str = params.kind;
         let limit = params.limit.unwrap_or(10).min(MAX_SEARCH_LIMIT);
         let db = Arc::clone(&self.db);
+        let rag_config = Arc::clone(&self.rag_config);
 
         tokio::task::spawn_blocking(move || {
             if query.is_empty() {
@@ -696,8 +706,18 @@ impl CartogServer {
                 None => rag::search::KindFilter::CodeOnly,
             };
 
-            let result = rag::search::hybrid_search(&db, &query, limit, kind_filter)
-                .map_err(|e| mcp_err(format!("semantic search failed: {e}")))?;
+            let mut provider = rag::create_embedding_provider(&rag_config)
+                .map_err(|e| mcp_err(format!("failed to load embedding model: {e}")))?;
+            let mut reranker =
+                rag::create_reranker_provider(&rag_config.reranker_provider);
+            let result = match reranker.as_mut() {
+                Some(r) => rag::search::hybrid_search(
+                    &db, &query, limit, kind_filter, provider.as_mut(), Some(r.as_mut()),
+                ),
+                None => rag::search::hybrid_search(
+                    &db, &query, limit, kind_filter, provider.as_mut(), None,
+                ),
+            }.map_err(|e| mcp_err(format!("semantic search failed: {e}")))?;
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -741,7 +761,12 @@ impl ServerHandler for CartogServer {
 ///
 /// When `watch` is true, a background file watcher keeps the index fresh.
 /// When `rag` is true (requires `watch`), embeddings are also auto-updated.
-pub async fn run_server(db_path: &std::path::Path, watch: bool, rag: bool) -> anyhow::Result<()> {
+pub async fn run_server(
+    db_path: &std::path::Path,
+    watch: bool,
+    rag: bool,
+    rag_config: rag::EmbeddingProviderConfig,
+) -> anyhow::Result<()> {
     info!("starting cartog MCP server v{}", env!("CARGO_PKG_VERSION"));
 
     // Optionally spawn a background file watcher
@@ -750,6 +775,7 @@ pub async fn run_server(db_path: &std::path::Path, watch: bool, rag: bool) -> an
         let cwd = std::env::current_dir()?;
         let mut config = WatchConfig::new(cwd);
         config.rag = rag;
+        config.rag_config = rag_config.clone();
         match watch::spawn_watch(config, &db_path_str) {
             Ok(handle) => {
                 info!(rag, "background file watcher started");
@@ -764,7 +790,7 @@ pub async fn run_server(db_path: &std::path::Path, watch: bool, rag: bool) -> an
         None
     };
 
-    let server = CartogServer::new(db_path)?;
+    let server = CartogServer::new(db_path, rag_config)?;
     let service = server.serve(stdio()).await?;
     service.waiting().await?;
 

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -224,6 +224,10 @@ fn json_response(db: &Database, json: String) -> Result<CallToolResult, McpError
 
 // ── MCP Server ──
 
+/// MCP server exposing cartog tools over stdio.
+///
+/// **Lock ordering** (always acquire in this order to avoid deadlocks):
+///   `db` → `embedding_provider` → `reranker_provider`
 #[derive(Clone)]
 pub struct CartogServer {
     tool_router: ToolRouter<Self>,
@@ -232,8 +236,11 @@ pub struct CartogServer {
     /// Canonicalized CWD captured at server start to avoid repeated syscalls.
     /// Wrapped in `Arc` so clones (required by `#[derive(Clone)]`) are cheap.
     cwd: Arc<Path>,
-    /// RAG provider configuration (embedding + reranker).
-    rag_config: Arc<rag::EmbeddingProviderConfig>,
+    /// Cached embedding provider, created once at server start to avoid
+    /// reloading the ONNX model (or probing Ollama) on every request.
+    embedding_provider: Arc<Mutex<Box<dyn rag::provider::EmbeddingProvider>>>,
+    /// Cached reranker provider (if configured).
+    reranker_provider: Arc<Mutex<Option<Box<dyn rag::provider::RerankerProvider>>>>,
     /// Persistent LSP manager for warm server reuse across index calls.
     #[cfg(feature = "lsp")]
     lsp_manager: Arc<Mutex<cartog_lsp::manager::LspManager>>,
@@ -250,10 +257,14 @@ impl CartogServer {
         let cwd = std::env::current_dir()
             .and_then(|p| p.canonicalize())
             .map_err(|e| anyhow::anyhow!("cannot determine CWD: {e}"))?;
+        let provider = rag::create_embedding_provider(&rag_config)
+            .map_err(|e| anyhow::anyhow!("failed to load embedding model: {e}"))?;
+        let reranker = rag::create_reranker_provider(&rag_config.reranker_provider);
         Ok(Self {
             tool_router: Self::tool_router(),
             db: Arc::new(Mutex::new(db)),
-            rag_config: Arc::new(rag_config),
+            embedding_provider: Arc::new(Mutex::new(provider)),
+            reranker_provider: Arc::new(Mutex::new(reranker)),
             #[cfg(feature = "lsp")]
             lsp_manager: Arc::new(Mutex::new(cartog_lsp::manager::LspManager::new(&cwd))),
             cwd: Arc::from(cwd),
@@ -282,7 +293,9 @@ impl CartogServer {
             // Phase 1: heuristic indexing (hold DB lock briefly)
             #[allow(unused_mut)]
             let mut result = {
-                let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+                let db = db.lock().map_err(|_| {
+                    mcp_err("internal error: database lock poisoned (server restart required)")
+                })?;
                 indexer::index_directory(&db, &validated, force, false)
                     .map_err(|e| mcp_err(format!("indexing failed: {e}")))?
                 // db lock released here
@@ -294,10 +307,12 @@ impl CartogServer {
             // Future optimization: collect LSP results without DB lock, batch-write after.
             #[cfg(feature = "lsp")]
             {
-                let mut mgr = lsp_manager
-                    .lock()
-                    .map_err(|_| mcp_err("LSP manager lock poisoned"))?;
-                let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+                let mut mgr = lsp_manager.lock().map_err(|_| {
+                    mcp_err("internal error: LSP manager lock poisoned (server restart required)")
+                })?;
+                let db = db.lock().map_err(|_| {
+                    mcp_err("internal error: database lock poisoned (server restart required)")
+                })?;
                 match cartog_lsp::lsp_resolve_edges(&db, &validated, Some(&mut mgr)) {
                     Ok(n) => {
                         result.edges_lsp_resolved = n;
@@ -333,7 +348,9 @@ impl CartogServer {
 
         tokio::task::spawn_blocking(move || {
             debug!(file = %file, "outline");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let symbols = db
                 .outline(&file)
                 .map_err(|e| mcp_err(format!("outline query failed: {e}")))?;
@@ -372,7 +389,9 @@ impl CartogServer {
                 .transpose()?;
 
             debug!(name = %name, kind = ?kind_filter, "refs");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let results = db
                 .refs(&name, kind_filter)
                 .map_err(|e| mcp_err(format!("refs query failed: {e}")))?;
@@ -403,7 +422,9 @@ impl CartogServer {
 
         tokio::task::spawn_blocking(move || {
             debug!(name = %name, "callees");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let edges = db
                 .callees(&name)
                 .map_err(|e| mcp_err(format!("callees query failed: {e}")))?;
@@ -430,7 +451,9 @@ impl CartogServer {
 
         tokio::task::spawn_blocking(move || {
             debug!(name = %name, depth, "impact");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let results = db
                 .impact(&name, depth)
                 .map_err(|e| mcp_err(format!("impact query failed: {e}")))?;
@@ -461,7 +484,9 @@ impl CartogServer {
 
         tokio::task::spawn_blocking(move || {
             debug!(name = %name, "hierarchy");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let pairs = db
                 .hierarchy(&name)
                 .map_err(|e| mcp_err(format!("hierarchy query failed: {e}")))?;
@@ -492,7 +517,9 @@ impl CartogServer {
 
         tokio::task::spawn_blocking(move || {
             debug!(file = %file, "deps");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let edges = db
                 .file_deps(&file)
                 .map_err(|e| mcp_err(format!("deps query failed: {e}")))?;
@@ -549,7 +576,7 @@ impl CartogServer {
                 .transpose()?;
             let file_filter = validated_file.as_deref();
             debug!(query = %query, kind = ?kind_filter, limit, "search");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
             let symbols = db
                 .search(&query, kind_filter, file_filter, limit)
                 .map_err(|e| mcp_err(format!("search failed: {e}")))?;
@@ -571,7 +598,9 @@ impl CartogServer {
 
         tokio::task::spawn_blocking(move || {
             debug!("stats");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
             let stats = db
                 .stats()
                 .map_err(|e| mcp_err(format!("stats query failed: {e}")))?;
@@ -616,7 +645,7 @@ impl CartogServer {
             let changed_files = indexer::git_recently_changed_files(&root, commits)
                 .map_err(|e| mcp_err(format!("git changes failed: {e}")))?;
 
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
             let symbols = db
                 .symbols_for_files(&changed_files, kind_filter)
                 .map_err(|e| mcp_err(format!("symbols query failed: {e}")))?;
@@ -646,20 +675,25 @@ impl CartogServer {
         let force = params.force;
         let db = Arc::clone(&self.db);
         let cwd = Arc::clone(&self.cwd);
-        let rag_config = Arc::clone(&self.rag_config);
+        let provider = Arc::clone(&self.embedding_provider);
 
         tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "rag index");
 
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
 
             // Ensure the code graph index is up to date first
             let _ = indexer::index_directory(&db, &validated, false, false)
                 .map_err(|e| mcp_err(format!("code graph indexing failed: {e}")))?;
 
-            let mut provider = rag::create_embedding_provider(&rag_config)
-                .map_err(|e| mcp_err(format!("failed to load embedding model: {e}")))?;
+            let mut provider = provider.lock().map_err(|_| {
+                mcp_err(
+                    "internal error: embedding provider lock poisoned (server restart required)",
+                )
+            })?;
             let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force)
                 .map_err(|e| mcp_err(format!("embedding indexing failed: {e}")))?;
 
@@ -683,7 +717,8 @@ impl CartogServer {
         let kind_str = params.kind;
         let limit = params.limit.unwrap_or(10).min(MAX_SEARCH_LIMIT);
         let db = Arc::clone(&self.db);
-        let rag_config = Arc::clone(&self.rag_config);
+        let provider = Arc::clone(&self.embedding_provider);
+        let reranker = Arc::clone(&self.reranker_provider);
 
         tokio::task::spawn_blocking(move || {
             if query.is_empty() {
@@ -691,7 +726,7 @@ impl CartogServer {
             }
 
             debug!(query = %query, kind = ?kind_str, limit, "rag search");
-            let db = db.lock().map_err(|_| mcp_err("database lock poisoned"))?;
+            let db = db.lock().map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
 
             let kind_filter = match kind_str.as_deref() {
                 Some("all") => rag::search::KindFilter::All,
@@ -706,10 +741,12 @@ impl CartogServer {
                 None => rag::search::KindFilter::CodeOnly,
             };
 
-            let mut provider = rag::create_embedding_provider(&rag_config)
-                .map_err(|e| mcp_err(format!("failed to load embedding model: {e}")))?;
-            let mut reranker =
-                rag::create_reranker_provider(&rag_config.reranker_provider);
+            let mut provider = provider
+                .lock()
+                .map_err(|_| mcp_err("internal error: embedding provider lock poisoned (server restart required)"))?;
+            let mut reranker = reranker
+                .lock()
+                .map_err(|_| mcp_err("internal error: reranker lock poisoned (server restart required)"))?;
             let result = match reranker.as_mut() {
                 Some(r) => rag::search::hybrid_search(
                     &db, &query, limit, kind_filter, provider.as_mut(), Some(r.as_mut()),

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -227,7 +227,7 @@ fn json_response(db: &Database, json: String) -> Result<CallToolResult, McpError
 /// MCP server exposing cartog tools over stdio.
 ///
 /// **Lock ordering** (always acquire in this order to avoid deadlocks):
-///   `db` → `embedding_provider` → `reranker_provider`
+///   `lsp_manager` → `db` → `embedding_provider` → `reranker_provider`
 #[derive(Clone)]
 pub struct CartogServer {
     tool_router: ToolRouter<Self>,

--- a/crates/cartog-rag/Cargo.toml
+++ b/crates/cartog-rag/Cargo.toml
@@ -7,10 +7,17 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["provider-local"]
+provider-local = ["dep:fastembed"]
+provider-ollama = ["dep:reqwest", "dep:serde_json"]
+
 [dependencies]
 cartog-core = { workspace = true }
 cartog-db = { workspace = true }
 anyhow = { workspace = true }
-fastembed = { workspace = true }
+fastembed = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 tracing = { workspace = true }

--- a/crates/cartog-rag/README.md
+++ b/crates/cartog-rag/README.md
@@ -38,7 +38,7 @@ model = "nomic-embed-text"
 ### Hybrid search pipeline
 
 1. **FTS5 keyword search** — BM25 ranking over symbol names and source content
-2. **Vector KNN search** — cosine similarity on 384-dim embeddings via sqlite-vec
+2. **Vector KNN search** — cosine similarity on configurable-dimension embeddings via sqlite-vec
 3. **RRF merge** — Reciprocal Rank Fusion (k=60) combines both ranked lists
 4. **Hydration** — load symbol metadata and source content from the database
 5. **Cross-encoder reranking** — reranker scores top-50 candidates (if model available)
@@ -46,24 +46,23 @@ model = "nomic-embed-text"
 
 Over-retrieves `(limit * 3).max(20)` candidates from each source to improve fusion quality before applying the final limit.
 
-### Engine caching
+### Provider lifecycle
 
-- Embedding engine: `static Mutex`, loaded once per process, reused across calls
-- Reranker engine: tri-state `Mutex` — `None` (not attempted), `Some(None)` (load failed, don't retry), `Some(Some(engine))` (ready)
+Providers are created per-command invocation via `create_embedding_provider(config)`. The caller passes an `EmbeddingProviderConfig` (from `.cartog.toml`) and receives a boxed `EmbeddingProvider` trait object. Reranker providers follow the same pattern with `create_reranker_provider(config)`.
 
 ## Public API
 
 | Export | Description |
 |--------|-------------|
+| `create_embedding_provider()` | Create a provider from config |
+| `create_reranker_provider()` | Create a reranker from config ("local" or "none") |
+| `EmbeddingProviderConfig` | Configuration for provider selection |
+| `provider::EmbeddingProvider` | Trait for embedding backends |
+| `provider::RerankerProvider` | Trait for reranker backends |
 | `search::hybrid_search()` | Run the full hybrid search pipeline |
 | `indexer::index_embeddings()` | Embed symbols and write vectors to DB |
-| `setup::download_model()` | Download the embedding model |
-| `setup::download_cross_encoder()` | Download the reranker model |
-| `embeddings::EmbeddingEngine` | Low-level embedding interface |
-| `reranker::CrossEncoderEngine` | Low-level reranker interface |
-| `EMBEDDING_DIM` | 384 (vector dimension constant) |
-| `is_embedding_model_cached()` | Check if embedding model is downloaded |
-| `is_reranker_model_cached()` | Check if reranker model is downloaded |
+| `setup::download_model()` | Download the embedding model (local provider) |
+| `EMBEDDING_DIM` | Default vector dimension (384) |
 
 ## Crate dependencies
 

--- a/crates/cartog-rag/README.md
+++ b/crates/cartog-rag/README.md
@@ -21,7 +21,7 @@ Configurable via `.cartog.toml` `[embedding]` section. Supports pluggable provid
 
 **Reranker**: BGE-reranker-base — cross-encoder that scores (query, document) pairs jointly (~1.1GB, optional, local only).
 
-Models cached in `~/.cache/cartog/models/` (respects `FASTEMBED_CACHE_DIR` and `XDG_CACHE_HOME`).
+Local models cached in `~/.cache/cartog/models/` (respects `FASTEMBED_CACHE_DIR` and `XDG_CACHE_HOME`). Ollama models are managed by the Ollama server.
 
 ```toml
 # .cartog.toml — example with Ollama
@@ -30,7 +30,8 @@ provider = "ollama"
 model = "nomic-embed-text"
 # dimension = 768  # auto-detected if omitted
 
-[embedding.local]
+# Local provider only: asymmetric model prefixes
+# [embedding.local]
 # query_prefix = "search_query: "
 # document_prefix = "search_document: "
 ```

--- a/crates/cartog-rag/README.md
+++ b/crates/cartog-rag/README.md
@@ -10,12 +10,30 @@ Indexes both **code symbols** (functions, classes, methods) and **Markdown docum
 
 ## How it works
 
-### Models
+### Embedding providers
 
-- **Embedding**: BGE-small-en-v1.5 quantized — 384-dimensional vectors, ONNX runtime via fastembed (~80MB)
-- **Reranker**: BGE-reranker-base — cross-encoder that scores (query, document) pairs jointly (~1.1GB, optional)
+Configurable via `.cartog.toml` `[embedding]` section. Supports pluggable providers:
 
-Both are auto-downloaded from HuggingFace on first use. Cached in `~/.cache/cartog/models/` (respects `FASTEMBED_CACHE_DIR` and `XDG_CACHE_HOME`).
+| Provider | Feature flag | Models | Notes |
+|----------|-------------|--------|-------|
+| **local** (default) | `provider-local` | Any fastembed built-in (BGE, all-MiniLM, nomic, etc.) | ONNX Runtime via fastembed, auto-downloaded from HuggingFace |
+| **ollama** | `provider-ollama` | Any Ollama model (nomic-embed-text, mxbai-embed-large, etc.) | HTTP client, auto-detects dimension |
+
+**Reranker**: BGE-reranker-base — cross-encoder that scores (query, document) pairs jointly (~1.1GB, optional, local only).
+
+Models cached in `~/.cache/cartog/models/` (respects `FASTEMBED_CACHE_DIR` and `XDG_CACHE_HOME`).
+
+```toml
+# .cartog.toml — example with Ollama
+[embedding]
+provider = "ollama"
+model = "nomic-embed-text"
+# dimension = 768  # auto-detected if omitted
+
+[embedding.local]
+# query_prefix = "search_query: "
+# document_prefix = "search_document: "
+```
 
 ### Hybrid search pipeline
 

--- a/crates/cartog-rag/src/embeddings.rs
+++ b/crates/cartog-rag/src/embeddings.rs
@@ -85,23 +85,8 @@ impl EmbeddingEngine {
     }
 }
 
-/// Serialize a `Vec<f32>` to little-endian bytes for sqlite-vec storage.
-pub fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(embedding.len() * 4);
-    for &val in embedding {
-        bytes.extend_from_slice(&val.to_le_bytes());
-    }
-    bytes
-}
-
-/// Deserialize little-endian bytes back to `Vec<f32>`.
-#[allow(dead_code)]
-pub fn bytes_to_embedding(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
-        .collect()
-}
+// Re-export from provider module (canonical location).
+pub use super::provider::{bytes_to_embedding, embedding_to_bytes};
 
 #[cfg(test)]
 mod tests {

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -1,9 +1,9 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use tracing::info;
 
 use cartog_db::Database;
 
-use super::embeddings::{embedding_to_bytes, EmbeddingEngine};
+use super::provider::{embedding_to_bytes, EmbeddingProvider};
 
 /// Result of a RAG indexing operation.
 #[derive(Debug, Default, serde::Serialize)]
@@ -23,8 +23,8 @@ const DB_BATCH_LIMIT: usize = 256;
 /// Process a batch of texts through the embedding engine and write results to DB.
 ///
 /// Returns the number of successfully processed items in this batch.
-fn flush_embedding_batch(
-    engine: &mut EmbeddingEngine,
+fn flush_embedding_batch<P: EmbeddingProvider + ?Sized>(
+    provider: &mut P,
     db: &Database,
     texts: &[String],
     symbol_ids: &[String],
@@ -32,7 +32,7 @@ fn flush_embedding_batch(
     result: &mut RagIndexResult,
 ) -> Result<usize> {
     let str_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-    match engine.embed_batch(&str_refs) {
+    match provider.embed_documents(&str_refs) {
         Ok(embeddings) => {
             for (embedding, sid) in embeddings.iter().zip(symbol_ids.iter()) {
                 let embedding_id = db.get_or_create_embedding_id(sid)?;
@@ -48,11 +48,10 @@ fn flush_embedding_batch(
             Ok(embeddings.len())
         }
         Err(e) => {
-            // Batch failed — fall back to one-at-a-time to isolate the bad symbol
             tracing::warn!(error = %e, "Batch embedding failed, falling back to sequential");
             let mut count = 0;
             for (text, sid) in texts.iter().zip(symbol_ids.iter()) {
-                match engine.embed(text) {
+                match provider.embed_document(text) {
                     Ok(embedding) => {
                         let embedding_id = db.get_or_create_embedding_id(sid)?;
                         let bytes = embedding_to_bytes(&embedding);
@@ -165,10 +164,11 @@ fn is_insignificant_line(line: &str) -> bool {
 /// Requires the embedding model to be available (downloaded via `cartog rag setup`
 /// or auto-downloaded on first use by fastembed).
 /// When `force` is true, clears all existing embeddings and re-embeds everything.
-pub fn index_embeddings(db: &Database, force: bool) -> Result<RagIndexResult> {
-    let mut engine = EmbeddingEngine::new()
-        .context("Failed to load embedding model. Run 'cartog rag setup' to download it.")?;
-
+pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
+    db: &Database,
+    provider: &mut P,
+    force: bool,
+) -> Result<RagIndexResult> {
     let total_content_symbols = db.symbol_content_count()?;
 
     // Auto-detect embedding format change and force re-embed
@@ -243,8 +243,7 @@ pub fn index_embeddings(db: &Database, force: bool) -> Result<RagIndexResult> {
         let texts: Vec<String> = batch.iter().map(|(t, _)| t.clone()).collect();
         let sids: Vec<String> = batch.iter().map(|(_, s)| s.clone()).collect();
 
-        let count =
-            flush_embedding_batch(&mut engine, db, &texts, &sids, &mut db_batch, &mut result)?;
+        let count = flush_embedding_batch(provider, db, &texts, &sids, &mut db_batch, &mut result)?;
         processed += count;
 
         if processed % 1000 < CHUNK_SIZE {
@@ -414,7 +413,110 @@ mod tests {
 
     #[test]
     fn test_embedding_format_version_is_current() {
-        // Ensures the constant is kept in sync — update when adding migrations
         assert_eq!(EMBEDDING_FORMAT_VERSION, 3);
+    }
+
+    // ── index_embeddings tests with mock provider ──
+
+    use crate::provider::test_utils::MockEmbeddingProvider;
+    use cartog_core::{Symbol, SymbolKind};
+
+    fn setup_db_with_symbols(n: usize) -> Database {
+        let db = Database::open_memory().unwrap();
+        for i in 0..n {
+            let name = format!("func_{i}");
+            let sym = Symbol::new(
+                &name,
+                SymbolKind::Function,
+                "test.py",
+                (i * 10 + 1) as u32,
+                (i * 10 + 10) as u32,
+                0,
+                100,
+                None,
+            );
+            db.insert_symbol(&sym).unwrap();
+            let content = format!("def {name}(x):\n    return x * {i}\n");
+            let header = format!("// File: test.py | function {name}");
+            db.upsert_symbol_content(&sym.id, &name, &content, &header)
+                .unwrap();
+        }
+        db
+    }
+
+    #[test]
+    fn test_index_embeddings_basic() {
+        let db = setup_db_with_symbols(5);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let result = index_embeddings(&db, &mut provider, false).unwrap();
+        assert_eq!(result.symbols_embedded, 5);
+        assert_eq!(result.symbols_skipped, 0);
+        assert_eq!(result.total_content_symbols, 5);
+        assert!(provider.embed_count > 0);
+    }
+
+    #[test]
+    fn test_index_embeddings_idempotent() {
+        let db = setup_db_with_symbols(3);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let r1 = index_embeddings(&db, &mut provider, false).unwrap();
+        assert_eq!(r1.symbols_embedded, 3);
+
+        let r2 = index_embeddings(&db, &mut provider, false).unwrap();
+        assert_eq!(r2.symbols_embedded, 0, "second run should embed nothing");
+    }
+
+    #[test]
+    fn test_index_embeddings_force_reembeds() {
+        let db = setup_db_with_symbols(3);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let r1 = index_embeddings(&db, &mut provider, false).unwrap();
+        assert_eq!(r1.symbols_embedded, 3);
+
+        let r2 = index_embeddings(&db, &mut provider, true).unwrap();
+        assert_eq!(r2.symbols_embedded, 3, "force should re-embed everything");
+    }
+
+    #[test]
+    fn test_index_embeddings_stores_format_version() {
+        let db = setup_db_with_symbols(1);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        index_embeddings(&db, &mut provider, false).unwrap();
+
+        let version: String = db
+            .get_metadata("embedding_format_version")
+            .unwrap()
+            .unwrap();
+        assert_eq!(version, EMBEDDING_FORMAT_VERSION.to_string());
+    }
+
+    #[test]
+    fn test_index_embeddings_empty_db() {
+        let db = Database::open_memory().unwrap();
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let result = index_embeddings(&db, &mut provider, false).unwrap();
+        assert_eq!(result.symbols_embedded, 0);
+        assert_eq!(result.total_content_symbols, 0);
+        assert_eq!(provider.embed_count, 0);
+    }
+
+    #[test]
+    fn test_index_embeddings_skips_trivial_content() {
+        let db = Database::open_memory().unwrap();
+        let sym = Symbol::new("tiny", SymbolKind::Function, "a.py", 1, 2, 0, 10, None);
+        db.insert_symbol(&sym).unwrap();
+        // Content + header below MIN_EMBED_TEXT_BYTES (40 bytes)
+        db.upsert_symbol_content(&sym.id, "tiny", "x=1", "h")
+            .unwrap();
+
+        let mut provider = MockEmbeddingProvider::new(384);
+        let result = index_embeddings(&db, &mut provider, false).unwrap();
+        assert_eq!(result.symbols_skipped, 1);
+        assert_eq!(result.symbols_embedded, 0);
     }
 }

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -1,25 +1,157 @@
 //! Semantic search and RAG pipeline for cartog.
 //!
-//! Combines FTS5 keyword search (BM25) with vector KNN search (BGE-small-en-v1.5,
-//! 384-dim embeddings via fastembed) using Reciprocal Rank Fusion, then optionally
-//! reranks with a cross-encoder (BGE-reranker-base).
+//! Combines FTS5 keyword search (BM25) with vector KNN search using Reciprocal
+//! Rank Fusion, then optionally reranks with a cross-encoder.
+//!
+//! Supports pluggable embedding providers via the [`provider::EmbeddingProvider`] trait:
+//! - **local** (default): ONNX models via fastembed (feature `provider-local`)
+//! - **ollama**: HTTP API to an Ollama server (feature `provider-ollama`)
 
+#[cfg(feature = "provider-local")]
 pub mod embeddings;
 pub mod indexer;
+pub mod provider;
+pub mod providers;
+#[cfg(feature = "provider-local")]
 pub mod reranker;
 pub mod search;
+#[cfg(feature = "provider-local")]
 pub mod setup;
 
-/// Embedding dimension for the bge-small-en-v1.5 model.
-pub const EMBEDDING_DIM: usize = 384;
+/// Default embedding dimension (re-exported from cartog-db for convenience).
+pub const EMBEDDING_DIM: usize = cartog_db::DEFAULT_EMBEDDING_DIM;
 
-/// HuggingFace repo ID for the quantized embedding model.
+/// Parameters for creating an embedding provider.
+#[derive(Clone)]
+pub struct EmbeddingProviderConfig {
+    /// Provider type: "local" or "ollama".
+    pub provider: String,
+    /// Model name (provider-specific). None = provider default.
+    pub model: Option<String>,
+    /// Explicit dimension override. None = auto-detect from model/provider.
+    pub dimension: Option<usize>,
+    /// Query prefix for asymmetric models.
+    pub query_prefix: Option<String>,
+    /// Document prefix for asymmetric models.
+    pub document_prefix: Option<String>,
+    /// Base URL for remote providers (Ollama). None = provider default.
+    pub base_url: Option<String>,
+    /// Reranker provider: "local" (default) or "none".
+    pub reranker_provider: String,
+}
+
+impl Default for EmbeddingProviderConfig {
+    fn default() -> Self {
+        Self {
+            provider: "local".to_string(),
+            model: None,
+            dimension: None,
+            query_prefix: None,
+            document_prefix: None,
+            base_url: None,
+            reranker_provider: "local".to_string(),
+        }
+    }
+}
+
+impl EmbeddingProviderConfig {
+    /// Resolve the embedding dimension for this config.
+    /// Uses explicit dimension if set, otherwise falls back to provider default.
+    pub fn resolved_dimension(&self) -> usize {
+        self.dimension.unwrap_or(EMBEDDING_DIM)
+    }
+}
+
+/// Create an embedding provider from the given configuration.
+pub fn create_embedding_provider(
+    config: &EmbeddingProviderConfig,
+) -> anyhow::Result<Box<dyn provider::EmbeddingProvider>> {
+    match config.provider.as_str() {
+        #[cfg(feature = "provider-local")]
+        "local" => {
+            let provider = providers::local::LocalEmbeddingProvider::new(
+                config.model.as_deref(),
+                config.query_prefix.clone(),
+                config.document_prefix.clone(),
+            )?;
+            Ok(Box::new(provider))
+        }
+        #[cfg(feature = "provider-ollama")]
+        "ollama" => {
+            let provider = providers::ollama::OllamaEmbeddingProvider::new(
+                config.base_url.as_deref(),
+                config.model.as_deref(),
+                config.dimension,
+            )?;
+            Ok(Box::new(provider))
+        }
+        other => anyhow::bail!(
+            "Unknown or disabled embedding provider: '{other}'. Supported: {}",
+            supported_providers()
+        ),
+    }
+}
+
+fn supported_providers() -> &'static str {
+    match (
+        cfg!(feature = "provider-local"),
+        cfg!(feature = "provider-ollama"),
+    ) {
+        (true, true) => "local, ollama",
+        (true, false) => "local",
+        (false, true) => "ollama",
+        (false, false) => "none (enable provider features)",
+    }
+}
+
+/// Create the default local embedding provider (BGE-small-en-v1.5 quantized).
+pub fn create_default_embedding_provider() -> anyhow::Result<Box<dyn provider::EmbeddingProvider>> {
+    create_embedding_provider(&EmbeddingProviderConfig::default())
+}
+
+/// Create a reranker provider based on the given provider name.
+///
+/// - `"local"` — loads the local ONNX cross-encoder (requires `provider-local` feature)
+/// - `"none"` — disables re-ranking
+///
+/// Returns `None` if re-ranking is disabled, the model is unavailable, or the feature is off.
+pub fn create_reranker_provider(
+    reranker_provider: &str,
+) -> Option<Box<dyn provider::RerankerProvider>> {
+    match reranker_provider {
+        "none" => None,
+        #[cfg(feature = "provider-local")]
+        "local" => match providers::local::LocalRerankerProvider::load() {
+            Ok(r) => Some(Box::new(r)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Cross-encoder not available, skipping re-ranking");
+                None
+            }
+        },
+        other => {
+            tracing::warn!(
+                provider = other,
+                "Unknown reranker provider, skipping re-ranking"
+            );
+            None
+        }
+    }
+}
+
+/// Create the default local reranker provider (BGE-reranker-base).
+pub fn create_default_reranker_provider() -> Option<Box<dyn provider::RerankerProvider>> {
+    create_reranker_provider("local")
+}
+
+// ── Local ONNX model cache management (provider-local only) ──
+
+#[cfg(feature = "provider-local")]
 const EMBEDDING_MODEL_CODE: &str = "Qdrant/bge-small-en-v1.5-onnx-Q";
-/// Primary ONNX file that must exist for the embedding model to be considered cached.
+#[cfg(feature = "provider-local")]
 const EMBEDDING_MODEL_FILE: &str = "model_optimized.onnx";
-/// HuggingFace repo ID for the cross-encoder reranker model.
+#[cfg(feature = "provider-local")]
 const RERANKER_MODEL_CODE: &str = "BAAI/bge-reranker-base";
-/// Primary ONNX file that must exist for the reranker model to be considered cached.
+#[cfg(feature = "provider-local")]
 const RERANKER_MODEL_FILE: &str = "onnx/model.onnx";
 
 /// Check if a model is already downloaded in the hf-hub cache (no network access).
@@ -27,6 +159,7 @@ const RERANKER_MODEL_FILE: &str = "onnx/model.onnx";
 /// Mirrors `hf_hub::CacheRepo::get()` logic: reads the commit hash from
 /// `<cache>/models--<org>--<name>/refs/main`, then checks for the ONNX file
 /// in `snapshots/<hash>/<model_file>`.
+#[cfg(feature = "provider-local")]
 fn is_model_cached(model_code: &str, model_file: &str) -> bool {
     let cache_dir = model_cache_dir();
     let dir_name = format!("models--{}", model_code.replace('/', "--"));
@@ -42,12 +175,12 @@ fn is_model_cached(model_code: &str, model_file: &str) -> bool {
     model_path.exists()
 }
 
-/// Whether the embedding model (BGE-small-en-v1.5 quantized) is already cached.
+#[cfg(feature = "provider-local")]
 pub fn is_embedding_model_cached() -> bool {
     is_model_cached(EMBEDDING_MODEL_CODE, EMBEDDING_MODEL_FILE)
 }
 
-/// Whether the cross-encoder reranker model (BGE-reranker-base) is already cached.
+#[cfg(feature = "provider-local")]
 pub fn is_reranker_model_cached() -> bool {
     is_model_cached(RERANKER_MODEL_CODE, RERANKER_MODEL_FILE)
 }
@@ -122,5 +255,70 @@ mod tests {
                 dir.display()
             );
         }
+    }
+
+    #[test]
+    fn test_boxed_reranker_as_deref_mut_some() {
+        use provider::test_utils::MockRerankerProvider;
+
+        let mut reranker: Option<Box<dyn provider::RerankerProvider>> =
+            Some(Box::new(MockRerankerProvider));
+        let r = reranker.as_deref_mut();
+        assert!(r.is_some());
+        assert_eq!(r.unwrap().name(), "mock-reranker");
+    }
+
+    #[test]
+    fn test_boxed_reranker_as_deref_mut_none() {
+        let mut reranker: Option<Box<dyn provider::RerankerProvider>> = None;
+        let r = reranker.as_deref_mut();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn test_embedding_dim_constant() {
+        assert_eq!(EMBEDDING_DIM, 384);
+        assert_eq!(EMBEDDING_DIM, cartog_db::DEFAULT_EMBEDDING_DIM);
+    }
+
+    #[test]
+    fn test_create_embedding_provider_invalid_provider() {
+        let config = EmbeddingProviderConfig {
+            provider: "nonexistent".to_string(),
+            ..Default::default()
+        };
+        let result = create_embedding_provider(&config);
+        let err = result.err().expect("should be an error").to_string();
+        assert!(
+            err.contains("nonexistent"),
+            "error should mention the invalid provider name: {err}"
+        );
+    }
+
+    #[test]
+    fn test_provider_config_default_values() {
+        let config = EmbeddingProviderConfig::default();
+        assert_eq!(config.provider, "local");
+        assert!(config.model.is_none());
+        assert!(config.dimension.is_none());
+        assert!(config.query_prefix.is_none());
+        assert!(config.document_prefix.is_none());
+        assert!(config.base_url.is_none());
+        assert_eq!(config.resolved_dimension(), 384);
+    }
+
+    #[test]
+    fn test_provider_config_resolved_dimension_with_explicit() {
+        let config = EmbeddingProviderConfig {
+            dimension: Some(768),
+            ..Default::default()
+        };
+        assert_eq!(config.resolved_dimension(), 768);
+    }
+
+    #[test]
+    fn test_supported_providers_includes_local() {
+        let s = supported_providers();
+        assert!(s.contains("local"), "should include local: {s}");
     }
 }

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -56,7 +56,9 @@ impl Default for EmbeddingProviderConfig {
 
 impl EmbeddingProviderConfig {
     /// Resolve the embedding dimension for this config.
-    /// Uses explicit dimension if set, otherwise falls back to provider default.
+    /// Uses explicit dimension if set, otherwise falls back to the local provider default (384).
+    /// For Ollama, the actual dimension is auto-detected at provider construction time;
+    /// this method should not be relied upon for non-local providers without an explicit dimension.
     pub fn resolved_dimension(&self) -> usize {
         self.dimension.unwrap_or(EMBEDDING_DIM)
     }

--- a/crates/cartog-rag/src/provider.rs
+++ b/crates/cartog-rag/src/provider.rs
@@ -1,0 +1,247 @@
+use anyhow::Result;
+
+/// Serialize a `Vec<f32>` to little-endian bytes for sqlite-vec storage.
+pub fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(embedding.len() * 4);
+    for &val in embedding {
+        bytes.extend_from_slice(&val.to_le_bytes());
+    }
+    bytes
+}
+
+/// Deserialize little-endian bytes back to `Vec<f32>`.
+#[allow(dead_code)]
+pub fn bytes_to_embedding(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect()
+}
+
+/// Trait for embedding providers (local ONNX, Ollama, OpenAI, etc.).
+///
+/// Implementations handle model-specific details like query/document prefixes
+/// (e.g. nomic prepends `"search_query:"` vs `"search_document:"`).
+pub trait EmbeddingProvider: Send {
+    fn name(&self) -> &str;
+    fn dimension(&self) -> usize;
+
+    /// Embed a query (for search). Some models use a different prefix than documents.
+    fn embed_query(&mut self, text: &str) -> Result<Vec<f32>> {
+        self.embed_document(text)
+    }
+
+    /// Embed a document (for indexing).
+    fn embed_document(&mut self, text: &str) -> Result<Vec<f32>>;
+
+    /// Embed multiple documents in a batch.
+    fn embed_documents(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
+}
+
+/// Trait for cross-encoder re-ranking providers.
+pub trait RerankerProvider: Send {
+    fn name(&self) -> &str;
+
+    /// Score multiple documents against a single query.
+    /// Returns scores in the same order as the input documents.
+    fn score_batch(&mut self, query: &str, documents: &[&str]) -> Result<Vec<f32>>;
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+
+    /// Mock embedding provider that returns deterministic vectors for testing.
+    /// The vector is seeded from the text hash so identical inputs get identical outputs.
+    pub struct MockEmbeddingProvider {
+        pub dim: usize,
+        pub embed_count: usize,
+        pub query_prefix: Option<String>,
+        pub document_prefix: Option<String>,
+    }
+
+    impl MockEmbeddingProvider {
+        pub fn new(dim: usize) -> Self {
+            Self {
+                dim,
+                embed_count: 0,
+                query_prefix: None,
+                document_prefix: None,
+            }
+        }
+
+        pub fn with_prefixes(dim: usize, query: &str, document: &str) -> Self {
+            Self {
+                dim,
+                embed_count: 0,
+                query_prefix: Some(query.to_string()),
+                document_prefix: Some(document.to_string()),
+            }
+        }
+
+        fn deterministic_vector(&self, text: &str) -> Vec<f32> {
+            let hash = text
+                .bytes()
+                .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
+            (0..self.dim)
+                .map(|i| ((hash.wrapping_add(i as u64) % 1000) as f32) / 1000.0)
+                .collect()
+        }
+    }
+
+    impl EmbeddingProvider for MockEmbeddingProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn dimension(&self) -> usize {
+            self.dim
+        }
+
+        fn embed_query(&mut self, text: &str) -> Result<Vec<f32>> {
+            self.embed_count += 1;
+            let input = match &self.query_prefix {
+                Some(p) => format!("{p}{text}"),
+                None => text.to_string(),
+            };
+            Ok(self.deterministic_vector(&input))
+        }
+
+        fn embed_document(&mut self, text: &str) -> Result<Vec<f32>> {
+            self.embed_count += 1;
+            let input = match &self.document_prefix {
+                Some(p) => format!("{p}{text}"),
+                None => text.to_string(),
+            };
+            Ok(self.deterministic_vector(&input))
+        }
+
+        fn embed_documents(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            texts.iter().map(|t| self.embed_document(t)).collect()
+        }
+    }
+
+    /// Mock reranker that returns scores based on keyword overlap.
+    pub struct MockRerankerProvider;
+
+    impl RerankerProvider for MockRerankerProvider {
+        fn name(&self) -> &str {
+            "mock-reranker"
+        }
+
+        fn score_batch(&mut self, query: &str, documents: &[&str]) -> Result<Vec<f32>> {
+            let query_words: std::collections::HashSet<&str> = query.split_whitespace().collect();
+            Ok(documents
+                .iter()
+                .map(|doc| {
+                    let doc_words: std::collections::HashSet<&str> =
+                        doc.split_whitespace().collect();
+                    query_words.intersection(&doc_words).count() as f32
+                })
+                .collect())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_utils::*;
+    use super::*;
+
+    #[test]
+    fn mock_provider_returns_correct_dimension() {
+        let mut provider = MockEmbeddingProvider::new(768);
+        assert_eq!(provider.dimension(), 768);
+        assert_eq!(provider.name(), "mock");
+
+        let vec = provider.embed_document("test").unwrap();
+        assert_eq!(vec.len(), 768);
+    }
+
+    #[test]
+    fn mock_provider_deterministic_output() {
+        let mut p1 = MockEmbeddingProvider::new(384);
+        let mut p2 = MockEmbeddingProvider::new(384);
+
+        let v1 = p1.embed_document("hello world").unwrap();
+        let v2 = p2.embed_document("hello world").unwrap();
+        assert_eq!(v1, v2);
+
+        let v3 = p1.embed_document("different text").unwrap();
+        assert_ne!(v1, v3);
+    }
+
+    #[test]
+    fn embed_query_defaults_to_embed_document() {
+        let mut provider = MockEmbeddingProvider::new(384);
+        let query = provider.embed_query("test").unwrap();
+        let doc = provider.embed_document("test").unwrap();
+        assert_eq!(query, doc);
+    }
+
+    #[test]
+    fn prefixes_produce_different_embeddings() {
+        let mut provider =
+            MockEmbeddingProvider::with_prefixes(384, "search_query: ", "search_document: ");
+
+        let query = provider.embed_query("test").unwrap();
+        let doc = provider.embed_document("test").unwrap();
+        assert_ne!(query, doc);
+    }
+
+    #[test]
+    fn batch_embed_matches_individual() {
+        let mut provider = MockEmbeddingProvider::new(384);
+        let texts = ["foo", "bar", "baz"];
+
+        let batch = provider.embed_documents(&texts).unwrap();
+        assert_eq!(batch.len(), 3);
+
+        let individual: Vec<Vec<f32>> = texts
+            .iter()
+            .map(|t| provider.embed_document(t).unwrap())
+            .collect();
+        assert_eq!(batch, individual);
+    }
+
+    #[test]
+    fn batch_embed_empty_input() {
+        let mut provider = MockEmbeddingProvider::new(384);
+        let result = provider.embed_documents(&[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn embed_count_tracks_calls() {
+        let mut provider = MockEmbeddingProvider::new(384);
+        assert_eq!(provider.embed_count, 0);
+
+        provider.embed_document("a").unwrap();
+        provider.embed_query("b").unwrap();
+        assert_eq!(provider.embed_count, 2);
+
+        provider.embed_documents(&["c", "d", "e"]).unwrap();
+        assert_eq!(provider.embed_count, 5);
+    }
+
+    #[test]
+    fn mock_reranker_scores_by_overlap() {
+        let mut reranker = MockRerankerProvider;
+        let scores = reranker
+            .score_batch(
+                "validate token",
+                &["validate the token here", "unrelated stuff", "token"],
+            )
+            .unwrap();
+        assert_eq!(scores.len(), 3);
+        assert!(scores[0] > scores[1]);
+        assert!(scores[2] > scores[1]);
+    }
+
+    #[test]
+    fn mock_reranker_empty_documents() {
+        let mut reranker = MockRerankerProvider;
+        let scores = reranker.score_batch("test", &[]).unwrap();
+        assert!(scores.is_empty());
+    }
+}

--- a/crates/cartog-rag/src/providers/local.rs
+++ b/crates/cartog-rag/src/providers/local.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, Result};
+use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
+use tracing::info;
+
+use crate::model_cache_dir;
+use crate::provider::{EmbeddingProvider, RerankerProvider};
+
+const EMBED_BATCH_SIZE: usize = 64;
+
+/// Local ONNX embedding provider via fastembed.
+pub struct LocalEmbeddingProvider {
+    model: TextEmbedding,
+    dim: usize,
+    query_prefix: Option<String>,
+    document_prefix: Option<String>,
+}
+
+impl LocalEmbeddingProvider {
+    /// Create a new local embedding provider.
+    ///
+    /// `model_name`: fastembed model code (e.g. "BAAI/bge-small-en-v1.5") or None for default.
+    /// `query_prefix` / `document_prefix`: optional prefixes for asymmetric models.
+    pub fn new(
+        model_name: Option<&str>,
+        query_prefix: Option<String>,
+        document_prefix: Option<String>,
+    ) -> Result<Self> {
+        let embedding_model = match model_name {
+            Some(name) => name
+                .parse::<EmbeddingModel>()
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
+            None => EmbeddingModel::BGESmallENV15Q,
+        };
+
+        let model_info = TextEmbedding::get_model_info(&embedding_model)?;
+        let dim = model_info.dim;
+
+        let is_cached = crate::is_embedding_model_cached();
+        if is_cached {
+            info!("Loading embedding model...");
+        } else {
+            info!("Downloading embedding model (first time only)...");
+        }
+
+        let model = TextEmbedding::try_new(
+            TextInitOptions::new(embedding_model)
+                .with_cache_dir(model_cache_dir())
+                .with_show_download_progress(true),
+        )
+        .context("Failed to initialize embedding model")?;
+
+        Ok(Self {
+            model,
+            dim,
+            query_prefix,
+            document_prefix,
+        })
+    }
+}
+
+impl EmbeddingProvider for LocalEmbeddingProvider {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    fn dimension(&self) -> usize {
+        self.dim
+    }
+
+    fn embed_query(&mut self, text: &str) -> Result<Vec<f32>> {
+        let owned;
+        let input: &str = match &self.query_prefix {
+            Some(prefix) => {
+                owned = format!("{prefix}{text}");
+                &owned
+            }
+            None => text,
+        };
+        let results = self
+            .model
+            .embed(vec![input], Some(1))
+            .context("Embedding query failed")?;
+        results.into_iter().next().context("No embedding returned")
+    }
+
+    fn embed_document(&mut self, text: &str) -> Result<Vec<f32>> {
+        let owned;
+        let input: &str = match &self.document_prefix {
+            Some(prefix) => {
+                owned = format!("{prefix}{text}");
+                &owned
+            }
+            None => text,
+        };
+        let results = self
+            .model
+            .embed(vec![input], Some(1))
+            .context("Embedding document failed")?;
+        results.into_iter().next().context("No embedding returned")
+    }
+
+    fn embed_documents(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        match &self.document_prefix {
+            Some(prefix) => {
+                let prefixed: Vec<String> = texts.iter().map(|t| format!("{prefix}{t}")).collect();
+                let refs: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
+                self.model
+                    .embed(refs, Some(EMBED_BATCH_SIZE))
+                    .context("Batch embedding failed")
+            }
+            None => self
+                .model
+                .embed(texts, Some(EMBED_BATCH_SIZE))
+                .context("Batch embedding failed"),
+        }
+    }
+}
+
+/// Local ONNX cross-encoder re-ranker via fastembed.
+pub struct LocalRerankerProvider {
+    model: fastembed::TextRerank,
+}
+
+impl LocalRerankerProvider {
+    pub fn load() -> Result<Self> {
+        if crate::is_reranker_model_cached() {
+            info!("Loading reranker model...");
+        } else {
+            info!("Downloading reranker model (~1.1GB, first time only)...");
+        }
+
+        let model = fastembed::TextRerank::try_new(
+            fastembed::RerankInitOptions::new(fastembed::RerankerModel::BGERerankerBase)
+                .with_cache_dir(model_cache_dir())
+                .with_show_download_progress(true),
+        )
+        .context("Failed to initialize cross-encoder model")?;
+
+        Ok(Self { model })
+    }
+}
+
+impl RerankerProvider for LocalRerankerProvider {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    fn score_batch(&mut self, query: &str, documents: &[&str]) -> Result<Vec<f32>> {
+        if documents.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let results = self
+            .model
+            .rerank(query, documents, false, None)
+            .context("Cross-encoder batch scoring failed")?;
+
+        let mut scores = vec![0.0f32; documents.len()];
+        for r in &results {
+            scores[r.index] = r.score;
+        }
+
+        Ok(scores)
+    }
+}

--- a/crates/cartog-rag/src/providers/mod.rs
+++ b/crates/cartog-rag/src/providers/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "provider-local")]
+pub mod local;
+#[cfg(feature = "provider-ollama")]
+pub mod ollama;

--- a/crates/cartog-rag/src/providers/mod.rs
+++ b/crates/cartog-rag/src/providers/mod.rs
@@ -1,3 +1,6 @@
+pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434";
+pub const DEFAULT_OLLAMA_MODEL: &str = "nomic-embed-text";
+
 #[cfg(feature = "provider-local")]
 pub mod local;
 #[cfg(feature = "provider-ollama")]

--- a/crates/cartog-rag/src/providers/ollama.rs
+++ b/crates/cartog-rag/src/providers/ollama.rs
@@ -1,0 +1,157 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::provider::EmbeddingProvider;
+
+const DEFAULT_BASE_URL: &str = "http://localhost:11434";
+const DEFAULT_MODEL: &str = "nomic-embed-text";
+
+/// Ollama embedding provider using the `/api/embed` endpoint.
+pub struct OllamaEmbeddingProvider {
+    client: reqwest::blocking::Client,
+    base_url: String,
+    model: String,
+    dim: usize,
+}
+
+#[derive(Serialize)]
+struct EmbedRequest<'a> {
+    model: &'a str,
+    input: Vec<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct EmbedResponse {
+    embeddings: Vec<Vec<f32>>,
+}
+
+impl OllamaEmbeddingProvider {
+    pub fn new(
+        base_url: Option<&str>,
+        model: Option<&str>,
+        dimension: Option<usize>,
+    ) -> Result<Self> {
+        let base_url = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
+        let model = model.unwrap_or(DEFAULT_MODEL);
+
+        info!(base_url, model, "Connecting to Ollama embedding server");
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        // Probe the server to detect dimension if not explicitly set
+        let dim = match dimension {
+            Some(d) => d,
+            None => {
+                info!("Detecting embedding dimension from Ollama...");
+                let probe_resp = client
+                    .post(format!("{base_url}/api/embed"))
+                    .json(&EmbedRequest {
+                        model,
+                        input: vec!["dimension probe"],
+                    })
+                    .send()
+                    .context("Failed to connect to Ollama server")?
+                    .error_for_status()
+                    .context("Ollama returned an error")?
+                    .json::<EmbedResponse>()
+                    .context("Failed to parse Ollama response")?;
+
+                let d = probe_resp.embeddings.first().map(|v| v.len()).unwrap_or(0);
+                if d == 0 {
+                    anyhow::bail!(
+                        "Ollama returned empty embedding — check model '{model}' is pulled"
+                    );
+                }
+                info!(dimension = d, "Detected Ollama embedding dimension");
+                d
+            }
+        };
+
+        Ok(Self {
+            client,
+            base_url: base_url.to_string(),
+            model: model.to_string(),
+            dim,
+        })
+    }
+
+    fn embed_texts(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let resp = self
+            .client
+            .post(format!("{}/api/embed", self.base_url))
+            .json(&EmbedRequest {
+                model: &self.model,
+                input: texts.to_vec(),
+            })
+            .send()
+            .context("Ollama embed request failed")?
+            .error_for_status()
+            .context("Ollama returned an error")?
+            .json::<EmbedResponse>()
+            .context("Failed to parse Ollama embed response")?;
+
+        if resp.embeddings.len() != texts.len() {
+            anyhow::bail!(
+                "Ollama returned {} embeddings for {} inputs",
+                resp.embeddings.len(),
+                texts.len()
+            );
+        }
+
+        Ok(resp.embeddings)
+    }
+}
+
+impl EmbeddingProvider for OllamaEmbeddingProvider {
+    fn name(&self) -> &str {
+        "ollama"
+    }
+
+    fn dimension(&self) -> usize {
+        self.dim
+    }
+
+    fn embed_document(&mut self, text: &str) -> Result<Vec<f32>> {
+        let results = self.embed_texts(&[text])?;
+        results
+            .into_iter()
+            .next()
+            .context("No embedding returned from Ollama")
+    }
+
+    fn embed_documents(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.embed_texts(texts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_embed_request_serialization() {
+        let req = EmbedRequest {
+            model: "nomic-embed-text",
+            input: vec!["hello world", "test"],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("nomic-embed-text"));
+        assert!(json.contains("hello world"));
+    }
+
+    #[test]
+    fn test_embed_response_deserialization() {
+        let json = r#"{"embeddings":[[0.1, 0.2, 0.3],[0.4, 0.5, 0.6]]}"#;
+        let resp: EmbedResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.embeddings.len(), 2);
+        assert_eq!(resp.embeddings[0], vec![0.1, 0.2, 0.3]);
+    }
+}

--- a/crates/cartog-rag/src/providers/ollama.rs
+++ b/crates/cartog-rag/src/providers/ollama.rs
@@ -105,6 +105,16 @@ impl OllamaEmbeddingProvider {
             );
         }
 
+        for (i, emb) in resp.embeddings.iter().enumerate() {
+            if emb.len() != self.dim {
+                anyhow::bail!(
+                    "Ollama embedding[{i}] has dimension {} but expected {dim}",
+                    emb.len(),
+                    dim = self.dim
+                );
+            }
+        }
+
         Ok(resp.embeddings)
     }
 }

--- a/crates/cartog-rag/src/providers/ollama.rs
+++ b/crates/cartog-rag/src/providers/ollama.rs
@@ -4,9 +4,6 @@ use tracing::info;
 
 use crate::provider::EmbeddingProvider;
 
-const DEFAULT_BASE_URL: &str = "http://localhost:11434";
-const DEFAULT_MODEL: &str = "nomic-embed-text";
-
 /// Ollama embedding provider using the `/api/embed` endpoint.
 pub struct OllamaEmbeddingProvider {
     client: reqwest::blocking::Client,
@@ -32,8 +29,10 @@ impl OllamaEmbeddingProvider {
         model: Option<&str>,
         dimension: Option<usize>,
     ) -> Result<Self> {
-        let base_url = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
-        let model = model.unwrap_or(DEFAULT_MODEL);
+        let base_url = base_url
+            .unwrap_or(super::DEFAULT_OLLAMA_BASE_URL)
+            .trim_end_matches('/');
+        let model = model.unwrap_or(super::DEFAULT_OLLAMA_MODEL);
 
         info!(base_url, model, "Connecting to Ollama embedding server");
 

--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -3,8 +3,6 @@ use std::collections::HashMap;
 use anyhow::Result;
 use serde::Serialize;
 
-use std::sync::Mutex;
-
 use cartog_core::{Symbol, SymbolKind};
 use cartog_db::Database;
 
@@ -19,58 +17,7 @@ pub enum KindFilter {
     CodeOnly,
 }
 
-use super::embeddings::{embedding_to_bytes, EmbeddingEngine};
-use super::reranker::CrossEncoderEngine;
-
-/// Cached embedding engine — loaded once, reused across search calls.
-static EMBEDDING_ENGINE: Mutex<Option<EmbeddingEngine>> = Mutex::new(None);
-
-/// Cached cross-encoder engine — loaded once, reused across search calls.
-/// Uses tri-state: None = not attempted, Some(None) = load failed, Some(Some(_)) = ready.
-static RERANKER_ENGINE: Mutex<Option<Option<CrossEncoderEngine>>> = Mutex::new(None);
-
-/// Get or initialize the cached embedding engine.
-///
-/// NOTE: The Mutex is held for the entire duration of model inference.
-/// This is fine for single-threaded CLI and MCP usage (one query at a time).
-/// If the MCP server becomes multi-threaded with concurrent queries,
-/// this should be replaced with a pool or per-thread engine.
-fn with_embedding_engine<F, R>(f: F) -> Result<R>
-where
-    F: FnOnce(&mut EmbeddingEngine) -> Result<R>,
-{
-    let mut guard = EMBEDDING_ENGINE
-        .lock()
-        .map_err(|_| anyhow::anyhow!("embedding engine lock poisoned"))?;
-    if guard.is_none() {
-        *guard = Some(EmbeddingEngine::new()?);
-    }
-    f(guard.as_mut().unwrap())
-}
-
-/// Get or initialize the cached cross-encoder engine.
-///
-/// Returns None if model is not available (not downloaded) or lock is poisoned.
-/// Uses tri-state caching: once a load attempt fails, it is not retried,
-/// avoiding repeated filesystem/network probes on every search call.
-fn with_reranker_engine<F, R>(f: F) -> Option<R>
-where
-    F: FnOnce(&mut CrossEncoderEngine) -> R,
-{
-    let mut guard = RERANKER_ENGINE.lock().ok()?;
-    if guard.is_none() {
-        // First attempt: try to load, cache the result either way
-        match CrossEncoderEngine::load() {
-            Ok(engine) => *guard = Some(Some(engine)),
-            Err(e) => {
-                tracing::debug!(error = %e, "Cross-encoder not available, skipping re-ranking");
-                *guard = Some(None); // Cache the failure — don't retry
-                return None;
-            }
-        }
-    }
-    guard.as_mut().unwrap().as_mut().map(f)
-}
+use super::provider::{embedding_to_bytes, EmbeddingProvider, RerankerProvider};
 
 /// A search result combining symbol metadata with relevance info.
 #[derive(Debug, Clone, Serialize)]
@@ -125,11 +72,13 @@ fn rrf_merge(ranked_lists: &[(&str, Vec<String>)], k: f64) -> Vec<(String, f64, 
 ///
 /// When `kind_filter` is set, results are filtered before applying `limit`,
 /// so the caller always gets up to `limit` results of the requested kind.
-pub fn hybrid_search(
+pub fn hybrid_search<E: EmbeddingProvider + ?Sized>(
     db: &Database,
     query: &str,
     limit: u32,
     kind_filter: KindFilter,
+    embedding_provider: &mut E,
+    reranker: Option<&mut dyn RerankerProvider>,
 ) -> Result<HybridSearchResult> {
     let retrieval_limit = (limit * 3).max(20); // Over-retrieve for better merge
 
@@ -139,7 +88,7 @@ pub fn hybrid_search(
 
     // 2. Vector search (if embeddings exist in the DB)
     let vec_results = if db.embedding_count()? > 0 {
-        vector_search(db, query, retrieval_limit)?
+        vector_search(db, query, retrieval_limit, embedding_provider)?
     } else {
         Vec::new()
     };
@@ -184,7 +133,7 @@ pub fn hybrid_search(
         }
     }
 
-    // 5. Cross-encoder re-ranking (if model is available).
+    // 5. Cross-encoder re-ranking (if provider is available).
     //    Cap at 50 candidates to bound latency.
     const RERANK_MAX: usize = 50;
     let rerank_slice = if candidates.len() > RERANK_MAX {
@@ -192,9 +141,9 @@ pub fn hybrid_search(
     } else {
         &mut candidates[..]
     };
-    with_reranker_engine(|engine| {
-        rerank_candidates(engine, query, rerank_slice);
-    });
+    if let Some(reranker) = reranker {
+        rerank_candidates(reranker, query, rerank_slice);
+    }
 
     // 5b. Stable tiebreaker: within same score, prefer higher in-degree (more referenced).
     candidates.sort_by(|a, b| {
@@ -246,7 +195,7 @@ pub fn hybrid_search(
 /// then re-sorts by cross-encoder score descending.
 /// Candidates without content retain their original order at the end.
 fn rerank_candidates(
-    engine: &mut CrossEncoderEngine,
+    reranker: &mut dyn RerankerProvider,
     query: &str,
     candidates: &mut [SearchResult],
 ) {
@@ -267,7 +216,7 @@ fn rerank_candidates(
         .map(|&i| candidates[i].content.as_deref().unwrap())
         .collect();
 
-    match engine.score_batch(query, &docs) {
+    match reranker.score_batch(query, &docs) {
         Ok(scores) => {
             for (&idx, score) in scoreable_indices.iter().zip(scores.iter()) {
                 candidates[idx].rerank_score = Some(*score as f64);
@@ -277,15 +226,7 @@ fn rerank_candidates(
             tracing::warn!(error = %e, "Cross-encoder batch scoring failed, keeping RRF order");
         }
     }
-
-    // Stable sort: candidates with rerank_score come first (sorted by score desc),
-    // then candidates without score (in original RRF order).
-    candidates.sort_by(|a, b| match (a.rerank_score, b.rerank_score) {
-        (Some(sa), Some(sb)) => sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => std::cmp::Ordering::Equal,
-    });
+    // Caller (hybrid_search) handles final sorting by rerank_score + RRF + in_degree.
 }
 
 /// FTS5 search with safe query escaping.
@@ -339,8 +280,13 @@ fn is_fts5_syntax_error(err: &anyhow::Error) -> bool {
 }
 
 /// Vector search: embed the query and find nearest neighbors.
-fn vector_search(db: &Database, query: &str, limit: u32) -> Result<Vec<String>> {
-    let query_embedding = with_embedding_engine(|engine| engine.embed(query))?;
+fn vector_search<E: EmbeddingProvider + ?Sized>(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    provider: &mut E,
+) -> Result<Vec<String>> {
+    let query_embedding = provider.embed_query(query)?;
     let query_bytes = embedding_to_bytes(&query_embedding);
 
     let nn_results = db.vector_search(&query_bytes, limit)?;
@@ -362,6 +308,7 @@ fn vector_search(db: &Database, query: &str, limit: u32) -> Result<Vec<String>> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::test_utils::MockEmbeddingProvider;
     use cartog_core::SymbolKind;
 
     /// Create a symbol + content pair and insert into the database.
@@ -513,7 +460,15 @@ mod tests {
         seed_python_corpus(&db);
 
         // "validate token" should rank validate_token #1 (both terms in name+content)
-        let result = hybrid_search(&db, "validate token", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "validate token",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(result.fts_count > 0, "FTS5 should find results");
         assert_eq!(result.vec_count, 0, "no embeddings → no vector results");
         assert_eq!(result.results[0].symbol.name, "validate_token");
@@ -532,7 +487,15 @@ mod tests {
         }
 
         // "authenticate" should find AuthService (content match)
-        let result = hybrid_search(&db, "authenticate", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "authenticate",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "AuthService");
 
         // send_email should NOT appear for an auth-related query
@@ -576,7 +539,15 @@ mod tests {
         );
 
         // "connect" matches DatabaseConnection's content; the others don't mention "connect"
-        let result = hybrid_search(&db, "connect", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "connect",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "DatabaseConnection");
         assert_eq!(
             result.results.len(),
@@ -585,7 +556,15 @@ mod tests {
         );
 
         // "router" should rank createRouter #1
-        let result = hybrid_search(&db, "router", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "router",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "createRouter");
     }
 
@@ -618,15 +597,39 @@ mod tests {
         );
 
         // "extract symbols" — both terms in extract's content; Database/resolve_edges don't have "extract"
-        let result = hybrid_search(&db, "extract symbols", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "extract symbols",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "extract");
 
         // "resolve edges" — only resolve_edges has both terms
-        let result = hybrid_search(&db, "resolve edges", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "resolve edges",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "resolve_edges");
 
         // "Database" should not return extract or resolve_edges as #1
-        let result = hybrid_search(&db, "Database", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "Database",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "Database");
     }
 
@@ -651,7 +654,15 @@ mod tests {
         );
 
         // "handle request" — HandleRequest has both terms in name+content
-        let result = hybrid_search(&db, "handle request", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "handle request",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "HandleRequest");
 
         // Repository should not appear for "handle request" (no shared terms)
@@ -684,7 +695,15 @@ mod tests {
         );
 
         // "session" — SessionManager has it in name+content, migrate doesn't
-        let result = hybrid_search(&db, "session", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "session",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "SessionManager");
         let names: Vec<&str> = result
             .results
@@ -697,7 +716,15 @@ mod tests {
         );
 
         // "migrate" — exact name match
-        let result = hybrid_search(&db, "migrate", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "migrate",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results[0].symbol.name, "migrate");
     }
 
@@ -709,7 +736,15 @@ mod tests {
         seed_python_corpus(&db);
 
         // "token" appears in validate_token and generate_token content, NOT in send_email
-        let result = hybrid_search(&db, "token", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "token",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         let names: Vec<&str> = result
             .results
             .iter()
@@ -737,7 +772,15 @@ mod tests {
         // "validate token" as a phrase matches validate_token exactly (FTS5 splits
         // underscores into separate tokens). generate_token doesn't match the phrase
         // because "validate" is not in its content.
-        let result = hybrid_search(&db, "validate token", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "validate token",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             result.results[0].symbol.name, "validate_token",
             "symbol matching both terms as phrase should rank #1"
@@ -745,7 +788,15 @@ mod tests {
 
         // Now test OR ranking: "generate token" — generate_token and AuthService both
         // contain "generate" and "token". Both should appear in top results.
-        let result = hybrid_search(&db, "generate token", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "generate token",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         let top_names: Vec<&str> = result
             .results
             .iter()
@@ -787,7 +838,15 @@ mod tests {
         );
 
         // "database" matches via normalized_name column ("database connection")
-        let result = hybrid_search(&db, "database", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "database",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             result.results.len(),
             1,
@@ -817,7 +876,15 @@ mod tests {
         );
 
         // "validate token" as phrase matches normalized_name "validate token" exactly
-        let result = hybrid_search(&db, "validate token", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "validate token",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(
             !result.results.is_empty(),
             "phrase 'validate token' should match validateToken via normalized_name"
@@ -837,7 +904,15 @@ mod tests {
             "TOKEN_EXPIRY = 3600",
         );
 
-        let result = hybrid_search(&db, "token expiry", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "token expiry",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             result.results.len(),
             1,
@@ -860,7 +935,15 @@ mod tests {
         // FTS5 is token-based, not substring-based.
         // "valid" does NOT match "validate" or "validate_token".
         // Use `cartog search` for substring matching.
-        let result = hybrid_search(&db, "valid", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "valid",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(
             result.results.is_empty(),
             "FTS5 does not do substring matching — 'valid' should not match 'validate_token'. \
@@ -893,7 +976,15 @@ mod tests {
         // "validate response" — no symbol has these words adjacent (phrase won't match).
         // AND fallback: process_request has both "validate" and "response" in content.
         // build_response has only "response" — should rank below process_request.
-        let result = hybrid_search(&db, "validate response", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "validate response",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(
             !result.results.is_empty(),
             "AND fallback should find results"
@@ -912,19 +1003,41 @@ mod tests {
         seed_python_corpus(&db);
 
         // Without filter: "token" matches functions and possibly classes
-        let all = hybrid_search(&db, "token", 10, KindFilter::All).unwrap();
+        let all = hybrid_search(
+            &db,
+            "token",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(all.results.len() >= 2);
 
         // With kind=Function filter: only functions returned, still respects limit
-        let funcs =
-            hybrid_search(&db, "token", 10, KindFilter::Exact(SymbolKind::Function)).unwrap();
+        let funcs = hybrid_search(
+            &db,
+            "token",
+            10,
+            KindFilter::Exact(SymbolKind::Function),
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         for r in &funcs.results {
             assert_eq!(r.symbol.kind, SymbolKind::Function);
         }
 
         // With kind=Class: AuthService mentions "token" in content
-        let classes =
-            hybrid_search(&db, "token", 10, KindFilter::Exact(SymbolKind::Class)).unwrap();
+        let classes = hybrid_search(
+            &db,
+            "token",
+            10,
+            KindFilter::Exact(SymbolKind::Class),
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         for r in &classes.results {
             assert_eq!(r.symbol.kind, SymbolKind::Class);
         }
@@ -956,8 +1069,15 @@ mod tests {
         }
 
         // Request 3 functions — should get exactly 3 despite 10 total matches
-        let result =
-            hybrid_search(&db, "handler", 3, KindFilter::Exact(SymbolKind::Function)).unwrap();
+        let result = hybrid_search(
+            &db,
+            "handler",
+            3,
+            KindFilter::Exact(SymbolKind::Function),
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             result.results.len(),
             3,
@@ -998,7 +1118,15 @@ mod tests {
             "func validate(token string) bool {\n\treturn checkSignature(token)\n}",
         );
 
-        let result = hybrid_search(&db, "validate", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "validate",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             result.results.len(),
             3,
@@ -1023,7 +1151,15 @@ mod tests {
             "def foo(): pass",
         );
 
-        let result = hybrid_search(&db, "zzz_nonexistent_term", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "zzz_nonexistent_term",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(result.results.is_empty());
         assert_eq!(result.fts_count, 0);
         assert_eq!(result.vec_count, 0);
@@ -1035,7 +1171,15 @@ mod tests {
         let content = "def greet(name: str) -> str:\n    return f'Hello, {name}!'";
         insert_symbol_with_content(&db, "greet", SymbolKind::Function, "hello.py", 1, content);
 
-        let result = hybrid_search(&db, "greet", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "greet",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.results.len(), 1);
         assert_eq!(result.results[0].content.as_deref(), Some(content));
     }
@@ -1054,7 +1198,15 @@ mod tests {
             );
         }
 
-        let result = hybrid_search(&db, "handler", 3, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "handler",
+            3,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             result.results.len(),
             3,
@@ -1155,7 +1307,15 @@ mod tests {
             "def process_data(items):\n    return [transform(i) for i in items]",
         );
 
-        let result = hybrid_search(&db, "process data", 10, KindFilter::All).unwrap();
+        let result = hybrid_search(
+            &db,
+            "process data",
+            10,
+            KindFilter::All,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+        )
+        .unwrap();
         assert!(!result.results.is_empty());
 
         // Re-ranking depends on whether the cross-encoder model is downloadable.

--- a/crates/cartog-watch/README.md
+++ b/crates/cartog-watch/README.md
@@ -36,7 +36,7 @@ Both modes open their own `Database` connection (SQLite WAL allows concurrent re
 
 | Export | Description |
 |--------|-------------|
-| `WatchConfig` | Configuration: root path, debounce window, RAG toggle, RAG delay |
+| `WatchConfig` | Configuration: root path, debounce window, RAG toggle, RAG delay, `rag_config` (RAG provider configuration for embedding + reranker, threaded from `.cartog.toml`) |
 | `WatchHandle` | Handle to stop a background watcher (via `stop()` or `Drop`) |
 | `spawn_watch()` | Start watching on a background thread |
 | `run_watch()` | Start watching in the foreground (blocking) |

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -29,6 +29,8 @@ pub struct WatchConfig {
     pub rag: bool,
     /// Delay after last index before embedding (only when `rag` is true).
     pub rag_delay: Duration,
+    /// RAG provider configuration (embedding + reranker).
+    pub rag_config: rag::EmbeddingProviderConfig,
 }
 
 impl WatchConfig {
@@ -38,6 +40,7 @@ impl WatchConfig {
             debounce: Duration::from_secs(2),
             rag: false,
             rag_delay: Duration::from_secs(30),
+            rag_config: rag::EmbeddingProviderConfig::default(),
         }
     }
 }
@@ -135,7 +138,8 @@ fn watch_loop(
     db_path: &str,
     shutdown: &AtomicBool,
 ) -> Result<()> {
-    let db = Database::open(db_path).context("failed to open database for watcher")?;
+    let db = Database::open(db_path, config.rag_config.resolved_dimension())
+        .context("failed to open database for watcher")?;
 
     info!(
         path = %root.display(),
@@ -242,7 +246,10 @@ fn watch_loop(
                     if let Some(last) = last_index_time {
                         if last.elapsed() >= config.rag_delay {
                             info!("RAG delay elapsed, embedding pending symbols");
-                            match rag::indexer::index_embeddings(&db, false) {
+                            let provider = rag::create_embedding_provider(&config.rag_config);
+                            match provider.and_then(|mut p| {
+                                rag::indexer::index_embeddings(&db, p.as_mut(), false)
+                            }) {
                                 Ok(r) => {
                                     info!(
                                         embedded = r.symbols_embedded,
@@ -270,7 +277,8 @@ fn watch_loop(
     // Flush pending RAG embeddings on shutdown
     if config.rag && rag_pending {
         info!("flushing pending RAG embeddings before shutdown");
-        match rag::indexer::index_embeddings(&db, false) {
+        let provider = rag::create_embedding_provider(&config.rag_config);
+        match provider.and_then(|mut p| rag::indexer::index_embeddings(&db, p.as_mut(), false)) {
             Ok(r) => info!(embedded = r.symbols_embedded, "final RAG flush complete"),
             Err(e) => warn!(error = %e, "final RAG flush failed"),
         }

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -173,6 +173,26 @@ fn watch_loop(
 
     info!("watching for changes (Ctrl+C to stop)");
 
+    // Create the embedding provider once (lazy, on first RAG use)
+    let mut rag_provider: Option<Box<dyn rag::provider::EmbeddingProvider>> = None;
+    let ensure_provider =
+        |provider: &mut Option<Box<dyn rag::provider::EmbeddingProvider>>| -> bool {
+            if provider.is_none() {
+                match rag::create_embedding_provider(&config.rag_config) {
+                    Ok(p) => {
+                        *provider = Some(p);
+                        true
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "failed to create embedding provider");
+                        false
+                    }
+                }
+            } else {
+                true
+            }
+        };
+
     // RAG timer state: when we last indexed (to defer embedding)
     let mut rag_pending = false;
     let mut last_index_time: Option<Instant> = None;
@@ -246,19 +266,24 @@ fn watch_loop(
                     if let Some(last) = last_index_time {
                         if last.elapsed() >= config.rag_delay {
                             info!("RAG delay elapsed, embedding pending symbols");
-                            let provider = rag::create_embedding_provider(&config.rag_config);
-                            match provider.and_then(|mut p| {
-                                rag::indexer::index_embeddings(&db, p.as_mut(), false)
-                            }) {
-                                Ok(r) => {
-                                    info!(
-                                        embedded = r.symbols_embedded,
-                                        skipped = r.symbols_skipped,
-                                        "RAG embedding complete"
-                                    );
-                                }
-                                Err(e) => {
-                                    warn!(error = %e, "RAG embedding failed");
+                            if !ensure_provider(&mut rag_provider) {
+                                rag_pending = false;
+                                last_index_time = None;
+                                continue;
+                            }
+                            if let Some(ref mut provider) = rag_provider {
+                                match rag::indexer::index_embeddings(&db, provider.as_mut(), false)
+                                {
+                                    Ok(r) => {
+                                        info!(
+                                            embedded = r.symbols_embedded,
+                                            skipped = r.symbols_skipped,
+                                            "RAG embedding complete"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "RAG embedding failed");
+                                    }
                                 }
                             }
                             rag_pending = false;
@@ -277,10 +302,12 @@ fn watch_loop(
     // Flush pending RAG embeddings on shutdown
     if config.rag && rag_pending {
         info!("flushing pending RAG embeddings before shutdown");
-        let provider = rag::create_embedding_provider(&config.rag_config);
-        match provider.and_then(|mut p| rag::indexer::index_embeddings(&db, p.as_mut(), false)) {
-            Ok(r) => info!(embedded = r.symbols_embedded, "final RAG flush complete"),
-            Err(e) => warn!(error = %e, "final RAG flush failed"),
+        ensure_provider(&mut rag_provider);
+        if let Some(ref mut provider) = rag_provider {
+            match rag::indexer::index_embeddings(&db, provider.as_mut(), false) {
+                Ok(r) => info!(embedded = r.symbols_embedded, "final RAG flush complete"),
+                Err(e) => warn!(error = %e, "final RAG flush failed"),
+            }
         }
     }
 

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { workspace = true }
 [features]
 default = []
 lsp = ["dep:cartog-lsp", "cartog-indexer/lsp", "cartog-mcp/lsp"]
+ollama-embedding = ["cartog-rag/provider-ollama"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/cartog/README.md
+++ b/crates/cartog/README.md
@@ -38,6 +38,8 @@ Database path is resolved with a 4-tier priority:
 3. Auto git-root detection — `.cartog.db` next to `.git/`
 4. Fallback — `.cartog.db` in the current directory
 
+`.cartog.toml` also configures RAG providers via `[embedding]` (provider, model, dimension) and `[reranker]` (provider) sections. See `crates/cartog-rag/README.md` for details.
+
 ### Logging
 
 All log output goes to **stderr** (stdout is reserved for CLI output and MCP protocol). Default level is `warn` for CLI commands, `info` for `serve`, `watch`, and `rag` operations. Override with `RUST_LOG`.

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -153,6 +153,9 @@ pub enum Command {
     /// Index statistics summary
     Stats,
 
+    /// Display the current configuration
+    Config,
+
     /// Search symbols by name (case-insensitive prefix + substring match)
     Search {
         /// Query string to match against symbol names

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -62,12 +62,19 @@ fn output<T: Serialize>(
 }
 
 /// Build or rebuild the code graph index.
-pub fn cmd_index(db_path: &Path, path: &str, force: bool, lsp: bool, json: bool) -> Result<()> {
+pub fn cmd_index(
+    db_path: &Path,
+    path: &str,
+    force: bool,
+    lsp: bool,
+    json: bool,
+    embedding_dim: usize,
+) -> Result<()> {
     let root = Path::new(path);
     if !json {
         eprint!("Indexing {path}...");
     }
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
 
     let result = indexer::index_directory(&db, root, force, lsp)?;
     if !json {
@@ -111,8 +118,9 @@ pub fn cmd_outline(
     file: &str,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let symbols = db.outline(file)?;
     let file = file.to_string();
 
@@ -151,8 +159,9 @@ pub fn cmd_callees(
     name: &str,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let edges = db.callees(name)?;
     let name = name.to_string();
 
@@ -180,8 +189,9 @@ pub fn cmd_impact(
     depth: u32,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let results = db.impact(name, depth)?;
     let name = name.to_string();
 
@@ -222,8 +232,9 @@ pub fn cmd_refs(
     kind: Option<EdgeKindFilter>,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let kind_filter = kind.map(EdgeKind::from);
     let results = db.refs(name, kind_filter)?;
     let name = name.to_string();
@@ -268,8 +279,9 @@ pub fn cmd_hierarchy(
     name: &str,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let pairs = db.hierarchy(name)?;
     let name = name.to_string();
 
@@ -297,8 +309,14 @@ pub fn cmd_hierarchy(
 }
 
 /// File-level import dependencies.
-pub fn cmd_deps(db_path: &Path, file: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+pub fn cmd_deps(
+    db_path: &Path,
+    file: &str,
+    json: bool,
+    token_budget: Option<u32>,
+    embedding_dim: usize,
+) -> Result<()> {
+    let db = open_db(db_path, embedding_dim)?;
     let edges = db.file_deps(file)?;
     let file = file.to_string();
 
@@ -319,6 +337,7 @@ pub fn cmd_deps(db_path: &Path, file: &str, json: bool, token_budget: Option<u32
 }
 
 /// Search for symbols by name (case-insensitive prefix + substring match).
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_search(
     db_path: &Path,
     query: &str,
@@ -327,8 +346,9 @@ pub fn cmd_search(
     limit: u32,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let kind_filter = kind.map(cartog_core::SymbolKind::from);
     let limit = limit.min(MAX_SEARCH_LIMIT);
     let symbols = db.search(query, kind_filter, file, limit)?;
@@ -353,8 +373,8 @@ pub fn cmd_search(
 }
 
 /// Index statistics summary.
-pub fn cmd_stats(db_path: &Path, json: bool) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize) -> Result<()> {
+    let db = open_db(db_path, embedding_dim)?;
     let stats = db.stats()?;
 
     output(&stats, json, None, |stats| {
@@ -382,8 +402,8 @@ pub fn cmd_stats(db_path: &Path, json: bool) -> Result<()> {
 }
 
 /// Token-budget-aware codebase summary: file tree + top symbols ranked by centrality.
-pub fn cmd_map(db_path: &Path, tokens: u32, json: bool) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+pub fn cmd_map(db_path: &Path, tokens: u32, json: bool, embedding_dim: usize) -> Result<()> {
+    let db = open_db(db_path, embedding_dim)?;
     let files = db.all_files()?;
 
     if files.is_empty() {
@@ -478,8 +498,9 @@ pub fn cmd_changes(
     kind: Option<SymbolKindFilter>,
     json: bool,
     token_budget: Option<u32>,
+    embedding_dim: usize,
 ) -> Result<()> {
-    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
+    let db = open_db(db_path, embedding_dim)?;
     let root = std::env::current_dir()?;
 
     let changed_files = indexer::git_recently_changed_files(&root, commits)?;
@@ -923,14 +944,18 @@ mod tests {
     // ── Config display tests ──
 
     fn default_config_display() -> ConfigDisplay {
+        use crate::config::{
+            DEFAULT_EMBEDDING_PROVIDER, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL,
+            DEFAULT_RERANKER_PROVIDER,
+        };
         ConfigDisplay {
             config_file: None,
             db_path: "/tmp/test.db".into(),
             embedding: EmbeddingDisplay {
                 provider: ValueDisplay {
-                    value: "local".into(),
+                    value: DEFAULT_EMBEDDING_PROVIDER.into(),
                     is_default: true,
-                    default: "local".into(),
+                    default: DEFAULT_EMBEDDING_PROVIDER.into(),
                 },
                 model: None,
                 dimension: None,
@@ -940,22 +965,22 @@ mod tests {
                 },
                 ollama: OllamaDisplay {
                     base_url: ValueDisplay {
-                        value: "http://localhost:11434".into(),
+                        value: DEFAULT_OLLAMA_BASE_URL.into(),
                         is_default: true,
-                        default: "http://localhost:11434".into(),
+                        default: DEFAULT_OLLAMA_BASE_URL.into(),
                     },
                     model: ValueDisplay {
-                        value: "nomic-embed-text".into(),
+                        value: DEFAULT_OLLAMA_MODEL.into(),
                         is_default: true,
-                        default: "nomic-embed-text".into(),
+                        default: DEFAULT_OLLAMA_MODEL.into(),
                     },
                 },
             },
             reranker: RerankerDisplay {
                 provider: ValueDisplay {
-                    value: "local".into(),
+                    value: DEFAULT_RERANKER_PROVIDER.into(),
                     is_default: true,
-                    default: "local".into(),
+                    default: DEFAULT_RERANKER_PROVIDER.into(),
                 },
             },
         }

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -11,8 +11,8 @@ use cartog_indexer as indexer;
 use cartog_rag as rag;
 use cartog_watch::{self as watch, WatchConfig};
 
-fn open_db(path: &Path) -> Result<Database> {
-    Database::open(path).context("Failed to open cartog database")
+fn open_db(path: &Path, embedding_dim: usize) -> Result<Database> {
+    Database::open(path, embedding_dim).context("Failed to open cartog database")
 }
 
 /// Estimate token count from a string using chars/4 approximation.
@@ -66,7 +66,7 @@ pub fn cmd_index(db_path: &Path, path: &str, force: bool, lsp: bool, json: bool)
     if !json {
         eprint!("Indexing {path}...");
     }
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
 
     let result = indexer::index_directory(&db, root, force, lsp)?;
     if !json {
@@ -111,7 +111,7 @@ pub fn cmd_outline(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let symbols = db.outline(file)?;
     let file = file.to_string();
 
@@ -151,7 +151,7 @@ pub fn cmd_callees(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let edges = db.callees(name)?;
     let name = name.to_string();
 
@@ -180,7 +180,7 @@ pub fn cmd_impact(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let results = db.impact(name, depth)?;
     let name = name.to_string();
 
@@ -222,7 +222,7 @@ pub fn cmd_refs(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let kind_filter = kind.map(EdgeKind::from);
     let results = db.refs(name, kind_filter)?;
     let name = name.to_string();
@@ -268,7 +268,7 @@ pub fn cmd_hierarchy(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let pairs = db.hierarchy(name)?;
     let name = name.to_string();
 
@@ -297,7 +297,7 @@ pub fn cmd_hierarchy(
 
 /// File-level import dependencies.
 pub fn cmd_deps(db_path: &Path, file: &str, json: bool, token_budget: Option<u32>) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let edges = db.file_deps(file)?;
     let file = file.to_string();
 
@@ -327,7 +327,7 @@ pub fn cmd_search(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let kind_filter = kind.map(cartog_core::SymbolKind::from);
     let limit = limit.min(MAX_SEARCH_LIMIT);
     let symbols = db.search(query, kind_filter, file, limit)?;
@@ -353,7 +353,7 @@ pub fn cmd_search(
 
 /// Index statistics summary.
 pub fn cmd_stats(db_path: &Path, json: bool) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let stats = db.stats()?;
 
     output(&stats, json, None, |stats| {
@@ -382,7 +382,7 @@ pub fn cmd_stats(db_path: &Path, json: bool) -> Result<()> {
 
 /// Token-budget-aware codebase summary: file tree + top symbols ranked by centrality.
 pub fn cmd_map(db_path: &Path, tokens: u32, json: bool) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let files = db.all_files()?;
 
     if files.is_empty() {
@@ -478,7 +478,7 @@ pub fn cmd_changes(
     json: bool,
     token_budget: Option<u32>,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let db = open_db(db_path, cartog_db::DEFAULT_EMBEDDING_DIM)?;
     let root = std::env::current_dir()?;
 
     let changed_files = indexer::git_recently_changed_files(&root, commits)?;
@@ -571,13 +571,19 @@ pub fn cmd_rag_setup(json: bool) -> Result<()> {
 }
 
 /// Build embedding index for semantic search.
-pub fn cmd_rag_index(db_path: &Path, path: &str, force: bool, json: bool) -> Result<()> {
-    // First ensure the standard code graph index is up to date
+pub fn cmd_rag_index(
+    db_path: &Path,
+    path: &str,
+    force: bool,
+    json: bool,
+    provider_config: &rag::EmbeddingProviderConfig,
+) -> Result<()> {
     let root = Path::new(path);
-    let db = open_db(db_path)?;
+    let mut provider = rag::create_embedding_provider(provider_config)?;
+    let db = open_db(db_path, provider.dimension())?;
     let _index_result = indexer::index_directory(&db, root, false, false)?;
 
-    let result = rag::indexer::index_embeddings(&db, force)?;
+    let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force)?;
 
     output(&result, json, None, |r| {
         format!(
@@ -595,15 +601,28 @@ pub fn cmd_rag_search(
     limit: u32,
     json: bool,
     token_budget: Option<u32>,
+    provider_config: &rag::EmbeddingProviderConfig,
 ) -> Result<()> {
-    let db = open_db(db_path)?;
+    let mut provider = rag::create_embedding_provider(provider_config)?;
+    let db = open_db(db_path, provider.dimension())?;
     let kind_filter = match kind {
         Some(SymbolKindFilter::All) => rag::search::KindFilter::All,
         Some(k) => rag::search::KindFilter::Exact(cartog_core::SymbolKind::from(k)),
         None => rag::search::KindFilter::CodeOnly,
     };
 
-    let search_result = rag::search::hybrid_search(&db, query, limit, kind_filter)?;
+    let mut reranker = rag::create_reranker_provider(&provider_config.reranker_provider);
+    let search_result = match reranker.as_mut() {
+        Some(r) => rag::search::hybrid_search(
+            &db,
+            query,
+            limit,
+            kind_filter,
+            provider.as_mut(),
+            Some(r.as_mut()),
+        ),
+        None => rag::search::hybrid_search(&db, query, limit, kind_filter, provider.as_mut(), None),
+    }?;
     let query = query.to_string();
 
     output(&search_result, json, token_budget, |sr| {
@@ -659,11 +678,13 @@ pub fn cmd_watch(
     debounce: u64,
     rag: bool,
     rag_delay: u64,
+    provider_config: rag::EmbeddingProviderConfig,
 ) -> Result<()> {
     let mut config = WatchConfig::new(PathBuf::from(path));
     config.debounce = Duration::from_secs(debounce);
     config.rag = rag;
     config.rag_delay = Duration::from_secs(rag_delay);
+    config.rag_config = provider_config;
 
     let db_path_str = db_path.to_string_lossy();
     watch::run_watch(config, &db_path_str)

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::cli::{EdgeKindFilter, SymbolKindFilter};
+use crate::config::CartogConfig;
 use cartog_core::{EdgeKind, SymbolKind};
 use cartog_db::{Database, MAX_SEARCH_LIMIT};
 use cartog_indexer as indexer;
@@ -671,6 +672,200 @@ pub fn cmd_rag_search(
     })
 }
 
+/// Display the current configuration with default-value indicators.
+pub fn cmd_config(
+    config: &CartogConfig,
+    config_path: Option<&Path>,
+    db_path: &Path,
+    json: bool,
+) -> Result<()> {
+    use crate::config::{
+        DEFAULT_EMBEDDING_PROVIDER, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL,
+        DEFAULT_RERANKER_PROVIDER,
+    };
+
+    let embed = config.embedding.as_ref();
+    let ollama = embed.and_then(|e| e.ollama.as_ref());
+    let local = embed.and_then(|e| e.local.as_ref());
+    let reranker = config.reranker.as_ref();
+
+    let display = ConfigDisplay {
+        config_file: config_path.map(|p| p.to_string_lossy().into_owned()),
+        db_path: db_path.to_string_lossy().into_owned(),
+        embedding: EmbeddingDisplay {
+            provider: ValueDisplay {
+                value: embed.map_or(DEFAULT_EMBEDDING_PROVIDER.into(), |e| {
+                    e.provider().to_string()
+                }),
+                is_default: embed.map_or(true, |e| e.provider.is_none()),
+                default: DEFAULT_EMBEDDING_PROVIDER.into(),
+            },
+            model: embed.and_then(|e| e.model.clone()),
+            dimension: embed.and_then(|e| e.dimension),
+            local: LocalEmbeddingDisplay {
+                query_prefix: local.and_then(|l| l.query_prefix.clone()),
+                document_prefix: local.and_then(|l| l.document_prefix.clone()),
+            },
+            ollama: OllamaDisplay {
+                base_url: ValueDisplay {
+                    value: ollama
+                        .map_or(DEFAULT_OLLAMA_BASE_URL.into(), |o| o.base_url().to_string()),
+                    is_default: ollama.map_or(true, |o| o.base_url.is_none()),
+                    default: DEFAULT_OLLAMA_BASE_URL.into(),
+                },
+                model: ValueDisplay {
+                    value: ollama.map_or(DEFAULT_OLLAMA_MODEL.into(), |o| o.model().to_string()),
+                    is_default: ollama.map_or(true, |o| o.model.is_none()),
+                    default: DEFAULT_OLLAMA_MODEL.into(),
+                },
+            },
+        },
+        reranker: RerankerDisplay {
+            provider: ValueDisplay {
+                value: reranker.map_or(DEFAULT_RERANKER_PROVIDER.into(), |r| {
+                    r.provider().to_string()
+                }),
+                is_default: reranker.map_or(true, |r| r.provider.is_none()),
+                default: DEFAULT_RERANKER_PROVIDER.into(),
+            },
+        },
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&display)?);
+    } else {
+        print!("{}", format_config_human(&display));
+    }
+    Ok(())
+}
+
+fn format_value(v: &ValueDisplay) -> String {
+    if v.is_default {
+        format!("{} (default)", v.value)
+    } else {
+        format!("{} (default: {})", v.value, v.default)
+    }
+}
+
+fn format_optional(v: &Option<String>) -> &str {
+    match v {
+        Some(s) => s.as_str(),
+        None => "-",
+    }
+}
+
+fn format_config_human(d: &ConfigDisplay) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    writeln!(
+        out,
+        "Config file: {}",
+        d.config_file.as_deref().unwrap_or("none")
+    )
+    .unwrap();
+    writeln!(out, "Database:    {}", d.db_path).unwrap();
+
+    writeln!(out, "\n[embedding]").unwrap();
+    writeln!(
+        out,
+        "  provider:          {}",
+        format_value(&d.embedding.provider)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  model:             {}",
+        format_optional(&d.embedding.model)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  dimension:         {}",
+        d.embedding.dimension.map_or("-".into(), |v| v.to_string())
+    )
+    .unwrap();
+
+    writeln!(out, "\n[embedding.local]").unwrap();
+    writeln!(
+        out,
+        "  query_prefix:      {}",
+        format_optional(&d.embedding.local.query_prefix)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  document_prefix:   {}",
+        format_optional(&d.embedding.local.document_prefix)
+    )
+    .unwrap();
+
+    writeln!(out, "\n[embedding.ollama]").unwrap();
+    writeln!(
+        out,
+        "  base_url:          {}",
+        format_value(&d.embedding.ollama.base_url)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  model:             {}",
+        format_value(&d.embedding.ollama.model)
+    )
+    .unwrap();
+
+    writeln!(out, "\n[reranker]").unwrap();
+    writeln!(
+        out,
+        "  provider:          {}",
+        format_value(&d.reranker.provider)
+    )
+    .unwrap();
+
+    out
+}
+
+#[derive(Serialize)]
+struct ConfigDisplay {
+    config_file: Option<String>,
+    db_path: String,
+    embedding: EmbeddingDisplay,
+    reranker: RerankerDisplay,
+}
+
+#[derive(Serialize)]
+struct EmbeddingDisplay {
+    provider: ValueDisplay,
+    model: Option<String>,
+    dimension: Option<usize>,
+    local: LocalEmbeddingDisplay,
+    ollama: OllamaDisplay,
+}
+
+#[derive(Serialize)]
+struct LocalEmbeddingDisplay {
+    query_prefix: Option<String>,
+    document_prefix: Option<String>,
+}
+
+#[derive(Serialize)]
+struct OllamaDisplay {
+    base_url: ValueDisplay,
+    model: ValueDisplay,
+}
+
+#[derive(Serialize)]
+struct RerankerDisplay {
+    provider: ValueDisplay,
+}
+
+#[derive(Serialize)]
+struct ValueDisplay {
+    value: String,
+    is_default: bool,
+    default: String,
+}
+
 /// Watch for file changes and auto-re-index.
 pub fn cmd_watch(
     db_path: &Path,
@@ -723,6 +918,122 @@ mod tests {
         let text = "abcd"; // 4 bytes = 1 token
         let result = truncate_to_budget(text, 1);
         assert_eq!(result, "abcd");
+    }
+
+    // ── Config display tests ──
+
+    fn default_config_display() -> ConfigDisplay {
+        ConfigDisplay {
+            config_file: None,
+            db_path: "/tmp/test.db".into(),
+            embedding: EmbeddingDisplay {
+                provider: ValueDisplay {
+                    value: "local".into(),
+                    is_default: true,
+                    default: "local".into(),
+                },
+                model: None,
+                dimension: None,
+                local: LocalEmbeddingDisplay {
+                    query_prefix: None,
+                    document_prefix: None,
+                },
+                ollama: OllamaDisplay {
+                    base_url: ValueDisplay {
+                        value: "http://localhost:11434".into(),
+                        is_default: true,
+                        default: "http://localhost:11434".into(),
+                    },
+                    model: ValueDisplay {
+                        value: "nomic-embed-text".into(),
+                        is_default: true,
+                        default: "nomic-embed-text".into(),
+                    },
+                },
+            },
+            reranker: RerankerDisplay {
+                provider: ValueDisplay {
+                    value: "local".into(),
+                    is_default: true,
+                    default: "local".into(),
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn test_format_config_human_all_defaults() {
+        let d = default_config_display();
+        let out = format_config_human(&d);
+        assert!(out.contains("Config file: none"));
+        assert!(out.contains("Database:    /tmp/test.db"));
+        assert!(out.contains("local (default)"));
+        assert!(out.contains("model:             -"));
+        assert!(out.contains("dimension:         -"));
+        assert!(out.contains("query_prefix:      -"));
+        assert!(out.contains("document_prefix:   -"));
+    }
+
+    #[test]
+    fn test_format_config_human_custom_values() {
+        let mut d = default_config_display();
+        d.config_file = Some("/project/.cartog.toml".into());
+        d.embedding.provider = ValueDisplay {
+            value: "ollama".into(),
+            is_default: false,
+            default: "local".into(),
+        };
+        d.embedding.model = Some("nomic-embed-text".into());
+        d.embedding.dimension = Some(768);
+
+        let out = format_config_human(&d);
+        assert!(out.contains("Config file: /project/.cartog.toml"));
+        assert!(out.contains("ollama (default: local)"));
+        assert!(out.contains("model:             nomic-embed-text"));
+        assert!(out.contains("dimension:         768"));
+    }
+
+    #[test]
+    fn test_format_value_default() {
+        let v = ValueDisplay {
+            value: "local".into(),
+            is_default: true,
+            default: "local".into(),
+        };
+        assert_eq!(format_value(&v), "local (default)");
+    }
+
+    #[test]
+    fn test_format_value_overridden() {
+        let v = ValueDisplay {
+            value: "ollama".into(),
+            is_default: false,
+            default: "local".into(),
+        };
+        assert_eq!(format_value(&v), "ollama (default: local)");
+    }
+
+    #[test]
+    fn test_format_optional_some() {
+        let v = Some("value".to_string());
+        assert_eq!(format_optional(&v), "value");
+    }
+
+    #[test]
+    fn test_format_optional_none() {
+        let v: Option<String> = None;
+        assert_eq!(format_optional(&v), "-");
+    }
+
+    #[test]
+    fn test_config_display_json_serialization() {
+        let d = default_config_display();
+        let json = serde_json::to_value(&d).unwrap();
+        assert_eq!(json["db_path"], "/tmp/test.db");
+        assert_eq!(json["embedding"]["provider"]["value"], "local");
+        assert_eq!(json["embedding"]["provider"]["is_default"], true);
+        assert!(json["config_file"].is_null());
+        assert!(json["embedding"]["model"].is_null());
     }
 
     #[test]

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -349,7 +349,10 @@ pub fn cmd_search(
     embedding_dim: usize,
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
-    let kind_filter = kind.map(cartog_core::SymbolKind::from);
+    let kind_filter = match kind {
+        Some(SymbolKindFilter::All) | None => None,
+        Some(k) => Some(cartog_core::SymbolKind::from(k)),
+    };
     let limit = limit.min(MAX_SEARCH_LIMIT);
     let symbols = db.search(query, kind_filter, file, limit)?;
     let query = query.to_string();
@@ -514,7 +517,10 @@ pub fn cmd_changes(
         return Ok(());
     }
 
-    let kind_filter = kind.map(cartog_core::SymbolKind::from);
+    let kind_filter = match kind {
+        Some(SymbolKindFilter::All) | None => None,
+        Some(k) => Some(cartog_core::SymbolKind::from(k)),
+    };
     let symbols = db.symbols_for_files(&changed_files, kind_filter)?;
 
     let result = cartog_core::ChangesResult {

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -11,12 +11,103 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Default, Deserialize)]
 pub struct CartogConfig {
     pub database: Option<DatabaseConfig>,
+    pub embedding: Option<EmbeddingConfig>,
+    pub reranker: Option<RerankerConfig>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct DatabaseConfig {
     /// Filesystem path to the cartog SQLite database. Supports `~` expansion.
     pub path: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct EmbeddingConfig {
+    /// Provider type: "local" (default) or "ollama".
+    pub provider: Option<String>,
+    /// Model name. For "local": fastembed built-in name or HuggingFace repo ID.
+    /// For "ollama": model name on the Ollama server.
+    pub model: Option<String>,
+    /// Embedding dimension. Auto-detected for built-in models, required for custom HF models.
+    pub dimension: Option<usize>,
+    /// Local provider settings (ONNX via fastembed).
+    pub local: Option<LocalEmbeddingConfig>,
+    /// Ollama provider settings.
+    pub ollama: Option<OllamaConfig>,
+}
+
+impl EmbeddingConfig {
+    pub fn provider(&self) -> &str {
+        self.provider.as_deref().unwrap_or("local")
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct LocalEmbeddingConfig {
+    /// Prefix prepended to text during search (e.g. "search_query: ").
+    pub query_prefix: Option<String>,
+    /// Prefix prepended to text during indexing (e.g. "search_document: ").
+    pub document_prefix: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct OllamaConfig {
+    /// Ollama server URL (default: "http://localhost:11434").
+    pub base_url: Option<String>,
+    /// Model name (default: "nomic-embed-text").
+    pub model: Option<String>,
+}
+
+impl OllamaConfig {
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_deref().unwrap_or("http://localhost:11434")
+    }
+
+    pub fn model(&self) -> &str {
+        self.model.as_deref().unwrap_or("nomic-embed-text")
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RerankerConfig {
+    /// Provider type: "local" (default) or "none".
+    pub provider: Option<String>,
+}
+
+impl RerankerConfig {
+    pub fn provider(&self) -> &str {
+        self.provider.as_deref().unwrap_or("local")
+    }
+}
+
+/// Convert the embedding config section into an `EmbeddingProviderConfig` for cartog-rag.
+pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProviderConfig {
+    match &config.embedding {
+        Some(embed) => {
+            let (query_prefix, document_prefix) = match &embed.local {
+                Some(local) => (local.query_prefix.clone(), local.document_prefix.clone()),
+                None => (None, None),
+            };
+            let ollama = embed.ollama.as_ref();
+            cartog_rag::EmbeddingProviderConfig {
+                provider: embed.provider().to_string(),
+                model: embed
+                    .model
+                    .clone()
+                    .or_else(|| ollama.map(|o| o.model().to_string())),
+                dimension: embed.dimension,
+                query_prefix,
+                document_prefix,
+                base_url: ollama.map(|o| o.base_url().to_string()),
+                reranker_provider: config
+                    .reranker
+                    .as_ref()
+                    .map(|r| r.provider().to_string())
+                    .unwrap_or_else(|| "local".to_string()),
+            }
+        }
+        None => cartog_rag::EmbeddingProviderConfig::default(),
+    }
 }
 
 /// Load the local project config from `.cartog.toml`.
@@ -155,6 +246,7 @@ mod tests {
             database: Some(DatabaseConfig {
                 path: Some("/config/path.db".to_string()),
             }),
+            ..Default::default()
         };
         let result = resolve_db_path(Some(PathBuf::from("/explicit/path.db")), &cfg);
         assert_eq!(result, PathBuf::from("/explicit/path.db"));
@@ -166,6 +258,7 @@ mod tests {
             database: Some(DatabaseConfig {
                 path: Some("/config/proj.db".to_string()),
             }),
+            ..Default::default()
         };
         let result = resolve_db_path(None, &cfg);
         assert_eq!(result, PathBuf::from("/config/proj.db"));
@@ -199,5 +292,218 @@ mod tests {
         std::env::set_current_dir(original).unwrap();
 
         assert_eq!(result, canonical_root.join(cartog_db::DB_FILE));
+    }
+
+    // ── Embedding config tests ──
+
+    #[test]
+    fn test_embedding_config_defaults() {
+        let cfg = EmbeddingConfig::default();
+        assert_eq!(cfg.provider(), "local");
+        assert!(cfg.dimension.is_none());
+        assert!(cfg.model.is_none());
+        assert!(cfg.local.is_none());
+        assert!(cfg.ollama.is_none());
+    }
+
+    #[test]
+    fn test_embedding_config_from_toml() {
+        let toml_str = r#"
+[embedding]
+provider = "ollama"
+model = "nomic-embed-text"
+dimension = 768
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let embed = cfg.embedding.unwrap();
+        assert_eq!(embed.provider(), "ollama");
+        assert_eq!(embed.model.as_deref(), Some("nomic-embed-text"));
+        assert_eq!(embed.dimension, Some(768));
+    }
+
+    #[test]
+    fn test_embedding_config_local_with_prefixes() {
+        let toml_str = r#"
+[embedding]
+provider = "local"
+model = "BAAI/bge-small-en-v1.5"
+
+[embedding.local]
+query_prefix = "search_query: "
+document_prefix = "search_document: "
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let embed = cfg.embedding.unwrap();
+        assert_eq!(embed.provider(), "local");
+        let local = embed.local.unwrap();
+        assert_eq!(local.query_prefix.as_deref(), Some("search_query: "));
+        assert_eq!(local.document_prefix.as_deref(), Some("search_document: "));
+    }
+
+    #[test]
+    fn test_ollama_config_defaults() {
+        let cfg = OllamaConfig::default();
+        assert_eq!(cfg.base_url(), "http://localhost:11434");
+        assert_eq!(cfg.model(), "nomic-embed-text");
+    }
+
+    #[test]
+    fn test_ollama_config_from_toml() {
+        let toml_str = r#"
+[embedding.ollama]
+base_url = "http://gpu-server:11434"
+model = "mxbai-embed-large"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let ollama = cfg.embedding.unwrap().ollama.unwrap();
+        assert_eq!(ollama.base_url(), "http://gpu-server:11434");
+        assert_eq!(ollama.model(), "mxbai-embed-large");
+    }
+
+    #[test]
+    fn test_reranker_config_defaults() {
+        let cfg = RerankerConfig::default();
+        assert_eq!(cfg.provider(), "local");
+    }
+
+    #[test]
+    fn test_reranker_config_none() {
+        let toml_str = r#"
+[reranker]
+provider = "none"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.reranker.unwrap().provider(), "none");
+    }
+
+    #[test]
+    fn test_full_config_backward_compat() {
+        let toml_str = r#"
+[database]
+path = "/tmp/test.db"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        assert!(cfg.embedding.is_none());
+        assert!(cfg.reranker.is_none());
+        assert_eq!(cfg.database.unwrap().path.as_deref(), Some("/tmp/test.db"));
+    }
+
+    #[test]
+    fn test_config_unknown_fields_ignored() {
+        let toml_str = r#"
+[embedding]
+provider = "local"
+unknown_field = "should be ignored"
+"#;
+        // serde default: unknown fields are silently ignored
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.embedding.unwrap().provider(), "local");
+    }
+
+    // ── to_provider_config tests ──
+
+    #[test]
+    fn test_to_provider_config_defaults() {
+        let cfg = CartogConfig::default();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.provider, "local");
+        assert!(pc.model.is_none());
+        assert_eq!(pc.resolved_dimension(), 384);
+        assert!(pc.query_prefix.is_none());
+        assert!(pc.document_prefix.is_none());
+    }
+
+    #[test]
+    fn test_to_provider_config_from_toml() {
+        let toml_str = r#"
+[embedding]
+provider = "ollama"
+model = "nomic-embed-text"
+dimension = 768
+
+[embedding.local]
+query_prefix = "search_query: "
+document_prefix = "search_document: "
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.provider, "ollama");
+        assert_eq!(pc.model.as_deref(), Some("nomic-embed-text"));
+        assert_eq!(pc.resolved_dimension(), 768);
+        assert_eq!(pc.query_prefix.as_deref(), Some("search_query: "));
+        assert_eq!(pc.document_prefix.as_deref(), Some("search_document: "));
+    }
+
+    #[test]
+    fn test_provider_config_dimension_override() {
+        let pc = cartog_rag::EmbeddingProviderConfig {
+            dimension: Some(1536),
+            ..Default::default()
+        };
+        assert_eq!(pc.resolved_dimension(), 1536);
+    }
+
+    #[test]
+    fn test_provider_config_dimension_default_fallback() {
+        let pc = cartog_rag::EmbeddingProviderConfig::default();
+        assert_eq!(pc.resolved_dimension(), 384);
+        assert!(pc.dimension.is_none());
+    }
+
+    #[test]
+    fn test_to_provider_config_ollama_model_fallback() {
+        let toml_str = r#"
+[embedding]
+provider = "ollama"
+
+[embedding.ollama]
+model = "mxbai-embed-large"
+base_url = "http://gpu:11434"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.provider, "ollama");
+        assert_eq!(pc.model.as_deref(), Some("mxbai-embed-large"));
+        assert_eq!(pc.base_url.as_deref(), Some("http://gpu:11434"));
+    }
+
+    #[test]
+    fn test_to_provider_config_top_level_model_wins() {
+        let toml_str = r#"
+[embedding]
+provider = "ollama"
+model = "top-level-model"
+
+[embedding.ollama]
+model = "ollama-model"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.model.as_deref(), Some("top-level-model"),);
+    }
+
+    #[test]
+    fn test_to_provider_config_base_url_threaded() {
+        let toml_str = r#"
+[embedding]
+provider = "ollama"
+
+[embedding.ollama]
+base_url = "http://custom:11434"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.base_url.as_deref(), Some("http://custom:11434"));
+    }
+
+    #[test]
+    fn test_to_provider_config_no_base_url_when_local() {
+        let toml_str = r#"
+[embedding]
+provider = "local"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert!(pc.base_url.is_none());
     }
 }

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -62,8 +62,8 @@ pub struct OllamaConfig {
     pub model: Option<String>,
 }
 
-pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434";
-pub const DEFAULT_OLLAMA_MODEL: &str = "nomic-embed-text";
+pub const DEFAULT_OLLAMA_BASE_URL: &str = cartog_rag::providers::DEFAULT_OLLAMA_BASE_URL;
+pub const DEFAULT_OLLAMA_MODEL: &str = cartog_rag::providers::DEFAULT_OLLAMA_MODEL;
 
 impl OllamaConfig {
     pub fn base_url(&self) -> &str {
@@ -125,10 +125,10 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
 /// Returns the parsed config and the path it was loaded from (if any).
 pub fn load_config() -> (CartogConfig, Option<PathBuf>) {
     match local_config_path() {
-        Some(p) => {
-            let cfg = read_config(&p).unwrap_or_default();
-            (cfg, Some(p))
-        }
+        Some(p) => match read_config(&p) {
+            Some(cfg) => (cfg, Some(p)),
+            None => (CartogConfig::default(), None),
+        },
         None => (CartogConfig::default(), None),
     }
 }
@@ -245,6 +245,14 @@ mod tests {
     fn test_read_config_missing_file_returns_none() {
         let result = read_config(Path::new("/nonexistent/path/config.toml"));
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_config_invalid_toml_returns_none() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        fs::write(&cfg_path, "this is {{ not valid toml").unwrap();
+        assert!(read_config(&cfg_path).is_none());
     }
 
     #[test]

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -36,9 +36,13 @@ pub struct EmbeddingConfig {
     pub ollama: Option<OllamaConfig>,
 }
 
+pub const DEFAULT_EMBEDDING_PROVIDER: &str = "local";
+
 impl EmbeddingConfig {
     pub fn provider(&self) -> &str {
-        self.provider.as_deref().unwrap_or("local")
+        self.provider
+            .as_deref()
+            .unwrap_or(DEFAULT_EMBEDDING_PROVIDER)
     }
 }
 
@@ -58,13 +62,16 @@ pub struct OllamaConfig {
     pub model: Option<String>,
 }
 
+pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434";
+pub const DEFAULT_OLLAMA_MODEL: &str = "nomic-embed-text";
+
 impl OllamaConfig {
     pub fn base_url(&self) -> &str {
-        self.base_url.as_deref().unwrap_or("http://localhost:11434")
+        self.base_url.as_deref().unwrap_or(DEFAULT_OLLAMA_BASE_URL)
     }
 
     pub fn model(&self) -> &str {
-        self.model.as_deref().unwrap_or("nomic-embed-text")
+        self.model.as_deref().unwrap_or(DEFAULT_OLLAMA_MODEL)
     }
 }
 
@@ -74,9 +81,13 @@ pub struct RerankerConfig {
     pub provider: Option<String>,
 }
 
+pub const DEFAULT_RERANKER_PROVIDER: &str = "local";
+
 impl RerankerConfig {
     pub fn provider(&self) -> &str {
-        self.provider.as_deref().unwrap_or("local")
+        self.provider
+            .as_deref()
+            .unwrap_or(DEFAULT_RERANKER_PROVIDER)
     }
 }
 
@@ -103,7 +114,7 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
                     .reranker
                     .as_ref()
                     .map(|r| r.provider().to_string())
-                    .unwrap_or_else(|| "local".to_string()),
+                    .unwrap_or_else(|| DEFAULT_RERANKER_PROVIDER.to_string()),
             }
         }
         None => cartog_rag::EmbeddingProviderConfig::default(),
@@ -111,10 +122,15 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
 }
 
 /// Load the local project config from `.cartog.toml`.
-pub fn load_config() -> CartogConfig {
-    local_config_path()
-        .and_then(|p| read_config(&p))
-        .unwrap_or_default()
+/// Returns the parsed config and the path it was loaded from (if any).
+pub fn load_config() -> (CartogConfig, Option<PathBuf>) {
+    match local_config_path() {
+        Some(p) => {
+            let cfg = read_config(&p).unwrap_or_default();
+            (cfg, Some(p))
+        }
+        None => (CartogConfig::default(), None),
+    }
 }
 
 /// Path to the local project config: `.cartog.toml` found by walking up from

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -62,6 +62,9 @@ fn main() -> Result<()> {
         }
         Command::Deps { file } => commands::cmd_deps(&db_path, &file, cli.json, token_budget),
         Command::Stats => commands::cmd_stats(&db_path, cli.json),
+        Command::Config => {
+            commands::cmd_config(&cartog_config, config_path.as_deref(), &db_path, cli.json)
+        }
         Command::Search {
             query,
             kind,

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -15,6 +15,7 @@ fn main() -> Result<()> {
     let (cartog_config, config_path) = config::load_config();
     let db_path = config::resolve_db_path(cli.db.clone(), &cartog_config);
     let provider_config = config::to_provider_config(&cartog_config);
+    let embedding_dim = provider_config.resolved_dimension();
 
     let is_serve = matches!(cli.command, Command::Serve { .. });
     let is_watch = matches!(cli.command, Command::Watch { .. });
@@ -48,20 +49,31 @@ fn main() -> Result<()> {
             path,
             force,
             no_lsp,
-        } => commands::cmd_index(&db_path, &path, force, !no_lsp, cli.json),
-        Command::Outline { file } => commands::cmd_outline(&db_path, &file, cli.json, token_budget),
-        Command::Callees { name } => commands::cmd_callees(&db_path, &name, cli.json, token_budget),
-        Command::Impact { name, depth } => {
-            commands::cmd_impact(&db_path, &name, depth, cli.json, token_budget)
+        } => commands::cmd_index(&db_path, &path, force, !no_lsp, cli.json, embedding_dim),
+        Command::Outline { file } => {
+            commands::cmd_outline(&db_path, &file, cli.json, token_budget, embedding_dim)
         }
+        Command::Callees { name } => {
+            commands::cmd_callees(&db_path, &name, cli.json, token_budget, embedding_dim)
+        }
+        Command::Impact { name, depth } => commands::cmd_impact(
+            &db_path,
+            &name,
+            depth,
+            cli.json,
+            token_budget,
+            embedding_dim,
+        ),
         Command::Refs { name, kind } => {
-            commands::cmd_refs(&db_path, &name, kind, cli.json, token_budget)
+            commands::cmd_refs(&db_path, &name, kind, cli.json, token_budget, embedding_dim)
         }
         Command::Hierarchy { name } => {
-            commands::cmd_hierarchy(&db_path, &name, cli.json, token_budget)
+            commands::cmd_hierarchy(&db_path, &name, cli.json, token_budget, embedding_dim)
         }
-        Command::Deps { file } => commands::cmd_deps(&db_path, &file, cli.json, token_budget),
-        Command::Stats => commands::cmd_stats(&db_path, cli.json),
+        Command::Deps { file } => {
+            commands::cmd_deps(&db_path, &file, cli.json, token_budget, embedding_dim)
+        }
+        Command::Stats => commands::cmd_stats(&db_path, cli.json, embedding_dim),
         Command::Config => {
             commands::cmd_config(&cartog_config, config_path.as_deref(), &db_path, cli.json)
         }
@@ -78,11 +90,17 @@ fn main() -> Result<()> {
             limit,
             cli.json,
             token_budget,
+            embedding_dim,
         ),
-        Command::Map { tokens } => commands::cmd_map(&db_path, tokens, cli.json),
-        Command::Changes { commits, kind } => {
-            commands::cmd_changes(&db_path, commits, kind, cli.json, token_budget)
-        }
+        Command::Map { tokens } => commands::cmd_map(&db_path, tokens, cli.json, embedding_dim),
+        Command::Changes { commits, kind } => commands::cmd_changes(
+            &db_path,
+            commits,
+            kind,
+            cli.json,
+            token_budget,
+            embedding_dim,
+        ),
         Command::Watch {
             path,
             debounce,

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -14,6 +14,7 @@ fn main() -> Result<()> {
     // Resolve database path: --db / CARTOG_DB > .cartog.toml > git root > cwd
     let cartog_config = config::load_config();
     let db_path = config::resolve_db_path(cli.db.clone(), &cartog_config);
+    let provider_config = config::to_provider_config(&cartog_config);
 
     let is_serve = matches!(cli.command, Command::Serve { .. });
     let is_watch = matches!(cli.command, Command::Watch { .. });
@@ -84,19 +85,25 @@ fn main() -> Result<()> {
             debounce,
             rag,
             rag_delay,
-        } => commands::cmd_watch(&db_path, &path, debounce, rag, rag_delay),
+        } => commands::cmd_watch(&db_path, &path, debounce, rag, rag_delay, provider_config),
         Command::Serve { watch, rag } => {
             let runtime = tokio::runtime::Runtime::new()?;
-            runtime.block_on(mcp::run_server(&db_path, watch, rag))
+            runtime.block_on(mcp::run_server(&db_path, watch, rag, provider_config))
         }
         Command::Rag(rag_cmd) => match rag_cmd {
             RagCommand::Setup => commands::cmd_rag_setup(cli.json),
             RagCommand::Index { path, force } => {
-                commands::cmd_rag_index(&db_path, &path, force, cli.json)
+                commands::cmd_rag_index(&db_path, &path, force, cli.json, &provider_config)
             }
-            RagCommand::Search { query, kind, limit } => {
-                commands::cmd_rag_search(&db_path, &query, kind, limit, cli.json, token_budget)
-            }
+            RagCommand::Search { query, kind, limit } => commands::cmd_rag_search(
+                &db_path,
+                &query,
+                kind,
+                limit,
+                cli.json,
+                token_budget,
+                &provider_config,
+            ),
         },
     }
 }

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Resolve database path: --db / CARTOG_DB > .cartog.toml > git root > cwd
-    let cartog_config = config::load_config();
+    let (cartog_config, config_path) = config::load_config();
     let db_path = config::resolve_db_path(cli.db.clone(), &cartog_config);
     let provider_config = config::to_provider_config(&cartog_config);
 

--- a/crates/cartog/tests/rag_relevancy.rs
+++ b/crates/cartog/tests/rag_relevancy.rs
@@ -12,7 +12,24 @@ use std::path::Path;
 
 use cartog::db::Database;
 use cartog::indexer::index_directory;
+use cartog::rag::provider::EmbeddingProvider;
 use cartog::rag::search::{hybrid_search, KindFilter};
+
+struct StubEmbeddingProvider;
+impl EmbeddingProvider for StubEmbeddingProvider {
+    fn name(&self) -> &str {
+        "stub"
+    }
+    fn dimension(&self) -> usize {
+        384
+    }
+    fn embed_document(&mut self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0; 384])
+    }
+    fn embed_documents(&mut self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vec![0.0; 384]).collect())
+    }
+}
 
 /// A single relevancy test case.
 struct QueryCase {
@@ -193,8 +210,15 @@ fn rag_relevancy_benchmark() {
     let n = cases.len() as f64;
 
     for case in &cases {
-        let result = hybrid_search(&db, case.query, case.k as u32, KindFilter::All)
-            .unwrap_or_else(|e| panic!("search failed for '{}': {e}", case.query));
+        let result = hybrid_search(
+            &db,
+            case.query,
+            case.k as u32,
+            KindFilter::All,
+            &mut StubEmbeddingProvider,
+            None,
+        )
+        .unwrap_or_else(|e| panic!("search failed for '{}': {e}", case.query));
 
         let names: Vec<String> = result
             .results
@@ -334,8 +358,15 @@ fn java_rag_relevancy_benchmark() {
     let n = cases.len() as f64;
 
     for case in &cases {
-        let result = hybrid_search(&db, case.query, case.k as u32, KindFilter::All)
-            .unwrap_or_else(|e| panic!("search failed for '{}': {e}", case.query));
+        let result = hybrid_search(
+            &db,
+            case.query,
+            case.k as u32,
+            KindFilter::All,
+            &mut StubEmbeddingProvider,
+            None,
+        )
+        .unwrap_or_else(|e| panic!("search failed for '{}': {e}", case.query));
 
         let names: Vec<String> = result
             .results

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -45,8 +45,13 @@ cartog/
 │   ├── cartog-rag/          # Semantic search and RAG pipeline
 │   │   └── src/
 │   │       ├── lib.rs       # Constants (EMBEDDING_DIM), model cache helpers
+│   │       ├── provider.rs  # EmbeddingProvider and RerankerProvider traits
+│   │       ├── providers/
+│   │       │   ├── mod.rs   # Provider module (feature-gated)
+│   │       │   ├── local.rs # Local ONNX provider via fastembed
+│   │       │   └── ollama.rs # Ollama HTTP provider
 │   │       ├── setup.rs     # Model download (fastembed auto-download)
-│   │       ├── embeddings.rs # ONNX embedding inference (BGE-small-en-v1.5)
+│   │       ├── embeddings.rs # ONNX embedding helpers (byte serialization)
 │   │       ├── indexer.rs   # Embed symbols, store vectors in sqlite-vec
 │   │       ├── reranker.rs  # Cross-encoder re-ranking (BGE-reranker-base)
 │   │       └── search.rs    # FTS5 + vector KNN, RRF merge, optional re-ranking
@@ -137,7 +142,7 @@ Each crate has a `README.md` with detailed technical documentation. Summary:
 - **[cartog-db](../crates/cartog-db/README.md)**: SQLite connection, schema (core + RAG tables), all query methods (search, refs, impact, hierarchy, callees), 6-tier heuristic edge resolution, FTS5 keyword search, sqlite-vec vector KNN.
 - **[cartog-languages](../crates/cartog-languages/README.md)**: `Extractor` trait + 8 code language extractors (Python, TS, TSX, JS, Rust, Go, Ruby, Java) + Markdown document extractor. Code extractors use declarative tree-sitter S-expression queries via `CachedQuery`; Markdown extractor uses heading-based chunking.
 - **[cartog-indexer](../crates/cartog-indexer/README.md)**: Directory walking, 3-tier change detection (git diff → SHA-256 → force), Merkle tree hashing for surgical symbol-level updates. Optionally delegates to `cartog-lsp` for unresolved edges.
-- **[cartog-rag](../crates/cartog-rag/README.md)**: Embedding (BGE-small-en-v1.5, 384-dim), hybrid search (FTS5 + vector KNN → RRF merge → cross-encoder reranking), model cache management. Indexes both code symbols and Markdown documents.
+- **[cartog-rag](../crates/cartog-rag/README.md)**: Pluggable embedding providers (local ONNX, Ollama), hybrid search (FTS5 + vector KNN → RRF merge → cross-encoder reranking), model cache management. Indexes both code symbols and Markdown documents.
 - **[cartog-lsp](../crates/cartog-lsp/README.md)**: Optional LSP-based edge resolution. Spawns language servers, sends `textDocument/definition`, maps responses to cartog symbol IDs.
 - **[cartog-watch](../crates/cartog-watch/README.md)**: Debounced file watcher (`notify-debouncer-mini`), incremental re-index on changes, deferred RAG embedding with configurable timer. See [spec-watch.md](spec-watch.md) for design details.
 - **[cartog-mcp](../crates/cartog-mcp/README.md)**: MCP server over stdio (`rmcp`). 12 tool handlers with JSON Schema params, path validation (canonicalization), `Arc<Mutex<Database>>` for shared state.

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -21,7 +21,8 @@
 | `rmcp` (server + transport-io) | MCP server over stdio | Server-only — cartog is never an MCP client. stdio transport matches how agents launch subprocesses |
 | `tokio` (rt-multi-thread) | Async runtime for MCP server only | Multi-thread for `spawn_blocking` throughput. Runtime created on-demand — sync commands skip it entirely |
 | `tracing` + `tracing-subscriber` | Structured logging to stderr | Logs to stderr so stdout stays clean for output and MCP protocol |
-| `fastembed` | ONNX Runtime inference for embeddings + re-ranking | `default-features = false` drops image models (CLIP etc.) we don't use. `rustls-tls` avoids OpenSSL system dependency |
+| `fastembed` | ONNX Runtime inference for embeddings + re-ranking (local provider) | Optional via `provider-local` feature (default on). `default-features = false` drops image models (CLIP etc.). `rustls-tls` avoids OpenSSL system dependency |
+| `reqwest` | HTTP client for remote embedding providers (Ollama) | Optional via `provider-ollama` feature. Uses `blocking` + `rustls-tls` |
 | `sqlite-vec` | Vector similarity search (KNN) in SQLite | `vec0` virtual table, requires integer rowids (bridged via `symbol_embedding_map`) |
 | `criterion` (dev) | Micro-benchmarks | Query latency benchmarks (µs-level) |
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -70,7 +70,7 @@ BERT attention is **O(n²) in sequence length**. Keeping input short is the sing
 
 This drives two key decisions:
 
-1. **Small embedding model** — BGE-small-en-v1.5 quantized (384 dimensions). 2-3x faster than full precision with negligible quality loss for code symbol matching. Outputs are L2-normalized, enabling L2 distance in sqlite-vec (equivalent to cosine ranking). Trade-off: English-only model — non-English identifiers/comments get degraded embeddings.
+1. **Small embedding model** — BGE-small-en-v1.5 quantized (default, 384 dimensions). 2-3x faster than full precision with negligible quality loss for code symbol matching. Outputs are L2-normalized, enabling L2 distance in sqlite-vec (equivalent to cosine ranking). Model and dimension are configurable via `.cartog.toml`. Trade-off: English-only model — non-English identifiers/comments get degraded embeddings.
 
 2. **AST-aware embedding text** — For code: header + signature + significant body lines (skipping blanks, comments, closing braces) up to ~200 tokens (~800 bytes):
    ```
@@ -108,7 +108,7 @@ Query
   │
   ├─→ Vector KNN search (sqlite-vec, L2 distance)
   │     L2-normalized embeddings → L2 distance ≡ cosine ranking
-  │     Query embedded with same BGE-small-en-v1.5 model
+  │     Query embedded with configured provider (default: BGE-small-en-v1.5)
   │
   ├─→ Reciprocal Rank Fusion (RRF, k=60)
   │     Merges both ranked lists: score = Σ 1/(k + rank + 1)
@@ -136,7 +136,7 @@ Returns the first non-empty result. Only FTS5 syntax errors trigger fallback —
 
 | Constant | Value | Rationale |
 |----------|-------|-----------|
-| `EMBEDDING_DIM` | 384 | BGE-small-en-v1.5 output dimension |
+| `EMBEDDING_DIM` | 384 | BGE-small-en-v1.5 output dimension (default, overridable per-provider) |
 | `EMBED_BATCH_SIZE` | 64 | Limits ONNX padding waste when text lengths vary |
 | `CHUNK_SIZE` | 512 | Symbols per embedding engine call |
 | `DB_BATCH_LIMIT` | 256 | Pending DB writes before flush |
@@ -148,6 +148,10 @@ Returns the first non-empty result. Only FTS5 syntax errors trigger fallback —
 | RRF `k` | 60.0 | Standard constant from Cormack et al. 2009 |
 | Over-retrieval | `limit × 3` (min 20) | Enough candidates for effective RRF merge |
 | `MAX_SEARCH_LIMIT` | 100 | Hard cap on returned results |
+
+### Provider architecture
+
+Embedding providers implement the `EmbeddingProvider` trait with `embed_query()`/`embed_document()` separation for asymmetric models. Providers are selected at runtime via `.cartog.toml` and gated behind Cargo feature flags (`provider-local`, `provider-ollama`).
 
 ## SQLite Tuning
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,6 +53,55 @@ cartog --db /tmp/x.db stats
 cartog --db /tmp/x.db map
 ```
 
+### Embedding Provider Configuration
+
+Configure the embedding provider in `.cartog.toml`:
+
+```toml
+# Default: local ONNX model (no config needed)
+
+# Use Ollama instead of local ONNX
+[embedding]
+provider = "ollama"
+model = "nomic-embed-text"
+
+[embedding.ollama]
+base_url = "http://localhost:11434"
+```
+
+**Provider options:**
+
+| Provider | Config | Setup | Notes |
+|----------|--------|-------|-------|
+| `local` (default) | No config needed | `cartog rag setup` to download models | ONNX Runtime via fastembed, ~1.2GB models |
+| `ollama` | `provider = "ollama"` | Ollama server running with model pulled | No model download needed, dimension auto-detected |
+
+**Advanced local configuration:**
+
+```toml
+[embedding]
+provider = "local"
+model = "BAAI/bge-base-en-v1.5"    # any fastembed built-in model
+
+[embedding.local]
+query_prefix = "search_query: "     # for asymmetric models
+document_prefix = "search_document: "
+```
+
+**Disable re-ranking** (saves ~1.1GB model download):
+
+```toml
+[reranker]
+provider = "none"
+```
+
+**Compile-time feature flags** (for minimal binary size):
+
+```bash
+cargo install cartog                                    # default: local ONNX provider
+cargo install cartog --features ollama-embedding         # + Ollama support
+```
+
 ---
 
 ## Commands
@@ -298,6 +347,8 @@ cartog rag setup
 ```
 
 **First-time download**: ~1.2GB of ONNX models (embedding ~80MB + reranker ~1.1GB). May take a few minutes depending on network speed. Models are cached in `~/.cache/cartog/models/` and reused across all projects — subsequent runs are instant.
+
+Note: `rag setup` downloads models for the **local** provider only. When using Ollama, models are managed by the Ollama server — run `ollama pull nomic-embed-text` instead.
 
 ### `cartog rag index [path] [--force]`
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -80,11 +80,18 @@ if [[ -f "$PLUGIN_JSON" ]]; then
   sed "s/\"version\": \".*\"/\"version\": \"${NEW}\"/" "$PLUGIN_JSON" > "$PLUGIN_JSON.tmp" && mv "$PLUGIN_JSON.tmp" "$PLUGIN_JSON"
 fi
 
+# update site version references (footers + badges)
+for f in site/index.html site/usage.html; do
+  if [[ -f "$f" ]]; then
+    sed "s/v${CURRENT}/v${NEW}/g" "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  fi
+done
+
 # update Cargo.lock
 cargo generate-lockfile --quiet 2>/dev/null || true
 
 info "committing version bump"
-git add "$CARGO_TOML" Cargo.lock "$PLUGIN_JSON"
+git add "$CARGO_TOML" Cargo.lock "$PLUGIN_JSON" site/
 git commit -m "chore: bump version to ${NEW}"
 
 info "tagging $TAG"

--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>cartog — Stop grepping blind. Query your code graph.</title>
-  <meta name="description" content="Pre-computed code graph for LLM coding agents. 83% fewer tokens, 97% recall, 100% local. Single binary, zero config.">
+  <title>Cartog — Stop grepping blind. Query your code graph.</title>
+  <meta name="description" content="Code graph navigator. Pre-computed symbols, calls, imports and inheritance — queried in microseconds. Single binary, 100% local, 7 languages.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -12,14 +12,14 @@
 <!-- ── Nav ──────────────────────────────────────── -->
 <header class="nav">
   <div class="nav-inner">
-    <a href="index.html" class="nav-logo">cartog</a>
+    <a href="index.html" class="nav-logo">Cartog</a>
     <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.nav-links').classList.toggle('open')">
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links">
       <li><a href="#features">Features</a></li>
-      <li><a href="#why">Why cartog</a></li>
-      <li><a href="#compare">Compare</a></li>
+      <li><a href="#why">Why Cartog</a></li>
+      <li><a href="#agents">Agents</a></li>
       <li><a href="#install">Install</a></li>
       <li><a href="usage.html">Docs</a></li>
       <li>
@@ -34,7 +34,7 @@
 <!-- ── Hero ─────────────────────────────────────── -->
 <section class="hero">
   <div class="container">
-    <div class="hero-eyebrow">Code Graph for LLM Agents</div>
+    <div class="hero-eyebrow">Code Graph Navigator</div>
 
     <h1>
       <span class="line-plain">Stop grepping blind.</span>
@@ -42,7 +42,7 @@
     </h1>
 
     <p class="subtitle">
-      Pre-computed symbols, calls, imports and inheritance — queried in microseconds, not tokens.
+      Pre-computed symbols, calls, imports and inheritance — queried in microseconds.
     </p>
 
     <div class="hero-installs">
@@ -61,10 +61,12 @@
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>
         </button>
       </div>
+      <a href="#install" style="font-size: 13px; color: var(--text-tertiary); margin-top: 4px;">More install options ↓</a>
     </div>
 
-    <div class="hero-ctas">
-      <a href="#why" class="btn-secondary">Why cartog ↓</a>
+    <div class="hero-ctas" style="margin-top: 32px;">
+      <a href="#why" class="btn-secondary">Why Cartog ↓</a>
+      <a href="#agents" class="btn-secondary">For LLM Agents ↓</a>
     </div>
 
     <div class="hero-meta">
@@ -77,9 +79,9 @@
         <div class="terminal-dot red"></div>
         <div class="terminal-dot yellow"></div>
         <div class="terminal-dot green"></div>
-        <span class="terminal-title">cartog demo</span>
+        <span class="terminal-title">Cartog demo</span>
       </div>
-      <img src="demo.gif" alt="cartog demo — index, search, refs, impact" class="terminal-gif">
+      <img src="demo.gif" alt="Cartog demo — index, search, refs, impact" class="terminal-gif">
     </div>
   </div>
 </section>
@@ -88,20 +90,20 @@
 <div class="stats-bar">
   <div class="container">
     <div class="stat-item">
-      <div class="stat-value">💰 83%</div>
-      <div class="stat-label">fewer tokens per query</div>
-    </div>
-    <div class="stat-item">
-      <div class="stat-value">🎯 97%</div>
-      <div class="stat-label">recall (completeness)</div>
-    </div>
-    <div class="stat-item">
       <div class="stat-value">⚡ 8μs</div>
       <div class="stat-label">query latency</div>
     </div>
     <div class="stat-item">
+      <div class="stat-value">🎯 97%</div>
+      <div class="stat-label">symbol recall</div>
+    </div>
+    <div class="stat-item">
+      <div class="stat-value">🌐 7</div>
+      <div class="stat-label">languages supported</div>
+    </div>
+    <div class="stat-item">
       <div class="stat-value">🔒 100%</div>
-      <div class="stat-label">local — no API calls</div>
+      <div class="stat-label">local — your code stays private</div>
     </div>
   </div>
 </div>
@@ -116,7 +118,7 @@
       <div class="how-step">
         <div class="how-step-number">1</div>
         <div class="how-step-title">Index</div>
-        <code>cartog index</code>
+        <code>cartog index .</code>
         <p>Walks your repo, extracts symbols, calls, imports, inheritance. Stores everything in a local SQLite file.</p>
       </div>
 
@@ -135,7 +137,47 @@
         <div class="how-step-number">3</div>
         <div class="how-step-title">Query</div>
         <code>cartog refs AuthService</code>
-        <p>Your agent calls refs, impact, search — gets precise answers in microseconds, not tokens.</p>
+        <p>Precise answers in microseconds. References, callers, impact analysis, semantic search.</p>
+      </div>
+    </div>
+
+    <p style="margin-top: 32px; text-align: center; font-size: 14px; color: var(--text-secondary);">
+      16 commands for search, navigation, and analysis. <a href="usage.html">See full documentation →</a>
+    </p>
+  </div>
+</section>
+
+<!-- ── Features ─────────────────────────────────── -->
+<section id="features">
+  <div class="container">
+    <div class="section-label">Features</div>
+    <h2 class="section-heading">Navigate your codebase, not file contents.</h2>
+    <p class="section-subtitle">Single binary, zero config, zero dependencies.</p>
+
+    <div class="features-grid" style="margin-top: 40px;">
+      <div class="feature-card">
+        <h3><span class="feature-icon">⚡</span> Zero dependencies</h3>
+        <p>Single binary + SQLite file. No Docker, no language servers required, no graph databases. <code>cargo install</code> and you're done.</p>
+      </div>
+      <div class="feature-card">
+        <h3><span class="feature-icon">🔄</span> Live index</h3>
+        <p><code>cartog watch</code> auto re-indexes on file changes. Debounced, incremental, near-instant. Always query fresh data.</p>
+      </div>
+      <div class="feature-card">
+        <h3><span class="feature-icon">🔍</span> Dual search</h3>
+        <p>Keyword search (sub-ms, symbol names) + semantic search (natural language). Local embeddings with optional GPU acceleration via Ollama.</p>
+      </div>
+      <div class="feature-card">
+        <h3><span class="feature-icon">🎯</span> Impact analysis</h3>
+        <p><code>cartog impact --depth 3</code> traces callers-of-callers instantly. Know the blast radius before you change anything.</p>
+      </div>
+      <div class="feature-card">
+        <h3><span class="feature-icon">🔬</span> Optional LSP precision</h3>
+        <p>Auto-detects language servers on PATH. Boosts edge resolution from ~25% to ~42-81%. Works without them, better with them.</p>
+      </div>
+      <div class="feature-card">
+        <h3><span class="feature-icon">🔒</span> 100% local</h3>
+        <p>tree-sitter parsing, SQLite storage, local embeddings. No API keys, no telemetry. Works in air-gapped environments.</p>
       </div>
     </div>
   </div>
@@ -145,7 +187,7 @@
 <section class="languages-section">
   <div class="container">
     <div class="section-label">Languages</div>
-    <h2 class="section-heading">7 languages supported</h2>
+    <h2 class="section-heading">7 languages supported <span style="font-size: 14px; font-weight: 500; color: var(--text-tertiary);">— more coming</span></h2>
     <div class="lang-grid">
       <span class="lang-tag">
         <svg width="20" height="20" viewBox="0 0 256 255"><defs><linearGradient id="py-a" x1="12.96%" x2="79.68%" y1="12.04%" y2="93.06%"><stop offset="0%" stop-color="#387EB8"/><stop offset="100%" stop-color="#366994"/></linearGradient><linearGradient id="py-b" x1="19.13%" x2="90.43%" y1="20.58%" y2="88.72%"><stop offset="0%" stop-color="#FFC331"/><stop offset="100%" stop-color="#F5A623"/></linearGradient></defs><path fill="url(#py-a)" d="M126.916.072c-64.832 0-60.784 28.115-60.784 28.115l.072 29.128h61.868v8.745H41.631S.145 61.355.145 126.77c0 65.417 36.21 63.097 36.21 63.097h21.61v-30.356s-1.165-36.21 35.632-36.21h61.362s34.475.557 34.475-33.319V33.97S194.67.072 126.916.072zM92.802 19.66a11.12 11.12 0 110 22.24 11.12 11.12 0 010-22.24z"/><path fill="url(#py-b)" d="M128.757 254.126c64.832 0 60.784-28.115 60.784-28.115l-.072-29.127H127.6v-8.745h86.441s41.486 4.705 41.486-60.712c0-65.416-36.21-63.096-36.21-63.096h-21.61v30.355s1.165 36.21-35.632 36.21h-61.362s-34.475-.557-34.475 33.32v56.013s-5.235 33.897 62.518 33.897zm34.114-19.586a11.12 11.12 0 110-22.24 11.12 11.12 0 010 22.24z"/></svg>
@@ -179,103 +221,54 @@
   </div>
 </section>
 
-<!-- ── Features ─────────────────────────────────── -->
-<section id="features">
-  <div class="container">
-    <div class="section-label">Features</div>
-    <h2 class="section-heading">Everything your agent needs. Nothing it doesn't.</h2>
-    <p class="section-subtitle">Single binary, zero config, zero dependencies. Works with any LLM that has bash or MCP access.</p>
-
-    <div class="features-grid" style="margin-top: 40px;">
-      <div class="feature-card">
-        <h3><span class="feature-icon">⚡</span> Zero dependencies</h3>
-        <p>Single binary + SQLite file. No Docker, no language servers required, no graph databases. <code>cargo install</code> and you're done.</p>
-      </div>
-      <div class="feature-card">
-        <h3><span class="feature-icon">🔄</span> Live index</h3>
-        <p><code>cartog watch</code> auto re-indexes on file changes. Your agent always queries fresh data. Debounced, incremental, near-instant.</p>
-      </div>
-      <div class="feature-card">
-        <h3><span class="feature-icon">🔌</span> MCP server</h3>
-        <p><code>cartog serve</code> exposes 12 tools over stdio. Plug into Claude Code, Cursor, Windsurf, Zed, or any MCP-compatible agent.</p>
-      </div>
-      <div class="feature-card">
-        <h3><span class="feature-icon">🔍</span> Dual search</h3>
-        <p>Keyword search (sub-ms, symbol names) + semantic search (natural language, local ONNX embeddings). Code by default, Markdown docs with <code>--kind document</code>.</p>
-      </div>
-      <div class="feature-card">
-        <h3><span class="feature-icon">🎯</span> Optional LSP precision</h3>
-        <p>Auto-detects language servers on PATH. Boosts edge resolution from ~25% to ~42-81%. Works without them, better with them.</p>
-      </div>
-      <div class="feature-card">
-        <h3><span class="feature-icon">🌐</span> 7 languages</h3>
-        <p>Python, TypeScript, JavaScript, Rust, Go, Ruby, Java. Symbols, calls, imports, inheritance, type references — all extracted.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ── Why cartog ───────────────────────────────── -->
+<!-- ── Why Cartog ───────────────────────────────── -->
 <section id="why">
   <div class="container">
-    <div class="section-label">Why cartog</div>
-    <h2 class="section-heading">Stop grepping blind</h2>
-    <p class="section-subtitle">Code is a graph of relationships. Pre-compute it once, query it in microseconds.</p>
+    <div class="section-label">Why Cartog</div>
+    <h2 class="section-heading">Code is a graph. Query it like one.</h2>
+    <p class="section-subtitle">Pre-compute the structure once, then answer any question in microseconds.</p>
 
     <div class="why-grid">
       <div class="why-card">
         <div class="why-number">01</div>
-        <h3>Your agent wastes tokens rediscovering structure</h3>
-        <p>Every grep + cat + filter cycle costs tokens and context window. cartog pre-computes the code graph — one <code>refs</code> call replaces 6+ discovery steps. 83% fewer tokens, 97% recall.</p>
-      </div>
-      <div class="why-card">
-        <div class="why-number">02</div>
         <h3>Grep can't trace what breaks</h3>
         <p>Transitive impact analysis is impossible with grep. <code>cartog impact --depth 3</code> traces callers-of-callers instantly. Know the blast radius before you change anything.</p>
       </div>
       <div class="why-card">
+        <div class="why-number">02</div>
+        <h3>Structured answers, not file dumps</h3>
+        <p>One <code>refs</code> call returns every caller, importer, and type reference — with file paths and line numbers. No parsing output, no false positives.</p>
+      </div>
+      <div class="why-card">
         <div class="why-number">03</div>
         <h3>Your code stays on your machine</h3>
-        <p>tree-sitter parsing, SQLite storage, ONNX embeddings — everything runs locally. No API keys, no telemetry, no network calls. Works in air-gapped environments.</p>
+        <p>tree-sitter parsing, SQLite storage, local embeddings. No API keys, no telemetry, no cloud. Works in air-gapped environments.</p>
       </div>
     </div>
-  </div>
-</section>
 
-<!-- ── Compare ──────────────────────────────────── -->
-<section id="compare">
-  <div class="container">
-    <div class="section-label">Compare</div>
-    <h2 class="section-heading">How cartog compares</h2>
-
-    <div class="table-wrapper">
+    <!-- Comparison table -->
+    <div class="table-wrapper" style="margin-top: 48px;">
       <table>
         <thead>
           <tr>
             <th></th>
             <th>grep / cat / find</th>
             <th>Language server (LSP)</th>
-            <th>cartog</th>
+            <th>Cartog</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>Tokens per query</td>
-            <td>~1,700</td>
-            <td>varies</td>
-            <td><span class="badge">~280</span></td>
-          </tr>
-          <tr>
-            <td>Recall</td>
-            <td>78%</td>
-            <td>~100%</td>
-            <td><span class="badge">97%</span></td>
-          </tr>
           <tr>
             <td>Transitive analysis</td>
             <td>impossible</td>
             <td>limited</td>
             <td><code>impact --depth 3</code></td>
+          </tr>
+          <tr>
+            <td>Query latency</td>
+            <td>multi-step</td>
+            <td>seconds</td>
+            <td><span class="badge">8-450 μs</span></td>
           </tr>
           <tr>
             <td>Setup</td>
@@ -299,7 +292,7 @@
             <td>Semantic search</td>
             <td>no</td>
             <td>no</td>
-            <td><span class="badge">local ONNX</span></td>
+            <td><span class="badge">local ONNX / Ollama</span></td>
           </tr>
           <tr>
             <td>Privacy</td>
@@ -317,32 +310,95 @@
   </div>
 </section>
 
+<!-- ── LLM Agents ──────────────────────────────── -->
+<section id="agents">
+  <div class="container">
+    <div class="section-label">LLM Agents</div>
+    <h2 class="section-heading">Supercharge your AI coding agent</h2>
+    <p class="section-subtitle">83% fewer tokens per query, 97% recall. Your agent queries the graph instead of grepping blind.</p>
+
+    <div class="why-grid" style="margin-top: 40px;">
+      <div class="why-card">
+        <div class="why-number">01</div>
+        <h3>MCP Server</h3>
+        <p><code>cartog serve</code> exposes 12 tools over stdio. Plug into Claude Code, Cursor, Windsurf, Zed, or any MCP-compatible agent.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-number">02</div>
+        <h3>Agent Skill</h3>
+        <p>The bundled skill teaches your agent <em>when</em> and <em>how</em> to use Cartog — search routing, refactoring workflows, fallback heuristics.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-number">03</div>
+        <h3>Token efficient</h3>
+        <p>One <code>refs</code> call replaces 6+ grep/cat cycles. Pre-computed graph means structured results — not raw file dumps that burn context window.</p>
+      </div>
+    </div>
+
+    <div class="table-wrapper" style="margin-top: 40px;">
+      <table>
+        <thead>
+          <tr>
+            <th>Integration</th>
+            <th>Setup</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Claude Code plugin</td>
+            <td><code>/plugin install cartog@cartog-plugins</code></td>
+            <td>Skill + MCP + auto-setup, all-in-one</td>
+          </tr>
+          <tr>
+            <td>MCP server</td>
+            <td><code>cartog serve --watch --rag</code></td>
+            <td>12 tools over stdio, live index + semantic search</td>
+          </tr>
+          <tr>
+            <td>Agent skill</td>
+            <td><code>npx skills add jrollin/cartog</code></td>
+            <td>Behavioral rules for any compatible agent</td>
+          </tr>
+          <tr>
+            <td>CLI (any agent with bash)</td>
+            <td><code>cargo install cartog</code></td>
+            <td>Direct commands — works with any tool-using LLM</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p style="margin-top: 16px; font-size: 14px; color: var(--text-secondary);">
+      See <a href="usage.html#mcp-server">MCP Server docs</a> and <a href="usage.html#agent-skill">Agent Skill docs</a> for per-client setup (Claude Desktop, Cursor, Windsurf, Zed, OpenCode).
+    </p>
+  </div>
+</section>
+
 <!-- ── Install ──────────────────────────────────── -->
 <section id="install">
   <div class="container">
     <div class="section-label">Install</div>
     <h2 class="section-heading">Get started in seconds</h2>
 
-    <div class="install-options">
+    <div class="install-options" style="grid-template-columns: 1fr;">
       <div class="install-card">
         <h3>Claude Code (recommended)</h3>
         <pre>/plugin marketplace add jrollin/cartog
 /plugin install cartog@cartog-plugins</pre>
         <p>Installs the agent skill, setup scripts, and MCP server config.</p>
       </div>
-      <div class="install-card" style="margin-top: 16px;">
+      <div class="install-card">
         <h3>Agent Skill</h3>
         <pre>npx skills add jrollin/cartog</pre>
         <p>Works with any agent runtime that supports the skills protocol.</p>
       </div>
-    </div>
-
-    <div class="install-options" style="margin-top: 16px;">
       <div class="install-card">
         <h3>From crates.io</h3>
-        <pre>cargo install cartog                  <span class="comment"># core</span>
-cargo install cartog --features lsp   <span class="comment"># + LSP (recommended)</span></pre>
-        <p>The <code>lsp</code> feature auto-detects language servers on PATH for higher precision edge resolution.</p>
+        <pre>cargo install cartog                              <span class="comment"># core</span>
+cargo install cartog --features lsp               <span class="comment"># + LSP (recommended)</span>
+cargo install cartog --features ollama-embedding  <span class="comment"># + Ollama support</span></pre>
+        <p>The <code>lsp</code> feature auto-detects language servers on PATH. The <code>ollama-embedding</code> feature enables Ollama as an embedding provider.</p>
       </div>
       <div class="install-card">
         <h3>Pre-built binaries</h3>
@@ -371,6 +427,7 @@ sudo mv cartog /usr/local/bin/</pre>
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>
       </button>
     </div>
+    <p style="margin-top: 32px; font-size: 14px;"><a href="usage.html">Read the documentation →</a></p>
   </div>
 </section>
 
@@ -378,7 +435,7 @@ sudo mv cartog /usr/local/bin/</pre>
 <footer class="footer">
   <div class="container">
     <div class="footer-inner">
-      <span>cartog · MIT License · v0.8.1</span>
+      <span>Cartog · MIT License · v0.9.4</span>
       <ul class="footer-links">
         <li><a href="https://github.com/jrollin/cartog">GitHub</a></li>
         <li><a href="https://crates.io/crates/cartog">crates.io</a></li>
@@ -390,28 +447,13 @@ sudo mv cartog /usr/local/bin/</pre>
 
 <script>
 function copyCmd(btn, text) {
-  navigator.clipboard.writeText(text).then(function() {
-    var svg = btn.innerHTML;
+  navigator.clipboard.writeText(text).then(() => {
     btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>';
-    setTimeout(function() { btn.innerHTML = svg; }, 2000);
+    setTimeout(() => {
+      btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>';
+    }, 2000);
   });
 }
-</script>
-
-<script>
-  // Live GitHub star count — silent fail, static fallback shown
-  fetch('https://api.github.com/repos/jrollin/cartog')
-    .then(function(r) { return r.json(); })
-    .then(function(d) {
-      var el = document.getElementById('gh-stars');
-      if (el && d.stargazers_count) {
-        var count = d.stargazers_count;
-        el.textContent = count >= 1000
-          ? (count / 1000).toFixed(1) + 'k'
-          : String(count);
-      }
-    })
-    .catch(function() {});
 </script>
 
 </body>

--- a/site/usage.html
+++ b/site/usage.html
@@ -19,7 +19,7 @@
     <ul class="nav-links">
       <li><a href="index.html#features">Features</a></li>
       <li><a href="index.html#why">Why Cartog</a></li>
-      <li><a href="index.html#compare">Compare</a></li>
+      <li><a href="index.html#why">Compare</a></li>
       <li><a href="index.html#install">Install</a></li>
       <li><a href="usage.html">Docs</a></li>
       <li>

--- a/site/usage.html
+++ b/site/usage.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>cartog — Documentation</title>
-  <meta name="description" content="CLI reference, agent skill setup, MCP server configuration, and semantic search for cartog.">
+  <title>Cartog — Documentation</title>
+  <meta name="description" content="CLI reference, agent skill setup, MCP server configuration, and semantic search for Cartog.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -12,13 +12,13 @@
 <!-- ── Nav ──────────────────────────────────────── -->
 <header class="nav">
   <div class="nav-inner">
-    <a href="index.html" class="nav-logo">cartog</a>
+    <a href="index.html" class="nav-logo">Cartog</a>
     <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.nav-links').classList.toggle('open')">
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links">
       <li><a href="index.html#features">Features</a></li>
-      <li><a href="index.html#why">Why cartog</a></li>
+      <li><a href="index.html#why">Why Cartog</a></li>
       <li><a href="index.html#compare">Compare</a></li>
       <li><a href="index.html#install">Install</a></li>
       <li><a href="usage.html">Docs</a></li>
@@ -61,6 +61,11 @@
           <a href="#cmd-serve">cartog serve</a>
         </div>
         <div class="sidebar-group">
+          <div class="sidebar-label">Configuration</div>
+          <a href="#config">Config File</a>
+          <a href="#config-providers">Embedding Providers</a>
+        </div>
+        <div class="sidebar-group">
           <div class="sidebar-label">Semantic Search</div>
           <a href="#rag-setup">rag setup</a>
           <a href="#rag-index">rag index</a>
@@ -86,7 +91,7 @@
     <main class="docs-content">
 
       <p style="margin-bottom: 24px;">
-        <span class="badge">v0.7.0</span>
+        <span class="badge">v0.9.4</span>
         <a href="https://github.com/jrollin/cartog/releases/latest" style="margin-left: 8px; font-size: 13px;">View changelog →</a>
       </p>
 
@@ -103,9 +108,13 @@ cartog impact validate_token <span class="comment"># what breaks if I change thi
 cartog rag index .           <span class="comment"># embed all symbols + documents</span>
 cartog rag search "authentication token validation"</pre>
       <p>Indexes both <strong>code</strong> (functions, classes, methods) and <strong>Markdown documents</strong> (READMEs, design docs, API docs). Models are downloaded once to <code>~/.cache/cartog/models/</code> and run locally via ONNX Runtime. No API keys needed.</p>
+      <p><strong>Using Ollama instead?</strong> Add this to your <code>.cartog.toml</code> and skip <code>rag setup</code>:</p>
+      <pre>[embedding]
+provider = "ollama"</pre>
+      <p>See <a href="#config-providers">Embedding Providers</a> for full setup.</p>
 
       <h2 id="search-modes">Search Modes</h2>
-      <p>cartog offers two search modes that complement each other:</p>
+      <p>Cartog offers two search modes that complement each other:</p>
       <table>
         <thead>
           <tr>
@@ -144,6 +153,103 @@ cartog refs foo         <span class="comment"># 3. find all usages</span>
 cartog callees foo      <span class="comment"># 4. see what it depends on</span>
 cartog impact foo       <span class="comment"># 5. assess blast radius</span>
 cartog index .          <span class="comment"># 6. re-index after changes</span></pre>
+
+      <!-- ── Configuration ─────────────────────── -->
+
+      <h2 id="config">Configuration</h2>
+      <p>Cartog works with zero configuration. Optionally, place a <code>.cartog.toml</code> at your project root to customize database path, embedding provider, and re-ranking.</p>
+      <pre><span class="comment"># .cartog.toml — full reference</span>
+
+[database]
+path = "~/.local/share/cartog/myproject.db"
+
+<span class="comment"># Embedding provider (optional — defaults to local ONNX)</span>
+[embedding]
+provider = "local"               <span class="comment"># "local" (default) or "ollama"</span>
+model = "BAAI/bge-small-en-v1.5" <span class="comment"># model name (provider-specific)</span>
+dimension = 384                  <span class="comment"># auto-detected for built-in models</span>
+
+<span class="comment"># Local provider: asymmetric model prefixes</span>
+[embedding.local]
+query_prefix = "search_query: "
+document_prefix = "search_document: "
+
+<span class="comment"># Ollama provider settings</span>
+[embedding.ollama]
+base_url = "http://localhost:11434"
+model = "nomic-embed-text"
+
+<span class="comment"># Reranker (optional — defaults to local cross-encoder)</span>
+[reranker]
+provider = "local"               <span class="comment"># "local" (default) or "none"</span></pre>
+
+      <p>Database path resolution priority: <code>--db</code> flag / <code>CARTOG_DB</code> env > <code>.cartog.toml</code> > git root auto-detection > cwd fallback.</p>
+
+      <h2 id="config-providers">Embedding Providers</h2>
+      <p>Semantic search requires an embedding provider. Two options:</p>
+      <table>
+        <thead>
+          <tr><th>Provider</th><th>Config</th><th>Setup</th><th>Notes</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>local</strong> (default)</td>
+            <td>No config needed</td>
+            <td><code>cartog rag setup</code></td>
+            <td>ONNX Runtime via fastembed. ~1.2GB model download. Runs on CPU.</td>
+          </tr>
+          <tr>
+            <td><strong>ollama</strong></td>
+            <td><code>[embedding]<br>provider = "ollama"</code></td>
+            <td><code>ollama pull nomic-embed-text</code></td>
+            <td>HTTP API. GPU acceleration via Ollama. No model download by cartog.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Example: Ollama with GPU acceleration</h3>
+      <pre><span class="comment"># 1. Install with Ollama feature</span>
+cargo install cartog --features ollama-embedding
+
+<span class="comment"># 2. Start Ollama and pull a model</span>
+ollama serve
+ollama pull nomic-embed-text
+
+<span class="comment"># 3. Configure .cartog.toml</span>
+cat > .cartog.toml &lt;&lt;EOF
+[embedding]
+provider = "ollama"
+model = "nomic-embed-text"
+
+[embedding.ollama]
+base_url = "http://localhost:11434"
+EOF
+
+<span class="comment"># 4. Index and search — no rag setup needed</span>
+cartog index .
+cartog rag index .
+cartog rag search "authentication flow"</pre>
+
+      <h3>Example: Local with a different model</h3>
+      <pre><span class="comment"># Use a larger model for better quality</span>
+cat > .cartog.toml &lt;&lt;EOF
+[embedding]
+provider = "local"
+model = "BAAI/bge-base-en-v1.5"
+EOF
+
+cartog rag setup     <span class="comment"># downloads the configured model</span>
+cartog rag index .
+cartog rag search "error handling"</pre>
+
+      <h3>Example: Disable re-ranking</h3>
+      <pre><span class="comment"># Skip the 1.1GB reranker model download</span>
+cat > .cartog.toml &lt;&lt;EOF
+[reranker]
+provider = "none"
+EOF
+
+cartog rag setup     <span class="comment"># only downloads embedding model (~80MB)</span></pre>
 
       <!-- ── CLI Reference ─────────────────────── -->
 
@@ -223,12 +329,16 @@ cartog serve --watch --rag    <span class="comment"># + watcher + auto RAG</span
       <!-- ── Semantic Search ───────────────────── -->
 
       <h2 id="rag-setup"><code>cartog rag setup</code></h2>
-      <p>Download embedding and re-ranker models from HuggingFace. Run once before using semantic search.</p>
+      <p>Download embedding and re-ranker models from HuggingFace. Run once before using semantic search with the <strong>local</strong> provider.</p>
       <pre>cartog rag setup</pre>
       <p>Downloads ~1.2GB of ONNX models (embedding ~80MB + reranker ~1.1GB). Cached in <code>~/.cache/cartog/models/</code>.</p>
+      <p><strong>Note:</strong> When using Ollama, skip this — models are managed by the Ollama server.</p>
+      <pre><span class="comment"># To also skip the reranker download:</span>
+[reranker]
+provider = "none"</pre>
 
       <h2 id="rag-index"><code>cartog rag index</code></h2>
-      <p>Build the embedding index for semantic search. Indexes both code symbols and Markdown documents (<code>.md</code> files). Requires <code>cartog index</code> and <code>cartog rag setup</code> first.</p>
+      <p>Build the embedding index for semantic search. Indexes both code symbols and Markdown documents (<code>.md</code> files). Requires <code>cartog index</code> first. For the local provider, also requires <code>cartog rag setup</code>.</p>
       <pre>cartog rag index              <span class="comment"># embed all symbols + documents</span>
 cartog rag index src/         <span class="comment"># embed subdirectory</span>
 cartog rag index --force      <span class="comment"># re-embed all</span></pre>
@@ -423,7 +533,7 @@ cartog --tokens 200 outline src/db.rs</pre>
 <footer class="footer">
   <div class="container">
     <div class="footer-inner">
-      <span>cartog · MIT License · v0.7.0</span>
+      <span>Cartog · MIT License · v0.9.4</span>
       <ul class="footer-links">
         <li><a href="https://github.com/jrollin/cartog">GitHub</a></li>
         <li><a href="https://crates.io/crates/cartog">crates.io</a></li>

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -131,6 +131,8 @@ cartog pre-computes a code graph (symbols + edges) with tree-sitter and stores i
 
 Before first use, ensure cartog is installed and indexed.
 
+If the project uses Ollama (check `.cartog.toml` for `[embedding] provider = "ollama"`), skip `rag setup` — models are managed by the Ollama server.
+
 The `scripts/` directory is located next to this SKILL.md file. **Before running any setup command**, look at the absolute path from which this SKILL.md was loaded (visible in your tool call history), take its parent directory, and use that as the scripts root in the bash commands below.
 
 For example: if this file was loaded from `/home/user/.claude/skills/cartog/SKILL.md`, run:

--- a/skills/cartog/references/query_cookbook.md
+++ b/skills/cartog/references/query_cookbook.md
@@ -135,6 +135,23 @@ cartog rag setup          # download embedding + re-ranker models
 cartog rag index .        # embed all symbols + documents
 ```
 
+#### Ollama provider
+
+If the project uses Ollama for embeddings (configured in `.cartog.toml`):
+
+```bash
+# No rag setup needed — models are managed by Ollama
+ollama pull nomic-embed-text        # ensure model is available
+cartog rag index .                  # embed with Ollama
+cartog rag search "error handling"  # search works the same
+```
+
+#### Troubleshooting
+
+- **"Unknown or disabled embedding provider: 'ollama'"** — Install with `cargo install cartog --features ollama-embedding`.
+- **"Failed to connect to Ollama server"** — Ensure Ollama is running (`ollama serve`).
+- **"Embedding dimension changed"** — Provider switch detected. Run `cartog rag index` to re-embed.
+
 ### "Find code related to a concept"
 ```bash
 cartog rag search "parse abstract syntax tree"


### PR DESCRIPTION
## Summary

- **Pluggable embedding providers**: support local ONNX (fastembed) and Ollama via `.cartog.toml` config
- **New `config` command** to display current configuration
- **Bug fixes from full code review**:
  - Fix column mapping in `search()` and `refs()` DB queries (content_hash/subtree_hash were wrong)
  - Fix `--kind all` panic in `search` and `changes` CLI commands
  - Wrap multi-statement deletes in transactions for crash safety
  - Add chunking guards to batch queries to avoid exceeding SQLite variable limits
  - Prevent symlink loop hangs with max_depth on WalkDir
  - Fix dedup collision bug with 3+ colliding symbol IDs
  - Detect EOF in LSP `read_headers` to avoid infinite loop
- **Hardening**: `Eq` on core types, Ollama dimension validation, lock ordering docs

## Test plan

- [x] All 450 tests pass
- [x] Each commit verified independently (bisect-safe)
- [x] `cargo clippy --all-features` clean
- [ ] Manual test: `cartog search --kind all` no longer panics
- [ ] Manual test: `cartog config` displays provider settings