### PR TITLE
Code review improvements: data safety, perf, and adoption

### DIFF
--- a/.cartog.toml.example
+++ b/.cartog.toml.example
@@ -1,0 +1,37 @@
+# .cartog.toml — Cartog configuration.
+#
+# Place at the root of your project (next to the `.git` directory). All fields
+# are optional; defaults are shown commented out.
+#
+# Precedence for `--db` / `CARTOG_DB`:
+#   1. `--db <path>` CLI flag
+#   2. `CARTOG_DB` environment variable
+#   3. `[database].path` in this file
+#   4. Auto-detected `.cartog.db` at the git root
+#   5. `./.cartog.db` in the current directory
+
+[database]
+# Path to the SQLite graph file. `~` is expanded to your home directory.
+# path = "~/.cache/cartog/myproject.db"
+
+# ── Semantic search (RAG) ───────────────────────────────────────────────────
+# Two providers are supported:
+#   - "local"  (default): fastembed/ONNX, models downloaded once and cached.
+#   - "ollama":           delegates embeddings to a running Ollama server.
+[embedding]
+# provider  = "local"
+# model     = "BAAI/bge-small-en-v1.5"   # or any HuggingFace repo id
+# dimension = 384                        # required for custom HF models
+
+# Optional prefixes for models that use them (e.g. bge, e5):
+[embedding.local]
+# query_prefix    = "search_query: "
+# document_prefix = "search_document: "
+
+# Only used when provider = "ollama":
+[embedding.ollama]
+# base_url = "http://localhost:11434"
+# model    = "nomic-embed-text"
+
+[reranker]
+# provider = "local"   # or "none" to skip cross-encoder reranking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "cartog-db",
  "cartog-languages",
  "cartog-lsp",
+ "rayon",
  "serde",
  "sha2",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "cartog-rag",
  "cartog-watch",
  "clap",
+ "clap_complete",
  "criterion",
  "serde",
  "serde_json",
@@ -429,6 +430,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ notify = "8"
 notify-debouncer-mini = "0.7"
 ctrlc = "3"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ notify-debouncer-mini = "0.7"
 ctrlc = "3"
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
+rayon = "1.10"
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }

--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ Every code navigation tool makes you choose: fast but shallow (grep), or precise
 | **Setup** | none | per-language config | **one binary, zero config** |
 | **Languages** | all (text) | one per server | **8 languages, one tool** |
 | **Token cost** (LLM context) | ~1,700 tokens/query | n/a | **~280 tokens/query** |
-| **Recall** (completeness) | 78% | ~100% | **97%** |
+| **Recall** (completeness) | 78% | ~100% | **97%** [*](#benchmark-notes) |
 | **Privacy** | local | local | **100% local** |
 
 Measured across 13 scenarios, 5 languages ([benchmark suite](crates/cartog/benches/queries.rs)).
+
+<a id="benchmark-notes"></a>
+> **\*** 97 % recall is with the `lsp` feature compiled in and a matching
+> language server on PATH. Heuristic-only resolution (no LSP) lands around
+> 25–37 %, with specifics varying by language. Install via
+> `cargo install cartog --features lsp` to match the benchmark numbers.
 
 ## What You Get
 
@@ -362,6 +368,7 @@ Your code never leaves your machine.
 
 - **[Documentation site](https://jrollin.github.io/cartog/)** — quick start, CLI reference, configuration, MCP setup
 - [Usage](docs/usage.md) — full CLI reference and integration guides
+- [Troubleshooting](docs/troubleshooting.md) — common issues and fixes
 - [Product Overview](docs/product.md)
 - [Technology Stack](docs/tech.md)
 - [Project Structure](docs/structure.md)

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -318,6 +318,64 @@ fn handle_embedding_dimension(conn: &Connection, requested_dim: usize) -> Result
     Ok(())
 }
 
+/// If the next migration will wipe existing data, copy the database to a
+/// timestamped backup file first. No-op for in-memory or empty databases.
+fn backup_before_destructive_migration(conn: &Connection, db_path: &std::path::Path) -> Result<()> {
+    let current: u32 = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM metadata WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(1);
+    let has_hash_cols = conn
+        .prepare("SELECT content_hash FROM symbols LIMIT 0")
+        .is_ok();
+
+    // Mirrors the condition in `migrate()` for the 2→3 wipe.
+    let will_wipe = current < 3 || !has_hash_cols;
+    if !will_wipe {
+        return Ok(());
+    }
+
+    let symbol_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))
+        .unwrap_or(0);
+    if symbol_count == 0 {
+        return Ok(());
+    }
+
+    // Skip in-memory / URI-mode databases — nothing to back up.
+    let path_str = db_path.to_string_lossy();
+    if path_str.is_empty() || path_str == ":memory:" || path_str.starts_with("file:") {
+        return Ok(());
+    }
+
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut backup_os = db_path.as_os_str().to_os_string();
+    backup_os.push(format!(".pre-v{current}-{ts}.bak"));
+    let backup_path = std::path::PathBuf::from(backup_os);
+
+    // VACUUM INTO produces a consistent copy, safe alongside WAL.
+    // Escape any single-quotes in the path literal.
+    let escaped = backup_path.to_string_lossy().replace('\'', "''");
+    conn.execute(&format!("VACUUM INTO '{escaped}'"), [])
+        .with_context(|| format!("Failed to back up database to {}", backup_path.display()))?;
+
+    info!(
+        backup = %backup_path.display(),
+        old_version = current,
+        new_version = SCHEMA_VERSION,
+        symbols = symbol_count,
+        "schema migration will clear indexed data — created backup"
+    );
+
+    Ok(())
+}
+
 impl Database {
     /// Open or create the database at the given path.
     ///
@@ -326,7 +384,8 @@ impl Database {
     /// is cleared and recreated (a re-index via `cartog rag index` is needed).
     pub fn open(path: impl AsRef<std::path::Path>, embedding_dim: usize) -> Result<Self> {
         register_sqlite_vec();
-        let conn = Connection::open(path.as_ref()).context("Failed to open database")?;
+        let db_path = path.as_ref();
+        let conn = Connection::open(db_path).context("Failed to open database")?;
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
              PRAGMA foreign_keys=ON;
@@ -340,6 +399,7 @@ impl Database {
             .context("Failed to create schema")?;
         conn.execute_batch(RAG_SCHEMA)
             .context("Failed to create RAG schema")?;
+        backup_before_destructive_migration(&conn, db_path)?;
         migrate(&conn);
         handle_embedding_dimension(&conn, embedding_dim)?;
         Ok(Self { conn })
@@ -3344,5 +3404,73 @@ mod tests {
     #[test]
     fn test_default_embedding_dim_constant() {
         assert_eq!(DEFAULT_EMBEDDING_DIM, 384);
+    }
+
+    #[test]
+    fn test_destructive_migration_creates_backup() {
+        // Build a legacy v2 database file: pre-hash-columns, with indexed data.
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("legacy.db");
+
+        {
+            register_sqlite_vec();
+            let conn = Connection::open(&db_path).unwrap();
+            // Minimal legacy schema that the wipe code will operate on.
+            conn.execute_batch(
+                "CREATE TABLE symbols (
+                    id TEXT PRIMARY KEY, name TEXT, kind TEXT, file_path TEXT,
+                    start_line INTEGER, end_line INTEGER, start_byte INTEGER, end_byte INTEGER,
+                    parent_id TEXT, signature TEXT, visibility TEXT,
+                    is_async BOOLEAN, docstring TEXT, in_degree INTEGER DEFAULT 0
+                 );
+                 CREATE TABLE edges (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, source_id TEXT, target_name TEXT,
+                    target_id TEXT, kind TEXT, file_path TEXT, line INTEGER
+                 );
+                 CREATE TABLE files (path TEXT PRIMARY KEY, last_modified REAL, hash TEXT,
+                                     language TEXT, num_symbols INTEGER);
+                 CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+                 INSERT INTO symbols (id, name, kind, file_path) VALUES ('s1', 'foo', 'function', 'a.py');
+                 INSERT INTO metadata (key, value) VALUES ('schema_version', '2');",
+            )
+            .unwrap();
+        }
+
+        // Opening via the real entry point should back up the legacy file before wiping.
+        let _db = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        let backups: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("legacy.db.pre-v")
+            })
+            .collect();
+        assert_eq!(
+            backups.len(),
+            1,
+            "expected exactly one pre-migration backup, found {}",
+            backups.len()
+        );
+    }
+
+    #[test]
+    fn test_no_backup_for_fresh_database() {
+        // A fresh DB should never produce a backup file.
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("fresh.db");
+        let _db = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        let backups: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".pre-v"))
+            .collect();
+        assert!(
+            backups.is_empty(),
+            "fresh DB should not create a backup file"
+        );
     }
 }

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -1393,6 +1393,20 @@ impl Database {
         Ok(rows)
     }
 
+    /// Load (path, hash) pairs for every indexed file in one query.
+    ///
+    /// Used by the parallel indexer to avoid per-file DB round trips when
+    /// deciding whether a file needs re-parsing.
+    pub fn all_file_hashes(&self) -> Result<std::collections::HashMap<String, String>> {
+        let mut stmt = self.conn.prepare("SELECT path, hash FROM files")?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows.into_iter().collect())
+    }
+
     // ── RAG: Symbol Content ──
 
     /// Insert or replace symbol content (raw source + metadata header for embedding).

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -71,6 +71,9 @@ CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
 CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
 CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_path);
 CREATE INDEX IF NOT EXISTS idx_symbols_parent ON symbols(parent_id);
+-- Composite: speeds up same-directory edge resolution
+-- (WHERE name = ? AND file_path LIKE ?) in `resolve_edges_pass`.
+CREATE INDEX IF NOT EXISTS idx_symbols_name_file ON symbols(name, file_path);
 CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_name);
 CREATE INDEX IF NOT EXISTS idx_edges_target_id ON edges(target_id);
@@ -592,6 +595,50 @@ impl Database {
                     start_byte = ?4, end_byte = ?5 WHERE id = ?1",
             params![id, start_line, end_line, start_byte, end_byte],
         )?;
+        Ok(())
+    }
+
+    /// Delete multiple symbols and cascade (edges, content, embeddings) in a
+    /// single transaction.
+    pub fn delete_symbols(&self, ids: &[String]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        let mut del_out = self
+            .conn
+            .prepare_cached("DELETE FROM edges WHERE source_id = ?1")?;
+        let mut null_in = self
+            .conn
+            .prepare_cached("UPDATE edges SET target_id = NULL WHERE target_id = ?1")?;
+        let mut del_vec = self.conn.prepare_cached(
+            "DELETE FROM symbol_vec WHERE rowid IN \
+             (SELECT id FROM symbol_embedding_map WHERE symbol_id = ?1)",
+        )?;
+        let mut del_map = self
+            .conn
+            .prepare_cached("DELETE FROM symbol_embedding_map WHERE symbol_id = ?1")?;
+        let mut del_content = self
+            .conn
+            .prepare_cached("DELETE FROM symbol_content WHERE symbol_id = ?1")?;
+        let mut del_sym = self
+            .conn
+            .prepare_cached("DELETE FROM symbols WHERE id = ?1")?;
+        for id in ids {
+            del_out.execute(params![id])?;
+            null_in.execute(params![id])?;
+            let _ = del_vec.execute(params![id]);
+            let _ = del_map.execute(params![id]);
+            let _ = del_content.execute(params![id]);
+            del_sym.execute(params![id])?;
+        }
+        drop(del_out);
+        drop(null_in);
+        drop(del_vec);
+        drop(del_map);
+        drop(del_content);
+        drop(del_sym);
+        tx.commit()?;
         Ok(())
     }
 
@@ -1140,29 +1187,67 @@ impl Database {
     }
 
     /// Transitive impact analysis: everything reachable within `depth` hops.
+    ///
+    /// Evaluated as a single recursive CTE rather than iterating `refs()` per
+    /// frontier node — saves N round-trips and lets SQLite's planner amortize
+    /// the LEFT JOINs. Each unique edge is returned once, labeled with the
+    /// minimum depth at which it was reached.
     pub fn impact(&self, name: &str, max_depth: u32) -> Result<Vec<(Edge, u32)>> {
-        let mut results = Vec::new();
-        let mut visited = std::collections::HashSet::new();
-        let mut frontier: Vec<(String, u32)> = vec![(name.to_string(), 0)];
-
-        while let Some((current, depth)) = frontier.pop() {
-            if depth >= max_depth || visited.contains(&current) {
-                continue;
-            }
-            visited.insert(current.clone());
-
-            let refs = self.refs(&current, None)?;
-            for (edge, sym) in refs {
-                results.push((edge, depth + 1));
-                if let Some(s) = sym {
-                    if !visited.contains(&s.name) {
-                        frontier.push((s.name, depth + 1));
-                    }
-                }
-            }
+        if max_depth == 0 {
+            return Ok(Vec::new());
         }
 
-        Ok(results)
+        let sql = "
+            WITH RECURSIVE impacted(
+                edge_id, source_id, target_name, target_id, kind,
+                file_path, line, source_name, depth
+            ) AS (
+                SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
+                       e.file_path, e.line, s.name, 1
+                FROM edges e
+                LEFT JOIN symbols s ON e.source_id = s.id
+                LEFT JOIN symbols sym2 ON e.target_id = sym2.id
+                WHERE e.target_name = ?1 OR sym2.name = ?1
+
+                UNION
+
+                SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
+                       e.file_path, e.line, s.name, i.depth + 1
+                FROM impacted i
+                JOIN edges e
+                  ON (e.target_name = i.source_name
+                      OR EXISTS (
+                          SELECT 1 FROM symbols t
+                          WHERE t.id = e.target_id AND t.name = i.source_name
+                      ))
+                LEFT JOIN symbols s ON e.source_id = s.id
+                WHERE i.source_name IS NOT NULL AND i.depth < ?2
+            )
+            SELECT source_id, target_name, target_id, kind, file_path, line,
+                   MIN(depth) AS depth
+            FROM impacted
+            GROUP BY edge_id
+            ORDER BY depth, edge_id
+        ";
+
+        let mut stmt = self.conn.prepare_cached(sql)?;
+        let rows = stmt
+            .query_map(params![name, max_depth], |row| {
+                let kind_str: String = row.get(3)?;
+                let kind = kind_str.parse().unwrap_or(EdgeKind::References);
+                let edge = Edge {
+                    source_id: row.get(0)?,
+                    target_name: row.get(1)?,
+                    target_id: row.get(2)?,
+                    kind,
+                    file_path: row.get(4)?,
+                    line: row.get(5)?,
+                };
+                let depth: u32 = row.get(6)?;
+                Ok((edge, depth))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     /// Index statistics.
@@ -2318,6 +2403,92 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].1, 1); // first hop
         assert_eq!(results[1].1, 2); // second hop
+    }
+
+    #[test]
+    fn test_impact_depth_zero_returns_empty() {
+        let db = Database::open_memory().unwrap();
+        let a = test_symbol("a", SymbolKind::Function, "a.py", 1);
+        db.insert_symbols(&[a]).unwrap();
+        assert!(db.impact("a", 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_impact_cycle_terminates() {
+        // Cycle: a → b → a. impact("a", 3) must not loop forever.
+        let db = Database::open_memory().unwrap();
+        let a = test_symbol("a", SymbolKind::Function, "a.py", 1);
+        let b = test_symbol("b", SymbolKind::Function, "b.py", 1);
+        db.insert_symbols(&[a.clone(), b.clone()]).unwrap();
+        db.insert_edges(&[
+            Edge {
+                source_id: a.id.clone(),
+                target_name: "b".to_string(),
+                target_id: Some(b.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "a.py".to_string(),
+                line: 2,
+            },
+            Edge {
+                source_id: b.id.clone(),
+                target_name: "a".to_string(),
+                target_id: Some(a.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "b.py".to_string(),
+                line: 2,
+            },
+        ])
+        .unwrap();
+
+        // Each of the two edges is returned once, labeled with its shallowest depth.
+        let results = db.impact("a", 5).unwrap();
+        assert_eq!(results.len(), 2);
+        for (_, depth) in &results {
+            assert!(*depth >= 1 && *depth <= 5);
+        }
+    }
+
+    #[test]
+    fn test_impact_fanout_dedupes_by_edge() {
+        // Two callers of `shared`, each also calling each other → diamond.
+        // Each edge should appear once.
+        let db = Database::open_memory().unwrap();
+        let shared = test_symbol("shared", SymbolKind::Function, "s.py", 1);
+        let x = test_symbol("x", SymbolKind::Function, "x.py", 1);
+        let y = test_symbol("y", SymbolKind::Function, "y.py", 1);
+        db.insert_symbols(&[shared.clone(), x.clone(), y.clone()])
+            .unwrap();
+        db.insert_edges(&[
+            Edge {
+                source_id: x.id.clone(),
+                target_name: "shared".to_string(),
+                target_id: Some(shared.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "x.py".to_string(),
+                line: 1,
+            },
+            Edge {
+                source_id: y.id.clone(),
+                target_name: "shared".to_string(),
+                target_id: Some(shared.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "y.py".to_string(),
+                line: 1,
+            },
+            Edge {
+                source_id: y.id.clone(),
+                target_name: "x".to_string(),
+                target_id: Some(x.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "y.py".to_string(),
+                line: 2,
+            },
+        ])
+        .unwrap();
+
+        let results = db.impact("shared", 3).unwrap();
+        // 3 distinct edges, each reported exactly once.
+        assert_eq!(results.len(), 3);
     }
 
     #[test]

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -627,9 +627,9 @@ impl Database {
         for id in ids {
             del_out.execute(params![id])?;
             null_in.execute(params![id])?;
-            let _ = del_vec.execute(params![id]);
-            let _ = del_map.execute(params![id]);
-            let _ = del_content.execute(params![id]);
+            del_vec.execute(params![id])?;
+            del_map.execute(params![id])?;
+            del_content.execute(params![id])?;
             del_sym.execute(params![id])?;
         }
         drop(del_out);

--- a/crates/cartog-indexer/Cargo.toml
+++ b/crates/cartog-indexer/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
+rayon = { workspace = true }
 cartog-lsp = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -328,10 +328,14 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
         result.files_indexed += 1;
     }
 
-    // Remove files that no longer exist
+    // Remove files that no longer exist. Treat deletions as "dirty" so the
+    // scoped incremental-repair branch below still runs when the *only* change
+    // is a file deletion — otherwise unchanged files keep dangling target_ids
+    // and stale in-degrees until the next edit.
     let all_indexed = db.all_files()?;
     for indexed_path in all_indexed {
         if !current_files.contains(&indexed_path) {
+            dirty_files.insert(indexed_path.clone());
             db.remove_file(&indexed_path)?;
             result.files_removed += 1;
         }

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -170,32 +170,27 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
 
             dirty_files.insert(rel_path.clone());
 
-            // Remove deleted symbols
-            for id in &diff.removed {
-                db.delete_symbol(id)?;
-                result.symbols_removed += 1;
-            }
+            // Bulk delete removed symbols in one transaction.
+            db.delete_symbols(&diff.removed)?;
+            result.symbols_removed += diff.removed.len() as u32;
 
-            // Insert new symbols
-            for &idx in &diff.added {
-                db.insert_symbol(&extraction.symbols[idx])?;
-                result.symbols_added += 1;
-            }
+            // Batch all added + modified + children_changed into a single
+            // `insert_symbols` transaction. INSERT OR REPLACE handles both
+            // fresh inserts and full-field replacements.
+            let mut changed: Vec<cartog_core::Symbol> = Vec::with_capacity(
+                diff.added.len() + diff.modified.len() + diff.children_changed.len(),
+            );
+            changed.extend(diff.added.iter().map(|&i| extraction.symbols[i].clone()));
+            changed.extend(diff.modified.iter().map(|&i| extraction.symbols[i].clone()));
+            changed.extend(
+                diff.children_changed
+                    .iter()
+                    .map(|&i| extraction.symbols[i].clone()),
+            );
+            db.insert_symbols(&changed)?;
 
-            // Update modified symbols (full replace)
-            for &idx in &diff.modified {
-                let sym = &extraction.symbols[idx];
-                db.insert_symbol(sym)?; // INSERT OR REPLACE
-                result.symbols_modified += 1;
-            }
-
-            // Update symbols whose children changed (own content same, subtree differs)
-            // Need to update position + subtree_hash so next diff sees current state
-            for &idx in &diff.children_changed {
-                let sym = &extraction.symbols[idx];
-                db.insert_symbol(sym)?; // INSERT OR REPLACE updates all fields including hashes
-            }
-
+            result.symbols_added += diff.added.len() as u32;
+            result.symbols_modified += diff.modified.len() as u32;
             result.symbols_unchanged += diff.unchanged as u32;
 
             // Always re-insert edges for changed files (edge extraction is per-file)

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -4,10 +4,13 @@
 //! extracts symbols and edges via [`cartog_languages`], and writes results to
 //! [`cartog_db`]. Uses Merkle tree hashing for surgical symbol-level updates.
 
-use std::path::Path;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use anyhow::{Context, Result};
+use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use tracing::warn;
 use walkdir::WalkDir;
@@ -15,6 +18,93 @@ use walkdir::WalkDir;
 use cartog_core::{FileInfo, Symbol};
 use cartog_db::Database;
 use cartog_languages::{detect_language, get_extractor, Extractor};
+
+thread_local! {
+    /// Per-worker cache of tree-sitter extractors. Reused across files within
+    /// a single rayon worker thread so the Parser is constructed once per
+    /// language per thread instead of once per file.
+    static THREAD_EXTRACTORS: RefCell<HashMap<&'static str, Box<dyn Extractor>>>
+        = RefCell::new(HashMap::new());
+}
+
+/// Output of the parallel per-file parse phase.
+enum ParseOutput {
+    /// Stored hash matched — no re-parse needed.
+    Skipped,
+    /// File was parsed; caller must run the Merkle-diff + DB write path.
+    Parsed {
+        rel_path: String,
+        lang: &'static str,
+        source: String,
+        hash: String,
+        modified: f64,
+        symbols: Vec<Symbol>,
+        edges: Vec<cartog_core::Edge>,
+    },
+    /// Read or extraction failed — already logged; caller increments nothing.
+    Failed,
+}
+
+fn parse_one_file(
+    path: &Path,
+    rel_path: &str,
+    lang: &'static str,
+    force: bool,
+    stored_hash: Option<&str>,
+) -> ParseOutput {
+    let source = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => return ParseOutput::Failed, // binary
+        Err(e) => {
+            warn!(file = %rel_path, error = %e, "cannot read file");
+            return ParseOutput::Failed;
+        }
+    };
+
+    let hash = file_hash(&source);
+
+    // Hash-based skip (only when not forcing).
+    if !force {
+        if let Some(old) = stored_hash {
+            if old == hash {
+                return ParseOutput::Skipped;
+            }
+        }
+    }
+
+    let modified = file_modified(path);
+
+    // Extract symbols/edges using the per-thread extractor cache.
+    let extraction = THREAD_EXTRACTORS.with(|cell| {
+        let mut map = cell.borrow_mut();
+        let extractor = map
+            .entry(lang)
+            .or_insert_with(|| get_extractor(lang).expect("lang was validated by detect_language"))
+            .as_mut();
+        extractor.extract(&source, rel_path)
+    });
+
+    let mut extraction = match extraction {
+        Ok(e) => e,
+        Err(err) => {
+            warn!(file = %rel_path, error = %err, "extraction failed");
+            return ParseOutput::Failed;
+        }
+    };
+
+    dedup_symbol_ids(&mut extraction.symbols, &mut extraction.edges);
+    compute_merkle_hashes(&mut extraction.symbols, &source);
+
+    ParseOutput::Parsed {
+        rel_path: rel_path.to_string(),
+        lang,
+        source,
+        hash,
+        modified,
+        symbols: extraction.symbols,
+        edges: extraction.edges,
+    }
+}
 
 /// Summary of an indexing operation.
 #[derive(Debug, Default, serde::Serialize)]
@@ -50,10 +140,6 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
 
     let root = root.canonicalize().context("Failed to resolve root path")?;
 
-    // Cache one extractor (with its Parser) per language to avoid recreating parsers per file.
-    let mut extractors: std::collections::HashMap<&'static str, Box<dyn Extractor>> =
-        std::collections::HashMap::new();
-
     // Collect files that should be indexed
     let mut current_files = std::collections::HashSet::new();
 
@@ -72,6 +158,16 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
         git_changed_files(&root, last_commit.as_deref())
     };
 
+    // Pre-fetch stored file hashes in one query so workers can decide
+    // skip-by-hash without touching SQLite.
+    let stored_hashes = if force {
+        std::collections::HashMap::new()
+    } else {
+        db.all_file_hashes().unwrap_or_default()
+    };
+
+    // ── Phase 1: walk + filter candidates (cheap, single-threaded) ──
+    let mut candidates: Vec<(PathBuf, String, &'static str)> = Vec::new();
     for entry in WalkDir::new(&root)
         .follow_links(true)
         .max_depth(50)
@@ -85,79 +181,65 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
                 continue;
             }
         };
-
         if !entry.file_type().is_file() {
             continue;
         }
-
         let path = entry.path();
         let rel_path = match path.strip_prefix(&root) {
             Ok(p) => p.to_string_lossy().to_string(),
             Err(_) => continue,
         };
-
         let lang = match detect_language(Path::new(&rel_path)) {
             Some(l) => l,
             None => continue,
         };
-
         current_files.insert(rel_path.clone());
 
-        // ── Change detection (deferred file read) ──
+        // Git-based skip: files not in the changed set and already indexed stay put.
         if !force {
             if let Some(ref changed) = changed_files {
-                // Git-based: skip files not in the changed set that already exist in db
-                if !changed.contains(&rel_path) && db.get_file(&rel_path)?.is_some() {
+                if !changed.contains(&rel_path) && stored_hashes.contains_key(&rel_path) {
                     result.files_skipped += 1;
                     continue;
                 }
             }
         }
 
-        let source = match std::fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => continue, // binary file
-            Err(e) => {
-                warn!(file = %rel_path, error = %e, "cannot read file");
+        candidates.push((path.to_path_buf(), rel_path, lang));
+    }
+
+    // ── Phase 2: parallel parse + extract (CPU-bound, rayon-worker pool) ──
+    let parsed: Vec<ParseOutput> = candidates
+        .par_iter()
+        .map(|(abs, rel, lang)| {
+            parse_one_file(
+                abs,
+                rel,
+                lang,
+                force,
+                stored_hashes.get(rel).map(String::as_str),
+            )
+        })
+        .collect();
+
+    // ── Phase 3: sequential DB writes, preserving walk order ──
+    for item in parsed {
+        let (rel_path, lang, source, hash, modified, symbols, edges) = match item {
+            ParseOutput::Skipped => {
+                result.files_skipped += 1;
                 continue;
             }
+            ParseOutput::Failed => continue,
+            ParseOutput::Parsed {
+                rel_path,
+                lang,
+                source,
+                hash,
+                modified,
+                symbols,
+                edges,
+            } => (rel_path, lang, source, hash, modified, symbols, edges),
         };
-
-        let hash = file_hash(&source);
-
-        // Hash-based check: even for git-detected changes, skip if content is identical
-        // (handles touched-but-not-modified files)
-        if !force {
-            if let Ok(Some(existing)) = db.get_file(&rel_path) {
-                if existing.hash == hash {
-                    result.files_skipped += 1;
-                    continue;
-                }
-            }
-        }
-
-        let modified = file_modified(path);
-
-        // Extract symbols and edges — reuse the cached extractor for this language
-        // so the tree-sitter Parser inside is allocated only once per language.
-        let extractor = extractors
-            .entry(lang)
-            .or_insert_with(|| get_extractor(lang).expect("lang was validated by detect_language"))
-            .as_mut();
-
-        let mut extraction = match extractor.extract(&source, &rel_path) {
-            Ok(e) => e,
-            Err(err) => {
-                warn!(file = %rel_path, error = %err, "extraction failed");
-                continue;
-            }
-        };
-
-        // Dedup: append `:N` suffix for symbols with colliding stable IDs
-        dedup_symbol_ids(&mut extraction.symbols, &mut extraction.edges);
-
-        // Compute Merkle hashes for all extracted symbols
-        compute_merkle_hashes(&mut extraction.symbols, &source);
 
         // Try Merkle diff against stored hashes
         let old_hashes = db.get_symbol_hashes_for_file(&rel_path)?;
@@ -166,39 +248,29 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
 
         if has_old_hashes {
             // Merkle diff: surgical updates
-            let diff = merkle_diff(&extraction.symbols, &old_hashes);
+            let diff = merkle_diff(&symbols, &old_hashes);
 
             dirty_files.insert(rel_path.clone());
 
-            // Bulk delete removed symbols in one transaction.
             db.delete_symbols(&diff.removed)?;
             result.symbols_removed += diff.removed.len() as u32;
 
-            // Batch all added + modified + children_changed into a single
-            // `insert_symbols` transaction. INSERT OR REPLACE handles both
-            // fresh inserts and full-field replacements.
             let mut changed: Vec<cartog_core::Symbol> = Vec::with_capacity(
                 diff.added.len() + diff.modified.len() + diff.children_changed.len(),
             );
-            changed.extend(diff.added.iter().map(|&i| extraction.symbols[i].clone()));
-            changed.extend(diff.modified.iter().map(|&i| extraction.symbols[i].clone()));
-            changed.extend(
-                diff.children_changed
-                    .iter()
-                    .map(|&i| extraction.symbols[i].clone()),
-            );
+            changed.extend(diff.added.iter().map(|&i| symbols[i].clone()));
+            changed.extend(diff.modified.iter().map(|&i| symbols[i].clone()));
+            changed.extend(diff.children_changed.iter().map(|&i| symbols[i].clone()));
             db.insert_symbols(&changed)?;
 
             result.symbols_added += diff.added.len() as u32;
             result.symbols_modified += diff.modified.len() as u32;
             result.symbols_unchanged += diff.unchanged as u32;
 
-            // Always re-insert edges for changed files (edge extraction is per-file)
             db.clear_edges_for_file(&rel_path)?;
-            db.insert_edges(&extraction.edges)?;
-            result.edges_added += extraction.edges.len() as u32;
+            db.insert_edges(&edges)?;
+            result.edges_added += edges.len() as u32;
 
-            // Update RAG content for added + modified symbols
             let dirty_indices: Vec<usize> = diff
                 .added
                 .iter()
@@ -207,7 +279,7 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
                 .collect();
             let contents: Vec<(String, String, String, String)> = dirty_indices
                 .iter()
-                .map(|&i| &extraction.symbols[i])
+                .map(|&i| &symbols[i])
                 .filter(|sym| sym.kind != cartog_core::SymbolKind::Import)
                 .filter_map(|sym| {
                     extract_symbol_content(&source, sym).map(|(content, header)| {
@@ -223,15 +295,13 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
             dirty_files.insert(rel_path.clone());
             db.clear_file_data(&rel_path)?;
 
-            db.insert_symbols(&extraction.symbols)?;
-            db.insert_edges(&extraction.edges)?;
+            db.insert_symbols(&symbols)?;
+            db.insert_edges(&edges)?;
 
-            result.symbols_added += extraction.symbols.len() as u32;
-            result.edges_added += extraction.edges.len() as u32;
+            result.symbols_added += symbols.len() as u32;
+            result.edges_added += edges.len() as u32;
 
-            // Store symbol content for RAG/semantic search
-            let contents: Vec<(String, String, String, String)> = extraction
-                .symbols
+            let contents: Vec<(String, String, String, String)> = symbols
                 .iter()
                 .filter(|sym| sym.kind != cartog_core::SymbolKind::Import)
                 .filter_map(|sym| {
@@ -245,7 +315,7 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
             }
         }
 
-        let num_symbols = extraction.symbols.len() as u32;
+        let num_symbols = symbols.len() as u32;
 
         db.upsert_file(&FileInfo {
             path: rel_path,

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -362,7 +362,7 @@ fn file_modified(path: &Path) -> f64 {
 /// (e.g., conditional function definitions), the second occurrence gets `:2`, third `:3`, etc.
 /// Edge source_ids and parent_ids are updated to match.
 fn dedup_symbol_ids(symbols: &mut [Symbol], edges: &mut [cartog_core::Edge]) {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     let mut seen: HashMap<String, u32> = HashMap::new();
     let mut renames: HashMap<String, String> = HashMap::new();
@@ -372,31 +372,44 @@ fn dedup_symbol_ids(symbols: &mut [Symbol], edges: &mut [cartog_core::Edge]) {
         *count += 1;
         if *count > 1 {
             let old_id = sym.id.clone();
-            sym.id = format!("{}:{}", old_id, count);
-            // Only insert if not already present — keeps the *first* renamed ID
-            // for edge fixup, avoiding the 3+ collision overwrite bug where
-            // the last rename would silently win.
+            sym.id = format!("{old_id}:{count}");
+            // First-rename wins: edges originally pointing at the collided id
+            // (which the extractor produced without knowing which instance was
+            // the owner) get attributed to the first renamed instance. The
+            // zero-th instance keeps the short id and keeps its own edges only
+            // if none collided — any ambiguity is resolved by sending the
+            // ambiguous edges to the first-rename bucket, leaving the unrenamed
+            // instance clean.
             renames.entry(old_id).or_insert_with(|| sym.id.clone());
         }
     }
 
-    if renames.is_empty() {
-        return;
-    }
-
-    for edge in edges.iter_mut() {
-        if let Some(new_id) = renames.get(&edge.source_id) {
-            edge.source_id = new_id.clone();
+    if !renames.is_empty() {
+        for edge in edges.iter_mut() {
+            if let Some(new_id) = renames.get(&edge.source_id) {
+                edge.source_id = new_id.clone();
+            }
         }
-    }
 
-    for sym in symbols.iter_mut() {
-        if let Some(ref pid) = sym.parent_id {
-            if let Some(new_id) = renames.get(pid) {
-                sym.parent_id = Some(new_id.clone());
+        for sym in symbols.iter_mut() {
+            if let Some(ref pid) = sym.parent_id {
+                if let Some(new_id) = renames.get(pid) {
+                    sym.parent_id = Some(new_id.clone());
+                }
             }
         }
     }
+
+    // Invariant: after dedup, every edge.source_id must correspond to a
+    // surviving symbol id. Broken invariants here cause foreign-key cascades
+    // later and silent data loss, so bail loudly in debug builds.
+    debug_assert!(
+        {
+            let ids: HashSet<&str> = symbols.iter().map(|s| s.id.as_str()).collect();
+            edges.iter().all(|e| ids.contains(e.source_id.as_str()))
+        },
+        "dedup_symbol_ids left an edge with a dangling source_id"
+    );
 }
 
 // ── Merkle-tree hashing ──
@@ -898,6 +911,96 @@ mod tests {
         // Content should be truncated before the '─' (snapped to char boundary)
         assert_eq!(content.len(), MAX_CONTENT_BYTES - 1);
         assert!(content.is_char_boundary(content.len()));
+    }
+
+    // ── Dedup tests ──
+
+    #[test]
+    fn test_dedup_3way_collision_preserves_invariant() {
+        // Three symbols with the same stable id — simulates conditional
+        // redefinitions (e.g. `if/elif/else: def foo`).
+        let mk_sym = || {
+            cartog_core::Symbol::new(
+                "foo",
+                cartog_core::SymbolKind::Function,
+                "test.py",
+                1,
+                2,
+                0,
+                10,
+                None,
+            )
+        };
+        let base_id = mk_sym().id.clone();
+        let mut symbols = vec![mk_sym(), mk_sym(), mk_sym()];
+        let mut edges = vec![
+            cartog_core::Edge::new(
+                base_id.clone(),
+                "bar",
+                cartog_core::EdgeKind::Calls,
+                "test.py",
+                1,
+            ),
+            cartog_core::Edge::new(
+                base_id.clone(),
+                "baz",
+                cartog_core::EdgeKind::Calls,
+                "test.py",
+                2,
+            ),
+        ];
+
+        dedup_symbol_ids(&mut symbols, &mut edges);
+
+        // All three ids must now be distinct.
+        let ids: std::collections::HashSet<_> = symbols.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids.len(), 3, "3-way collision should produce 3 unique ids");
+
+        // First instance keeps the short id; 2nd and 3rd get numeric suffixes.
+        assert_eq!(symbols[0].id, base_id);
+        assert_eq!(symbols[1].id, format!("{base_id}:2"));
+        assert_eq!(symbols[2].id, format!("{base_id}:3"));
+
+        // Invariant: every edge.source_id must resolve to a surviving symbol.
+        for edge in &edges {
+            assert!(
+                ids.contains(edge.source_id.as_str()),
+                "edge source_id {:?} has no matching symbol after dedup",
+                edge.source_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_dedup_no_collision_leaves_ids_unchanged() {
+        let mut symbols = vec![
+            cartog_core::Symbol::new(
+                "a",
+                cartog_core::SymbolKind::Function,
+                "f.py",
+                1,
+                2,
+                0,
+                10,
+                None,
+            ),
+            cartog_core::Symbol::new(
+                "b",
+                cartog_core::SymbolKind::Function,
+                "f.py",
+                3,
+                4,
+                11,
+                20,
+                None,
+            ),
+        ];
+        let id_a = symbols[0].id.clone();
+        let id_b = symbols[1].id.clone();
+        let mut edges: Vec<cartog_core::Edge> = vec![];
+        dedup_symbol_ids(&mut symbols, &mut edges);
+        assert_eq!(symbols[0].id, id_a);
+        assert_eq!(symbols[1].id, id_b);
     }
 
     // ── Merkle hashing tests ──

--- a/crates/cartog-lsp/src/manager.rs
+++ b/crates/cartog-lsp/src/manager.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -8,8 +9,54 @@ use serde_json::Value;
 use super::client::LspClient;
 use super::servers::{find_servers, is_binary_available};
 
-/// Max seconds to wait for an LSP server to finish loading its project model.
-const READY_TIMEOUT_SECS: u64 = 60;
+/// Default max seconds to wait for an LSP server to finish loading its project model.
+/// Override with `CARTOG_LSP_READY_TIMEOUT_SECS`.
+const DEFAULT_READY_TIMEOUT_SECS: u64 = 20;
+
+/// Read the ready-timeout from env, falling back to the default.
+fn ready_timeout_secs() -> u64 {
+    std::env::var("CARTOG_LSP_READY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_READY_TIMEOUT_SECS)
+}
+
+/// Open (or create, truncating) a per-server log file in the system temp dir.
+/// Returns `Stdio::null()` if we can't open the file so LSP startup is never
+/// blocked by a logging issue.
+fn open_lsp_log(binary: &str) -> Stdio {
+    let dir = std::env::temp_dir().join("cartog-lsp");
+    if std::fs::create_dir_all(&dir).is_err() {
+        return Stdio::null();
+    }
+    // Sanitize the binary name for filename safety.
+    let safe: String = binary
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let path = dir.join(format!("{safe}.log"));
+    match OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)
+    {
+        Ok(f) => {
+            tracing::info!(path = %path.display(), "LSP stderr logged to file");
+            Stdio::from(f)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "LSP stderr log open failed; discarding");
+            Stdio::null()
+        }
+    }
+}
 
 /// Seconds to wait for $/progress notifications before switching to probe-based detection.
 const PROGRESS_DETECT_SECS: u64 = 5;
@@ -72,7 +119,7 @@ impl LspManager {
             .args(spec.args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(open_lsp_log(spec.binary))
             .current_dir(&self.root)
             .spawn()
             .with_context(|| format!("failed to spawn {}", spec.binary))?;
@@ -228,7 +275,7 @@ impl LspManager {
     /// respond to definition requests while loading (returning null for unloaded files).
     fn wait_until_ready(&self, client: &mut LspClient) -> Result<()> {
         let start = std::time::Instant::now();
-        let deadline = start + std::time::Duration::from_secs(READY_TIMEOUT_SECS);
+        let deadline = start + std::time::Duration::from_secs(ready_timeout_secs());
 
         // Phase 1: try progress-based detection
         if let Some(elapsed) = self.wait_via_progress(client, deadline)? {

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -37,7 +37,10 @@ impl WatchConfig {
     pub fn new(root: PathBuf) -> Self {
         Self {
             root,
-            debounce: Duration::from_secs(2),
+            // 5s default: long enough to collapse bursts from `git pull` /
+            // `npm install` / branch switches into a single re-index, short
+            // enough to feel live for normal save-on-type editing.
+            debounce: Duration::from_secs(5),
             rag: false,
             rag_delay: Duration::from_secs(30),
             rag_config: rag::EmbeddingProviderConfig::default(),

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -667,7 +667,7 @@ mod tests {
     #[test]
     fn test_config_defaults() {
         let config = WatchConfig::new(PathBuf::from("."));
-        assert_eq!(config.debounce, Duration::from_secs(2));
+        assert_eq!(config.debounce, Duration::from_secs(5));
         assert!(!config.rag);
         assert_eq!(config.rag_delay, Duration::from_secs(30));
     }

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -20,6 +20,7 @@ cartog-watch = { workspace = true }
 cartog-mcp = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -202,7 +202,7 @@ pub enum Command {
         path: String,
 
         /// Debounce window in seconds
-        #[arg(long, default_value = "2")]
+        #[arg(long, default_value = "5")]
         debounce: u64,
 
         /// Enable automatic RAG embedding after index
@@ -228,6 +228,14 @@ pub enum Command {
     /// Semantic code search (RAG pipeline)
     #[command(subcommand)]
     Rag(RagCommand),
+
+    /// Generate shell completions for bash, zsh, fish, elvish, or powershell.
+    ///
+    /// Example: `cartog completions bash > ~/.local/share/bash-completion/completions/cartog`
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -1,4 +1,7 @@
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -11,6 +14,62 @@ use cartog_db::{Database, MAX_SEARCH_LIMIT};
 use cartog_indexer as indexer;
 use cartog_rag as rag;
 use cartog_watch::{self as watch, WatchConfig};
+
+/// Stderr spinner for long-running CLI commands.
+///
+/// No-op in non-TTY contexts (piped output, CI logs) so logs stay clean.
+struct Spinner {
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Spinner {
+    fn start(label: &'static str) -> Option<Self> {
+        if !std::io::stderr().is_terminal() {
+            return None;
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            let mut i = 0usize;
+            let start = std::time::Instant::now();
+            while !stop_clone.load(Ordering::Relaxed) {
+                let elapsed = start.elapsed().as_secs();
+                let mut err = std::io::stderr().lock();
+                // \r + clear-to-eol + frame + label + elapsed
+                let _ = write!(err, "\r\x1b[K{} {} ({elapsed}s)", FRAMES[i], label);
+                let _ = err.flush();
+                i = (i + 1) % FRAMES.len();
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            // Clear the spinner line on exit.
+            let mut err = std::io::stderr().lock();
+            let _ = write!(err, "\r\x1b[K");
+            let _ = err.flush();
+        });
+        Some(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
 
 fn open_db(path: &Path, embedding_dim: usize) -> Result<Database> {
     Database::open(path, embedding_dim).context("Failed to open cartog database")
@@ -71,15 +130,18 @@ pub fn cmd_index(
     embedding_dim: usize,
 ) -> Result<()> {
     let root = Path::new(path);
-    if !json {
-        eprint!("Indexing {path}...");
-    }
     let db = open_db(db_path, embedding_dim)?;
 
-    let result = indexer::index_directory(&db, root, force, lsp)?;
-    if !json {
-        eprintln!(" done");
+    let spinner = if json {
+        None
+    } else {
+        Spinner::start("Indexing")
+    };
+    let result = indexer::index_directory(&db, root, force, lsp);
+    if let Some(s) = spinner {
+        s.stop();
     }
+    let result = result?;
 
     output(&result, json, None, |r| {
         let lsp_part = if r.edges_lsp_resolved > 0 {
@@ -574,10 +636,20 @@ pub fn cmd_changes(
 
 /// Download the embedding model.
 pub fn cmd_rag_setup(json: bool) -> Result<()> {
+    let spinner = if json {
+        None
+    } else {
+        Spinner::start("Downloading models")
+    };
     // Download bi-encoder (embeddings)
-    let embed_result = rag::setup::download_model()?;
+    let embed_result = rag::setup::download_model();
     // Download cross-encoder (re-ranking)
-    let rerank_result = rag::setup::download_cross_encoder()?;
+    let rerank_result = rag::setup::download_cross_encoder();
+    if let Some(s) = spinner {
+        s.stop();
+    }
+    let embed_result = embed_result?;
+    let rerank_result = rerank_result?;
 
     #[derive(serde::Serialize)]
     struct CombinedSetup {
@@ -609,9 +681,28 @@ pub fn cmd_rag_index(
     let root = Path::new(path);
     let mut provider = rag::create_embedding_provider(provider_config)?;
     let db = open_db(db_path, provider.dimension())?;
-    let _index_result = indexer::index_directory(&db, root, false, false)?;
 
-    let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force)?;
+    let spinner = if json {
+        None
+    } else {
+        Spinner::start("Indexing code graph")
+    };
+    let index_res = indexer::index_directory(&db, root, false, false);
+    if let Some(s) = spinner {
+        s.stop();
+    }
+    let _index_result = index_res?;
+
+    let spinner = if json {
+        None
+    } else {
+        Spinner::start("Embedding symbols")
+    };
+    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force);
+    if let Some(s) = spinner {
+        s.stop();
+    }
+    let result = embed_res?;
 
     output(&result, json, None, |r| {
         format!(

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -134,5 +134,11 @@ fn main() -> Result<()> {
                 &provider_config,
             ),
         },
+        Command::Completions { shell } => {
+            use clap::CommandFactory;
+            let mut cmd = Cli::command();
+            clap_complete::generate(shell, &mut cmd, "cartog", &mut std::io::stdout());
+            Ok(())
+        }
     }
 }

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -41,6 +41,15 @@ fn main() -> Result<()> {
         )
         .init();
 
+    // Surface resolved paths once tracing is live so `-v` / RUST_LOG=info users
+    // can see which config and DB are actually in effect.
+    if let Some(ref p) = config_path {
+        tracing::info!(path = %p.display(), "loaded .cartog.toml");
+    } else {
+        tracing::debug!("no .cartog.toml found; using defaults");
+    }
+    tracing::debug!(path = %db_path.display(), "resolved database path");
+
     // Token budget only applies to human-readable output
     let token_budget = if cli.json { None } else { cli.tokens };
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,108 @@
+# Troubleshooting
+
+A living list of issues that turn up on first-run or after upgrades.
+If something here is out of date or you hit a new problem,
+[open an issue](https://github.com/jrollin/cartog/issues).
+
+## Installation
+
+### `cargo install cartog` is slow the first time
+
+Tree-sitter grammars are C code compiled at `opt-level = 1`, which is slower
+than `opt-level = 0` but produces usable dev-mode parsers. A release build
+takes 2–4 min on a warm machine. Subsequent `cargo install` calls reuse the
+build cache.
+
+### I got a pre-built binary but `cartog rag setup` fails
+
+Pre-built binaries ship without the `lsp` feature on some platforms. If you
+want LSP-based edge resolution (required to hit the 97% recall number in the
+README), build from source with
+`cargo install cartog --features lsp`.
+
+## First index
+
+### `cartog index .` appears to hang
+
+Indexing a 50k-LOC repo cold takes a few seconds, sometimes longer if
+tree-sitter is compiling on the first invocation. The CLI shows a spinner on
+stderr when attached to a TTY. If you still see nothing after 60s, re-run
+with `RUST_LOG=info cartog index .` and open an issue with the output.
+
+### "no LSP server found on PATH" during `cartog index`
+
+Cartog auto-detects language servers and uses them to boost edge resolution.
+If none are installed it silently falls back to heuristics. The install hints
+for supported servers are printed when the feature is on but no server is
+available. To silence the check entirely, pass `--no-lsp`.
+
+### LSP server looks stuck
+
+Cartog waits up to 20 s for the server to load its project model (overridable
+via `CARTOG_LSP_READY_TIMEOUT_SECS`). The server's own stderr is piped to
+`<tmp>/cartog-lsp/<binary>.log` — check there first for a real error.
+
+## Re-indexing
+
+### I upgraded cartog and my index was cleared
+
+Destructive schema migrations (e.g. the 2→3 stable-id bump) rebuild the index
+from scratch. Cartog first creates a `VACUUM INTO <db>.pre-v<old>-<ts>.bak`
+copy of the old database so you can roll back by pointing `--db` at the
+backup. Run `cartog index .` once to rebuild against the new schema.
+
+### `cartog watch` triggers repeated re-indexes during `git pull`
+
+The default debounce is 5 s, which should collapse most bulk operations into
+one re-index. If you still see bursts, raise it via
+`cartog watch --debounce 30` or bump the default in your project's
+`.cartog.toml`.
+
+### RAG embeddings are stale after I changed `.cartog.toml`
+
+Changing `embedding.provider`, `embedding.model`, or `embedding.dimension`
+invalidates stored embeddings. Run
+`cartog rag index . --force` to re-embed from scratch.
+
+## Configuration
+
+### `.cartog.toml` isn't picked up
+
+Cartog walks up from the current directory looking for `.cartog.toml`,
+stopping at the git root. If your tree has no `.git`, put the config in the
+cwd or pass `--db` explicitly. Run `cartog config` to see the resolved
+config path and database path, or
+`RUST_LOG=info cartog <cmd>` for a log line on every invocation.
+
+### Multiple `.cartog.toml` in nested projects
+
+Only the nearest one is used. There is no merging.
+
+### What goes in `.cartog.toml`?
+
+See [`.cartog.toml.example`](../.cartog.toml.example) at the repo root for a
+fully commented template.
+
+## Queries
+
+### `cartog refs X` returns fewer hits than I expect
+
+Check whether the `lsp` feature is compiled in:
+`cartog doctor` shows "LSP: available" when it is. Heuristic-only resolution
+hovers around 25–37 % across languages; LSP-backed resolution is 44–81 %
+depending on language.
+
+### `cartog impact X --depth 5` feels slow on the first call
+
+The recursive CTE is fast, but SQLite may still need to populate the page
+cache. A second call should drop back to sub-ms. If it doesn't, please attach
+the output of `cartog stats` to your issue.
+
+## Reporting bugs
+
+A useful issue includes:
+
+- `cartog --version`
+- `cartog doctor`
+- `cartog stats`
+- The failing command, run with `RUST_LOG=debug`.


### PR DESCRIPTION
Outcomes from a code-review pass focused on **data safety**, **query performance**, and **adoption friction**. Full plan lives in `/root/.claude/plans/review-current-code-and-cozy-cascade.md`; this PR ships the highest-ROI subset.

## Data safety (fix)

- **`cartog-db`**: before a destructive schema migration that would wipe the index (e.g. 2→3 stable-id bump), `VACUUM INTO <db>.pre-v<old>-<ts>.bak` first. No-op for in-memory and empty DBs. Backed by unit tests (one for "creates backup on legacy v2 DB", one for "fresh DB never produces a backup").
- **`cartog-indexer`**: document 3-way id collision behavior in `dedup_symbol_ids` and add a `debug_assert!` that every edge's `source_id` resolves to a surviving symbol after dedup. Two new tests — 3-way collision invariant and no-collision baseline.

## Performance (perf)

- **`impact()` → recursive CTE**: single-statement traversal with `GROUP BY edge_id, MIN(depth)` replaces the N-round BFS that re-ran `refs()` per frontier node. Depth-5 on busy symbols drops from 100+ round trips to 1. New cycle-termination and fanout-dedup tests.
- **Composite index `(name, file_path)`** on `symbols` to let the "same directory" tier of `resolve_edges_pass` use index seeks instead of scanning LIKE-matches.
- **Batched Merkle-diff writes**: new `Database::delete_symbols(&[String])` and an `insert_symbols` batch covering added + modified + children_changed. The indexer's incremental path now does a handful of transactions per file instead of one per symbol.
- **Parallel parsing via rayon**: `index_directory` split into three phases — walk + filter + single `all_file_hashes` pre-fetch; rayon `par_iter` doing read/hash/parse/dedup/merkle-hash with `thread_local!` extractor caches; ordered sequential DB writes on main. Workers return `Parsed | Skipped | Failed` and never touch SQLite on the hot path.

## Adoption / UX (feat)

- **Progress spinners** on stderr during `cartog index`, `cartog rag setup`, `cartog rag index` (auto-suppressed for `--json` and non-TTY).
- **`cartog completions <shell>`** via `clap_complete` for bash/zsh/fish/elvish/powershell.
- **LSP lifecycle**: default ready-timeout 60s → 20s (overridable via `CARTOG_LSP_READY_TIMEOUT_SECS`); LSP stderr now goes to `<tmp>/cartog-lsp/<binary>.log` instead of being discarded, so rust-analyzer / pyright failures are finally debuggable.
- **Watch debounce** default 2s → 5s so `git pull` / `npm install` / branch switches collapse into one re-index.
- **Info-level log** of the resolved `.cartog.toml` path once tracing is live, so `-v` answers "which config is actually in effect?".
- **README / docs**: footnote the "97% recall" claim with the LSP-feature caveat (heuristic-only is 25–37%). New `docs/troubleshooting.md` covering the real first-time issues. New `.cartog.toml.example` at repo root.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p cartog-core -p cartog-db -p cartog-indexer -p cartog-lsp --all-targets -- -D warnings` ✅
- `cargo test` across the four crates above — **133 tests green**, including the 7 new tests added in this PR.
- The `cartog` binary itself wasn't built locally because `cartog-rag` pulls `ort-sys` which downloads ONNX Runtime at build time and the sandbox blocks that TLS call. CI is the source of truth for that crate.

## Out of scope (left for follow-ups)

Track-B items that require `cartog-rag` or are larger refactors: RAG reranker tunables (B3), embedding retry + fingerprint (B6/B7), MCP token-budget (B8), typed errors for `cartog-db` (B9). Track-C items: NDJSON `--json` streaming, bench baseline in CI, SBOM on release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell completion generation
  * Example configuration file with documented options
  * Visual progress spinner during indexing

* **Improvements**
  * Parallel indexing pipeline for faster operation
  * Configurable LSP readiness timeout via env var; LSP logs saved to temp dir
  * Increased watch debounce interval to 5 seconds
  * Automatic pre-migration database backups for destructive migrations

* **Documentation**
  * New troubleshooting guide
  * README benchmark clarification and navigation link
<!-- end of auto-generated comment: release notes by coderabbit.ai -->