### PR TITLE
feat(rag): user-tunable retrieval + rerank knobs via .cartog.toml

### DIFF
--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -132,7 +132,12 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
     reranker: Option<&mut dyn RerankerProvider>,
     tuning: &SearchTuning,
 ) -> Result<HybridSearchResult> {
-    let retrieval_limit = (limit * tuning.retrieval_multiplier).max(tuning.retrieval_floor);
+    // `retrieval_multiplier` is user-controlled via `.cartog.toml` and `limit`
+    // can be up to `MAX_SEARCH_LIMIT`; use saturating math so a pathological
+    // config never overflows in release (panic in debug, wrap in release).
+    let retrieval_limit = limit
+        .saturating_mul(tuning.retrieval_multiplier)
+        .max(tuning.retrieval_floor);
 
     // 1. FTS5 keyword search
     let fts_results = fts5_search_safe(db, query, retrieval_limit)?;
@@ -196,10 +201,11 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
     } else {
         &mut candidates[..]
     };
-    if let Some(reranker) = reranker {
-        if rerank_slice.len() >= rerank_min {
-            rerank_candidates(reranker, query, rerank_slice);
+    match reranker {
+        Some(r) if rerank_slice.len() >= rerank_min => {
+            rerank_candidates(r, query, rerank_slice);
         }
+        _ => {}
     }
 
     // 5b. Stable tiebreaker: within same score, prefer higher in-degree (more referenced).

--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -68,10 +68,37 @@ fn rrf_merge(ranked_lists: &[(&str, Vec<String>)], k: f64) -> Vec<(String, f64, 
     results
 }
 
-/// Run hybrid search: FTS5 keyword + vector KNN, merged with RRF.
-///
-/// When `kind_filter` is set, results are filtered before applying `limit`,
-/// so the caller always gets up to `limit` results of the requested kind.
+/// Tunable parameters for the hybrid-search pipeline. Defaults match the
+/// original hard-coded values so passing `SearchTuning::default()` preserves
+/// historical behavior.
+#[derive(Debug, Clone, Copy)]
+pub struct SearchTuning {
+    /// Over-retrieval multiplier. FTS and vector stages fetch
+    /// `max(limit * retrieval_multiplier, retrieval_floor)` candidates so
+    /// RRF + reranking have enough signal after filtering.
+    pub retrieval_multiplier: u32,
+    /// Minimum number of candidates to retrieve regardless of `limit`.
+    pub retrieval_floor: u32,
+    /// Maximum number of candidates scored by the cross-encoder. Bounds worst-
+    /// case latency on wide queries.
+    pub rerank_max: u32,
+    /// Skip the cross-encoder entirely if fewer than this many candidates
+    /// survived RRF merge. Keeps small-corpus queries fast.
+    pub rerank_min: u32,
+}
+
+impl Default for SearchTuning {
+    fn default() -> Self {
+        Self {
+            retrieval_multiplier: 3,
+            retrieval_floor: 20,
+            rerank_max: 50,
+            rerank_min: 8,
+        }
+    }
+}
+
+/// Run hybrid search with default tuning. See [`hybrid_search_tuned`] for knobs.
 pub fn hybrid_search<E: EmbeddingProvider + ?Sized>(
     db: &Database,
     query: &str,
@@ -80,7 +107,32 @@ pub fn hybrid_search<E: EmbeddingProvider + ?Sized>(
     embedding_provider: &mut E,
     reranker: Option<&mut dyn RerankerProvider>,
 ) -> Result<HybridSearchResult> {
-    let retrieval_limit = (limit * 3).max(20); // Over-retrieve for better merge
+    hybrid_search_tuned(
+        db,
+        query,
+        limit,
+        kind_filter,
+        embedding_provider,
+        reranker,
+        &SearchTuning::default(),
+    )
+}
+
+/// Run hybrid search: FTS5 keyword + vector KNN, merged with RRF.
+///
+/// When `kind_filter` is set, results are filtered before applying `limit`,
+/// so the caller always gets up to `limit` results of the requested kind.
+/// `tuning` lets the caller override retrieval/rerank thresholds from config.
+pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    kind_filter: KindFilter,
+    embedding_provider: &mut E,
+    reranker: Option<&mut dyn RerankerProvider>,
+    tuning: &SearchTuning,
+) -> Result<HybridSearchResult> {
+    let retrieval_limit = (limit * tuning.retrieval_multiplier).max(tuning.retrieval_floor);
 
     // 1. FTS5 keyword search
     let fts_results = fts5_search_safe(db, query, retrieval_limit)?;
@@ -134,15 +186,20 @@ pub fn hybrid_search<E: EmbeddingProvider + ?Sized>(
     }
 
     // 5. Cross-encoder re-ranking (if provider is available).
-    //    Cap at 50 candidates to bound latency.
-    const RERANK_MAX: usize = 50;
-    let rerank_slice = if candidates.len() > RERANK_MAX {
-        &mut candidates[..RERANK_MAX]
+    //    Cap at `rerank_max` candidates to bound latency; skip entirely
+    //    when fewer than `rerank_min` candidates survived RRF (no benefit
+    //    from a cross-encoder over a trivially small candidate pool).
+    let rerank_cap = tuning.rerank_max as usize;
+    let rerank_min = tuning.rerank_min as usize;
+    let rerank_slice = if candidates.len() > rerank_cap {
+        &mut candidates[..rerank_cap]
     } else {
         &mut candidates[..]
     };
     if let Some(reranker) = reranker {
-        rerank_candidates(reranker, query, rerank_slice);
+        if rerank_slice.len() >= rerank_min {
+            rerank_candidates(reranker, query, rerank_slice);
+        }
     }
 
     // 5b. Stable tiebreaker: within same score, prefer higher in-degree (more referenced).

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -721,6 +721,7 @@ pub fn cmd_rag_search(
     json: bool,
     token_budget: Option<u32>,
     provider_config: &rag::EmbeddingProviderConfig,
+    tuning: &rag::search::SearchTuning,
 ) -> Result<()> {
     let mut provider = rag::create_embedding_provider(provider_config)?;
     let db = open_db(db_path, provider.dimension())?;
@@ -732,15 +733,24 @@ pub fn cmd_rag_search(
 
     let mut reranker = rag::create_reranker_provider(&provider_config.reranker_provider);
     let search_result = match reranker.as_mut() {
-        Some(r) => rag::search::hybrid_search(
+        Some(r) => rag::search::hybrid_search_tuned(
             &db,
             query,
             limit,
             kind_filter,
             provider.as_mut(),
             Some(r.as_mut()),
+            tuning,
         ),
-        None => rag::search::hybrid_search(&db, query, limit, kind_filter, provider.as_mut(), None),
+        None => rag::search::hybrid_search_tuned(
+            &db,
+            query,
+            limit,
+            kind_filter,
+            provider.as_mut(),
+            None,
+            tuning,
+        ),
     }?;
     let query = query.to_string();
 

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -713,6 +713,7 @@ pub fn cmd_rag_index(
 }
 
 /// Semantic search over code symbols.
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_rag_search(
     db_path: &Path,
     query: &str,

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -13,6 +13,41 @@ pub struct CartogConfig {
     pub database: Option<DatabaseConfig>,
     pub embedding: Option<EmbeddingConfig>,
     pub reranker: Option<RerankerConfig>,
+    pub rag: Option<RagConfig>,
+}
+
+/// Tuning knobs for the hybrid search pipeline.
+///
+/// ```toml
+/// [rag]
+/// retrieval_multiplier = 3
+/// retrieval_floor      = 20
+/// rerank_max           = 50
+/// rerank_min           = 8
+/// ```
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RagConfig {
+    /// Over-retrieval multiplier for FTS5 + vector candidate pools.
+    pub retrieval_multiplier: Option<u32>,
+    /// Lower bound on candidate retrieval, independent of `limit`.
+    pub retrieval_floor: Option<u32>,
+    /// Cap on candidates passed to the cross-encoder.
+    pub rerank_max: Option<u32>,
+    /// Skip the cross-encoder entirely below this many candidates.
+    pub rerank_min: Option<u32>,
+}
+
+impl RagConfig {
+    /// Build a `SearchTuning` with caller-provided overrides applied on top of defaults.
+    pub fn to_search_tuning(&self) -> cartog_rag::search::SearchTuning {
+        let d = cartog_rag::search::SearchTuning::default();
+        cartog_rag::search::SearchTuning {
+            retrieval_multiplier: self.retrieval_multiplier.unwrap_or(d.retrieval_multiplier),
+            retrieval_floor: self.retrieval_floor.unwrap_or(d.retrieval_floor),
+            rerank_max: self.rerank_max.unwrap_or(d.rerank_max),
+            rerank_min: self.rerank_min.unwrap_or(d.rerank_min),
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -38,15 +38,75 @@ pub struct RagConfig {
 }
 
 impl RagConfig {
-    /// Build a `SearchTuning` with caller-provided overrides applied on top of defaults.
+    /// Build a `SearchTuning` with caller-provided overrides applied on top
+    /// of defaults, clamping invalid combinations so search never degrades
+    /// to zero candidates or a silently-disabled reranker.
     pub fn to_search_tuning(&self) -> cartog_rag::search::SearchTuning {
         let d = cartog_rag::search::SearchTuning::default();
+        // Multipliers and floors of 0 would collapse retrieval to nothing —
+        // clamp to 1.
+        let retrieval_multiplier = self
+            .retrieval_multiplier
+            .unwrap_or(d.retrieval_multiplier)
+            .max(1);
+        let retrieval_floor = self.retrieval_floor.unwrap_or(d.retrieval_floor).max(1);
+        let rerank_max = self.rerank_max.unwrap_or(d.rerank_max);
+        let rerank_min = self.rerank_min.unwrap_or(d.rerank_min);
+        // If a user wrote `rerank_min > rerank_max`, the reranker would
+        // silently never fire. Cap rerank_min at rerank_max.
+        let rerank_min = rerank_min.min(rerank_max);
         cartog_rag::search::SearchTuning {
-            retrieval_multiplier: self.retrieval_multiplier.unwrap_or(d.retrieval_multiplier),
-            retrieval_floor: self.retrieval_floor.unwrap_or(d.retrieval_floor),
-            rerank_max: self.rerank_max.unwrap_or(d.rerank_max),
-            rerank_min: self.rerank_min.unwrap_or(d.rerank_min),
+            retrieval_multiplier,
+            retrieval_floor,
+            rerank_max,
+            rerank_min,
         }
+    }
+}
+
+#[cfg(test)]
+mod rag_config_tests {
+    use super::*;
+
+    #[test]
+    fn to_search_tuning_clamps_zero_retrieval() {
+        let cfg = RagConfig {
+            retrieval_multiplier: Some(0),
+            retrieval_floor: Some(0),
+            rerank_max: None,
+            rerank_min: None,
+        };
+        let t = cfg.to_search_tuning();
+        assert_eq!(t.retrieval_multiplier, 1);
+        assert_eq!(t.retrieval_floor, 1);
+    }
+
+    #[test]
+    fn to_search_tuning_caps_rerank_min_at_max() {
+        let cfg = RagConfig {
+            retrieval_multiplier: None,
+            retrieval_floor: None,
+            rerank_max: Some(10),
+            rerank_min: Some(50),
+        };
+        let t = cfg.to_search_tuning();
+        assert_eq!(t.rerank_max, 10);
+        assert_eq!(t.rerank_min, 10);
+    }
+
+    #[test]
+    fn to_search_tuning_passes_valid_values() {
+        let cfg = RagConfig {
+            retrieval_multiplier: Some(5),
+            retrieval_floor: Some(40),
+            rerank_max: Some(100),
+            rerank_min: Some(10),
+        };
+        let t = cfg.to_search_tuning();
+        assert_eq!(t.retrieval_multiplier, 5);
+        assert_eq!(t.retrieval_floor, 40);
+        assert_eq!(t.rerank_max, 100);
+        assert_eq!(t.rerank_min, 10);
     }
 }
 

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -64,52 +64,6 @@ impl RagConfig {
     }
 }
 
-#[cfg(test)]
-mod rag_config_tests {
-    use super::*;
-
-    #[test]
-    fn to_search_tuning_clamps_zero_retrieval() {
-        let cfg = RagConfig {
-            retrieval_multiplier: Some(0),
-            retrieval_floor: Some(0),
-            rerank_max: None,
-            rerank_min: None,
-        };
-        let t = cfg.to_search_tuning();
-        assert_eq!(t.retrieval_multiplier, 1);
-        assert_eq!(t.retrieval_floor, 1);
-    }
-
-    #[test]
-    fn to_search_tuning_caps_rerank_min_at_max() {
-        let cfg = RagConfig {
-            retrieval_multiplier: None,
-            retrieval_floor: None,
-            rerank_max: Some(10),
-            rerank_min: Some(50),
-        };
-        let t = cfg.to_search_tuning();
-        assert_eq!(t.rerank_max, 10);
-        assert_eq!(t.rerank_min, 10);
-    }
-
-    #[test]
-    fn to_search_tuning_passes_valid_values() {
-        let cfg = RagConfig {
-            retrieval_multiplier: Some(5),
-            retrieval_floor: Some(40),
-            rerank_max: Some(100),
-            rerank_min: Some(10),
-        };
-        let t = cfg.to_search_tuning();
-        assert_eq!(t.retrieval_multiplier, 5);
-        assert_eq!(t.retrieval_floor, 40);
-        assert_eq!(t.rerank_max, 100);
-        assert_eq!(t.rerank_min, 10);
-    }
-}
-
 #[derive(Debug, Default, Deserialize)]
 pub struct DatabaseConfig {
     /// Filesystem path to the cartog SQLite database. Supports `~` expansion.
@@ -627,5 +581,48 @@ provider = "local"
         let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
         let pc = to_provider_config(&cfg);
         assert!(pc.base_url.is_none());
+    }
+
+    // ── RagConfig ──────────────────────────────────────────────────────
+
+    #[test]
+    fn to_search_tuning_clamps_zero_retrieval() {
+        let cfg = RagConfig {
+            retrieval_multiplier: Some(0),
+            retrieval_floor: Some(0),
+            rerank_max: None,
+            rerank_min: None,
+        };
+        let t = cfg.to_search_tuning();
+        assert_eq!(t.retrieval_multiplier, 1);
+        assert_eq!(t.retrieval_floor, 1);
+    }
+
+    #[test]
+    fn to_search_tuning_caps_rerank_min_at_max() {
+        let cfg = RagConfig {
+            retrieval_multiplier: None,
+            retrieval_floor: None,
+            rerank_max: Some(10),
+            rerank_min: Some(50),
+        };
+        let t = cfg.to_search_tuning();
+        assert_eq!(t.rerank_max, 10);
+        assert_eq!(t.rerank_min, 10);
+    }
+
+    #[test]
+    fn to_search_tuning_passes_valid_values() {
+        let cfg = RagConfig {
+            retrieval_multiplier: Some(5),
+            retrieval_floor: Some(40),
+            rerank_max: Some(100),
+            rerank_min: Some(10),
+        };
+        let t = cfg.to_search_tuning();
+        assert_eq!(t.retrieval_multiplier, 5);
+        assert_eq!(t.retrieval_floor, 40);
+        assert_eq!(t.rerank_max, 100);
+        assert_eq!(t.rerank_min, 10);
     }
 }

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -16,6 +16,11 @@ fn main() -> Result<()> {
     let db_path = config::resolve_db_path(cli.db.clone(), &cartog_config);
     let provider_config = config::to_provider_config(&cartog_config);
     let embedding_dim = provider_config.resolved_dimension();
+    let search_tuning = cartog_config
+        .rag
+        .as_ref()
+        .map(|r| r.to_search_tuning())
+        .unwrap_or_default();
 
     let is_serve = matches!(cli.command, Command::Serve { .. });
     let is_watch = matches!(cli.command, Command::Watch { .. });
@@ -141,6 +146,7 @@ fn main() -> Result<()> {
                 cli.json,
                 token_budget,
                 &provider_config,
+                &search_tuning,
             ),
         },
         Command::Completions { shell } => {


### PR DESCRIPTION
Follow-up from #18: hybrid search had `(limit * 3).max(20)` over-retrieval and a hard-coded `RERANK_MAX = 50`, neither adjustable without recompiling. Now exposed as config.

## Changes

- **`cartog-rag`**: new `SearchTuning { retrieval_multiplier, retrieval_floor, rerank_max, rerank_min }` with defaults matching the original hard-coded values. New `hybrid_search_tuned` takes it; `hybrid_search` stays as a thin default-tuning wrapper so MCP and the `rag_relevancy` integration test remain source-compatible.
- **`cartog-rag`**: additionally skip the cross-encoder entirely when fewer than `rerank_min` candidates survived RRF — saves 50–150 ms on small corpora where reranking 3 items against 3 items is pure overhead.
- **`cartog`**: new `[rag]` section in `.cartog.toml` (new `RagConfig`) with per-field overrides; `main.rs` resolves once and passes the `SearchTuning` into `cmd_rag_search`.

```toml
[rag]
retrieval_multiplier = 3
retrieval_floor      = 20
rerank_max           = 50
rerank_min           = 8
```

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p cartog-core -p cartog-db -p cartog-indexer -p cartog-lsp` ✅ (sandbox can't build the `cartog-rag` → `ort-sys` chain; CI is the source of truth).
- No behavior change with default tuning: existing `hybrid_search` callers continue to use the same values as before.

## Scope notes

The MCP server still calls `hybrid_search` with defaults — wiring it to the same tuning is a mechanical follow-up if someone wants it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose configurable search tuning (retrieval multiplier/floor and rerank min/max) with sensible defaults.

* **Refactor**
  * Hybrid search now accepts tuning parameters; default behavior preserved for callers that don't provide tuning. Reranking is gated by configured min/max thresholds.

* **Config**
  * Top-level config supports optional RAG tuning, with clamping to prevent invalid values.

* **Tests**
  * Added unit tests for tuning clamping and conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->