### PR TITLE
ci: promote cargo-deny to required + add informational bench job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,16 +93,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # --- Security (informational) ---
-
   deny:
     name: Dependency Policy
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-deny
       - run: cargo deny check
+
+  # --- Performance (informational) ---
+
+  bench:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    # Benchmarks on shared GitHub runners are noisy — never fail a PR on a
+    # variance-driven regression, but surface results as an artifact so
+    # reviewers can spot outliers.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run criterion benches
+        run: cargo bench --bench queries -- --warm-up-time 1 --measurement-time 3
+      - uses: actions/upload-artifact@v7
+        with:
+          name: criterion-report
+          path: target/criterion
+          retention-days: 14
 
   sbom:
     name: SBOM


### PR DESCRIPTION
Follow-up from #18 covering the C2/C3 items in the code-review plan.

## Changes

- **`cargo-deny` required.** Drop `continue-on-error: true` from the Dependency Policy job so license violations and advisory errors block PRs. Policy already treats vulnerabilities as errors and `multiple-versions` / `wildcards` as warnings, so this should be a no-op on current `main` while protecting against future regressions.
- **New informational `bench` job.** Runs `cargo bench --bench queries` with a trimmed measurement window (1 s warmup, 3 s sample) on every PR and uploads the criterion HTML report as an artifact (14-day retention). GitHub's shared runners are too noisy for a hard regression threshold, so the job is `continue-on-error: true`; the value is giving reviewers a quick way to spot-check performance-sensitive PRs, not a blocker.

## Verification

- YAML syntax checked locally by re-reading the file.
- CI on this branch will exercise both new behaviors end to end.

## Scope notes

Committing a baseline JSON and doing a ±threshold regression check was in the original plan but is noisy on shared runners. That can be layered on later once we know which benchmarks are stable on `ubuntu-latest`.
