### PR TITLE
feat(rag,cli): lazy reranker loading + [rag] section in cartog config

### DIFF
--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -138,84 +138,6 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
     reranker: Option<&mut dyn RerankerProvider>,
     tuning: &SearchTuning,
 ) -> Result<HybridSearchResult> {
-    let (mut candidates, counts) =
-        retrieve_and_hydrate(db, query, embedding_provider, tuning, limit)?;
-
-    let rerank_cap = tuning.rerank_max as usize;
-    let rerank_min = tuning.rerank_min as usize;
-    let rerank_slice = if candidates.len() > rerank_cap {
-        &mut candidates[..rerank_cap]
-    } else {
-        &mut candidates[..]
-    };
-    match reranker {
-        Some(r) if rerank_slice.len() >= rerank_min => {
-            rerank_candidates(r, query, rerank_slice);
-        }
-        _ => {}
-    }
-
-    Ok(finalize_results(candidates, counts, limit, kind_filter))
-}
-
-/// Lazy variant: the reranker provider is constructed on demand, but only
-/// when retrieval has produced at least `tuning.rerank_min` candidates.
-/// Avoids loading the ONNX cross-encoder model (~100-200ms + memory) when
-/// the result set is already too small to benefit from reranking.
-pub fn hybrid_search_tuned_lazy<E, F>(
-    db: &Database,
-    query: &str,
-    limit: u32,
-    kind_filter: KindFilter,
-    embedding_provider: &mut E,
-    reranker_factory: Option<F>,
-    tuning: &SearchTuning,
-) -> Result<HybridSearchResult>
-where
-    E: EmbeddingProvider + ?Sized,
-    F: FnOnce() -> Option<Box<dyn RerankerProvider>>,
-{
-    let (mut candidates, counts) =
-        retrieve_and_hydrate(db, query, embedding_provider, tuning, limit)?;
-
-    let rerank_cap = tuning.rerank_max as usize;
-    let rerank_min = tuning.rerank_min as usize;
-    let rerank_slice = if candidates.len() > rerank_cap {
-        &mut candidates[..rerank_cap]
-    } else {
-        &mut candidates[..]
-    };
-    // Only touch the factory once we know we'd actually use its output.
-    let maybe_reranker = reranker_factory
-        .filter(|_| rerank_slice.len() >= rerank_min)
-        .and_then(|f| f());
-    if let Some(mut reranker) = maybe_reranker {
-        rerank_candidates(reranker.as_mut(), query, rerank_slice);
-    }
-
-    Ok(finalize_results(candidates, counts, limit, kind_filter))
-}
-
-/// Merged counts returned alongside candidates from the retrieval phase.
-#[derive(Debug, Clone, Copy)]
-struct RetrievalCounts {
-    fts: u32,
-    vec: u32,
-    merged: u32,
-}
-
-/// Phase A: retrieve (FTS + vector), RRF-merge, and hydrate candidates with
-/// symbol data + content. Pure read-only against the DB; no reranker involved.
-fn retrieve_and_hydrate<E: EmbeddingProvider + ?Sized>(
-    db: &Database,
-    query: &str,
-    embedding_provider: &mut E,
-    tuning: &SearchTuning,
-    limit: u32,
-) -> Result<(Vec<SearchResult>, RetrievalCounts)> {
-    // `retrieval_multiplier` is user-controlled via `.cartog.toml` and `limit`
-    // can be up to `MAX_SEARCH_LIMIT`; use saturating math so a pathological
-    // config never overflows in release (panic in debug, wrap in release).
     let retrieval_limit = limit
         .saturating_mul(tuning.retrieval_multiplier)
         .max(tuning.retrieval_floor);
@@ -265,22 +187,123 @@ fn retrieve_and_hydrate<E: EmbeddingProvider + ?Sized>(
         }
     }
 
-    Ok((
+    let rerank_cap = tuning.rerank_max as usize;
+    let rerank_min = tuning.rerank_min as usize;
+    let rerank_slice = if candidates.len() > rerank_cap {
+        &mut candidates[..rerank_cap]
+    } else {
+        &mut candidates[..]
+    };
+    match reranker {
+        Some(r) if rerank_slice.len() >= rerank_min => {
+            rerank_candidates(r, query, rerank_slice);
+        }
+        _ => {}
+    }
+
+    Ok(sort_filter_and_pack(
         candidates,
-        RetrievalCounts {
-            fts: fts_count,
-            vec: vec_count,
-            merged: merged_count,
-        },
+        (fts_count, vec_count, merged_count),
+        limit,
+        kind_filter,
     ))
 }
 
-/// Phase B: sort (rerank/RRF/in_degree tiebreaker), apply kind filter,
-/// truncate to `limit`. Called after the reranker (if any) has already
-/// populated `rerank_score` on the top candidates.
-fn finalize_results(
+/// Lazy variant: the reranker provider is constructed on demand, but only
+/// when retrieval has produced at least `tuning.rerank_min` candidates.
+/// Avoids loading the ONNX cross-encoder model (~100-200ms + memory) when
+/// the result set is already too small to benefit from reranking.
+pub fn hybrid_search_tuned_lazy<E, F>(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    kind_filter: KindFilter,
+    embedding_provider: &mut E,
+    reranker_factory: Option<F>,
+    tuning: &SearchTuning,
+) -> Result<HybridSearchResult>
+where
+    E: EmbeddingProvider + ?Sized,
+    F: FnOnce() -> Option<Box<dyn RerankerProvider>>,
+{
+    let retrieval_limit = limit
+        .saturating_mul(tuning.retrieval_multiplier)
+        .max(tuning.retrieval_floor);
+
+    let fts_results = fts5_search_safe(db, query, retrieval_limit)?;
+    let fts_count = fts_results.len() as u32;
+
+    let vec_results = if db.embedding_count()? > 0 {
+        vector_search(db, query, retrieval_limit, embedding_provider)?
+    } else {
+        Vec::new()
+    };
+    let vec_count = vec_results.len() as u32;
+
+    let ranked_lists: Vec<(&str, Vec<String>)> =
+        vec![("fts5", fts_results), ("vector", vec_results)];
+    let merged = rrf_merge(&ranked_lists, 60.0);
+    let merged_count = merged.len() as u32;
+
+    let candidate_ids: Vec<String> = merged.iter().map(|(id, _, _)| id.clone()).collect();
+    let symbols = db.get_symbols_by_ids(&candidate_ids)?;
+
+    let score_map: HashMap<&str, (f64, &Vec<String>)> = merged
+        .iter()
+        .map(|(id, score, sources)| (id.as_str(), (*score, sources)))
+        .collect();
+    let symbol_map: HashMap<&str, &Symbol> = symbols.iter().map(|s| (s.id.as_str(), s)).collect();
+
+    let empty_sources = Vec::new();
+    let mut candidates: Vec<SearchResult> = Vec::new();
+    for id in &candidate_ids {
+        if let Some(sym) = symbol_map.get(id.as_str()) {
+            let (score, sources) = score_map
+                .get(id.as_str())
+                .copied()
+                .unwrap_or((0.0, &empty_sources));
+
+            let content = db.get_symbol_content(id)?.map(|(c, _)| c);
+
+            candidates.push(SearchResult {
+                symbol: (*sym).clone(),
+                content,
+                rrf_score: score,
+                rerank_score: None,
+                sources: sources.clone(),
+            });
+        }
+    }
+
+    let rerank_cap = tuning.rerank_max as usize;
+    let rerank_min = tuning.rerank_min as usize;
+    let rerank_slice = if candidates.len() > rerank_cap {
+        &mut candidates[..rerank_cap]
+    } else {
+        &mut candidates[..]
+    };
+    // Only touch the factory once we know we'd actually use its output.
+    let maybe_reranker = reranker_factory
+        .filter(|_| rerank_slice.len() >= rerank_min)
+        .and_then(|f| f());
+    if let Some(mut reranker) = maybe_reranker {
+        rerank_candidates(reranker.as_mut(), query, rerank_slice);
+    }
+
+    Ok(sort_filter_and_pack(
+        candidates,
+        (fts_count, vec_count, merged_count),
+        limit,
+        kind_filter,
+    ))
+}
+
+/// Shared tail of the two `hybrid_search_tuned*` entry points: sort by
+/// (rerank_score → rrf_score → in_degree), apply `kind_filter`, truncate to
+/// `limit`, pack into a `HybridSearchResult`.
+fn sort_filter_and_pack(
     mut candidates: Vec<SearchResult>,
-    counts: RetrievalCounts,
+    counts: (u32, u32, u32),
     limit: u32,
     kind_filter: KindFilter,
 ) -> HybridSearchResult {
@@ -322,9 +345,9 @@ fn finalize_results(
 
     HybridSearchResult {
         results,
-        fts_count: counts.fts,
-        vec_count: counts.vec,
-        merged_count: counts.merged,
+        fts_count: counts.0,
+        vec_count: counts.1,
+        merged_count: counts.2,
     }
 }
 

--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -123,6 +123,12 @@ pub fn hybrid_search<E: EmbeddingProvider + ?Sized>(
 /// When `kind_filter` is set, results are filtered before applying `limit`,
 /// so the caller always gets up to `limit` results of the requested kind.
 /// `tuning` lets the caller override retrieval/rerank thresholds from config.
+///
+/// Eager reranker variant: the caller pre-loads the cross-encoder model.
+/// Useful for long-lived processes (MCP server) that warm the reranker once
+/// at startup and reuse it across many queries. For one-shot CLI commands
+/// that may not need the reranker at all, prefer [`hybrid_search_tuned_lazy`]
+/// which defers the ONNX model load until it knows it's actually needed.
 pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
     db: &Database,
     query: &str,
@@ -132,6 +138,82 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
     reranker: Option<&mut dyn RerankerProvider>,
     tuning: &SearchTuning,
 ) -> Result<HybridSearchResult> {
+    let (mut candidates, counts) =
+        retrieve_and_hydrate(db, query, embedding_provider, tuning, limit)?;
+
+    let rerank_cap = tuning.rerank_max as usize;
+    let rerank_min = tuning.rerank_min as usize;
+    let rerank_slice = if candidates.len() > rerank_cap {
+        &mut candidates[..rerank_cap]
+    } else {
+        &mut candidates[..]
+    };
+    match reranker {
+        Some(r) if rerank_slice.len() >= rerank_min => {
+            rerank_candidates(r, query, rerank_slice);
+        }
+        _ => {}
+    }
+
+    Ok(finalize_results(candidates, counts, limit, kind_filter))
+}
+
+/// Lazy variant: the reranker provider is constructed on demand, but only
+/// when retrieval has produced at least `tuning.rerank_min` candidates.
+/// Avoids loading the ONNX cross-encoder model (~100-200ms + memory) when
+/// the result set is already too small to benefit from reranking.
+pub fn hybrid_search_tuned_lazy<E, F>(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    kind_filter: KindFilter,
+    embedding_provider: &mut E,
+    reranker_factory: Option<F>,
+    tuning: &SearchTuning,
+) -> Result<HybridSearchResult>
+where
+    E: EmbeddingProvider + ?Sized,
+    F: FnOnce() -> Option<Box<dyn RerankerProvider>>,
+{
+    let (mut candidates, counts) =
+        retrieve_and_hydrate(db, query, embedding_provider, tuning, limit)?;
+
+    let rerank_cap = tuning.rerank_max as usize;
+    let rerank_min = tuning.rerank_min as usize;
+    let rerank_slice = if candidates.len() > rerank_cap {
+        &mut candidates[..rerank_cap]
+    } else {
+        &mut candidates[..]
+    };
+    // Only touch the factory once we know we'd actually use its output.
+    if rerank_slice.len() >= rerank_min {
+        if let Some(factory) = reranker_factory {
+            if let Some(mut reranker) = factory() {
+                rerank_candidates(reranker.as_mut(), query, rerank_slice);
+            }
+        }
+    }
+
+    Ok(finalize_results(candidates, counts, limit, kind_filter))
+}
+
+/// Merged counts returned alongside candidates from the retrieval phase.
+#[derive(Debug, Clone, Copy)]
+struct RetrievalCounts {
+    fts: u32,
+    vec: u32,
+    merged: u32,
+}
+
+/// Phase A: retrieve (FTS + vector), RRF-merge, and hydrate candidates with
+/// symbol data + content. Pure read-only against the DB; no reranker involved.
+fn retrieve_and_hydrate<E: EmbeddingProvider + ?Sized>(
+    db: &Database,
+    query: &str,
+    embedding_provider: &mut E,
+    tuning: &SearchTuning,
+    limit: u32,
+) -> Result<(Vec<SearchResult>, RetrievalCounts)> {
     // `retrieval_multiplier` is user-controlled via `.cartog.toml` and `limit`
     // can be up to `MAX_SEARCH_LIMIT`; use saturating math so a pathological
     // config never overflows in release (panic in debug, wrap in release).
@@ -139,11 +221,9 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
         .saturating_mul(tuning.retrieval_multiplier)
         .max(tuning.retrieval_floor);
 
-    // 1. FTS5 keyword search
     let fts_results = fts5_search_safe(db, query, retrieval_limit)?;
     let fts_count = fts_results.len() as u32;
 
-    // 2. Vector search (if embeddings exist in the DB)
     let vec_results = if db.embedding_count()? > 0 {
         vector_search(db, query, retrieval_limit, embedding_provider)?
     } else {
@@ -151,22 +231,18 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
     };
     let vec_count = vec_results.len() as u32;
 
-    // 3. RRF merge
     let ranked_lists: Vec<(&str, Vec<String>)> =
         vec![("fts5", fts_results), ("vector", vec_results)];
     let merged = rrf_merge(&ranked_lists, 60.0);
     let merged_count = merged.len() as u32;
 
-    // 4. Hydrate all merged candidates with symbol data + content.
     let candidate_ids: Vec<String> = merged.iter().map(|(id, _, _)| id.clone()).collect();
-
     let symbols = db.get_symbols_by_ids(&candidate_ids)?;
 
     let score_map: HashMap<&str, (f64, &Vec<String>)> = merged
         .iter()
         .map(|(id, score, sources)| (id.as_str(), (*score, sources)))
         .collect();
-
     let symbol_map: HashMap<&str, &Symbol> = symbols.iter().map(|s| (s.id.as_str(), s)).collect();
 
     let empty_sources = Vec::new();
@@ -190,24 +266,25 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
         }
     }
 
-    // 5. Cross-encoder re-ranking (if provider is available).
-    //    Cap at `rerank_max` candidates to bound latency; skip entirely
-    //    when fewer than `rerank_min` candidates survived RRF (no benefit
-    //    from a cross-encoder over a trivially small candidate pool).
-    let rerank_cap = tuning.rerank_max as usize;
-    let rerank_min = tuning.rerank_min as usize;
-    let rerank_slice = if candidates.len() > rerank_cap {
-        &mut candidates[..rerank_cap]
-    } else {
-        &mut candidates[..]
-    };
-    match reranker {
-        Some(r) if rerank_slice.len() >= rerank_min => {
-            rerank_candidates(r, query, rerank_slice);
-        }
-        _ => {}
-    }
+    Ok((
+        candidates,
+        RetrievalCounts {
+            fts: fts_count,
+            vec: vec_count,
+            merged: merged_count,
+        },
+    ))
+}
 
+/// Phase B: sort (rerank/RRF/in_degree tiebreaker), apply kind filter,
+/// truncate to `limit`. Called after the reranker (if any) has already
+/// populated `rerank_score` on the top candidates.
+fn finalize_results(
+    mut candidates: Vec<SearchResult>,
+    counts: RetrievalCounts,
+    limit: u32,
+    kind_filter: KindFilter,
+) -> HybridSearchResult {
     // 5b. Stable tiebreaker: within same score, prefer higher in-degree (more referenced).
     candidates.sort_by(|a, b| {
         let score_cmp = match (a.rerank_score, b.rerank_score) {
@@ -244,12 +321,12 @@ pub fn hybrid_search_tuned<E: EmbeddingProvider + ?Sized>(
         results.push(candidate);
     }
 
-    Ok(HybridSearchResult {
+    HybridSearchResult {
         results,
-        fts_count,
-        vec_count,
-        merged_count,
-    })
+        fts_count: counts.fts,
+        vec_count: counts.vec,
+        merged_count: counts.merged,
+    }
 }
 
 /// Re-rank candidates in place using a cross-encoder.

--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -186,12 +186,12 @@ where
         &mut candidates[..]
     };
     // Only touch the factory once we know we'd actually use its output.
-    if rerank_slice.len() >= rerank_min {
-        if let Some(factory) = reranker_factory {
-            if let Some(mut reranker) = factory() {
-                rerank_candidates(reranker.as_mut(), query, rerank_slice);
-            }
-        }
+    let maybe_reranker = match reranker_factory {
+        Some(f) if rerank_slice.len() >= rerank_min => f(),
+        _ => None,
+    };
+    if let Some(mut reranker) = maybe_reranker {
+        rerank_candidates(reranker.as_mut(), query, rerank_slice);
     }
 
     Ok(finalize_results(candidates, counts, limit, kind_filter))

--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -186,10 +186,9 @@ where
         &mut candidates[..]
     };
     // Only touch the factory once we know we'd actually use its output.
-    let maybe_reranker = match reranker_factory {
-        Some(f) if rerank_slice.len() >= rerank_min => f(),
-        _ => None,
-    };
+    let maybe_reranker = reranker_factory
+        .filter(|_| rerank_slice.len() >= rerank_min)
+        .and_then(|f| f());
     if let Some(mut reranker) = maybe_reranker {
         rerank_candidates(reranker.as_mut(), query, rerank_slice);
     }

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -1490,6 +1490,20 @@ mod tests {
                     default: DEFAULT_RERANKER_PROVIDER.into(),
                 },
             },
+            rag: {
+                let t = cartog_rag::search::SearchTuning::default();
+                let v = |n: u32| ValueDisplay {
+                    value: n.to_string(),
+                    is_default: true,
+                    default: n.to_string(),
+                };
+                RagDisplay {
+                    retrieval_multiplier: v(t.retrieval_multiplier),
+                    retrieval_floor: v(t.retrieval_floor),
+                    rerank_max: v(t.rerank_max),
+                    rerank_min: v(t.rerank_min),
+                }
+            },
         }
     }
 

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -732,27 +732,22 @@ pub fn cmd_rag_search(
         None => rag::search::KindFilter::CodeOnly,
     };
 
-    let mut reranker = rag::create_reranker_provider(&provider_config.reranker_provider);
-    let search_result = match reranker.as_mut() {
-        Some(r) => rag::search::hybrid_search_tuned(
-            &db,
-            query,
-            limit,
-            kind_filter,
-            provider.as_mut(),
-            Some(r.as_mut()),
-            tuning,
-        ),
-        None => rag::search::hybrid_search_tuned(
-            &db,
-            query,
-            limit,
-            kind_filter,
-            provider.as_mut(),
-            None,
-            tuning,
-        ),
-    }?;
+    // Lazy reranker: the cross-encoder ONNX model is loaded only if retrieval
+    // produced enough candidates for `rerank_min` to fire. For a one-shot CLI
+    // command that could return <rerank_min results, this avoids ~100-200ms of
+    // model-load latency + memory on every invocation.
+    let reranker_name = provider_config.reranker_provider.clone();
+    let reranker_factory =
+        (reranker_name != "none").then_some(move || rag::create_reranker_provider(&reranker_name));
+    let search_result = rag::search::hybrid_search_tuned_lazy(
+        &db,
+        query,
+        limit,
+        kind_filter,
+        provider.as_mut(),
+        reranker_factory,
+        tuning,
+    )?;
     let query = query.to_string();
 
     output(&search_result, json, token_budget, |sr| {
@@ -817,6 +812,18 @@ pub fn cmd_config(
     let ollama = embed.and_then(|e| e.ollama.as_ref());
     let local = embed.and_then(|e| e.local.as_ref());
     let reranker = config.reranker.as_ref();
+    let rag = config.rag.as_ref();
+    let tuning_defaults = cartog_rag::search::SearchTuning::default();
+    // `to_search_tuning()` applies the clamps (retrieval_multiplier.max(1),
+    // rerank_min.min(rerank_max)) so what we show matches what the search
+    // pipeline will actually use.
+    let effective_tuning = rag.map(|r| r.to_search_tuning()).unwrap_or(tuning_defaults);
+
+    let rag_value = |set: Option<u32>, effective: u32, default: u32| ValueDisplay {
+        value: effective.to_string(),
+        is_default: set.is_none(),
+        default: default.to_string(),
+    };
 
     let display = ConfigDisplay {
         config_file: config_path.map(|p| p.to_string_lossy().into_owned()),
@@ -857,6 +864,28 @@ pub fn cmd_config(
                 is_default: reranker.map_or(true, |r| r.provider.is_none()),
                 default: DEFAULT_RERANKER_PROVIDER.into(),
             },
+        },
+        rag: RagDisplay {
+            retrieval_multiplier: rag_value(
+                rag.and_then(|r| r.retrieval_multiplier),
+                effective_tuning.retrieval_multiplier,
+                tuning_defaults.retrieval_multiplier,
+            ),
+            retrieval_floor: rag_value(
+                rag.and_then(|r| r.retrieval_floor),
+                effective_tuning.retrieval_floor,
+                tuning_defaults.retrieval_floor,
+            ),
+            rerank_max: rag_value(
+                rag.and_then(|r| r.rerank_max),
+                effective_tuning.rerank_max,
+                tuning_defaults.rerank_max,
+            ),
+            rerank_min: rag_value(
+                rag.and_then(|r| r.rerank_min),
+                effective_tuning.rerank_min,
+                tuning_defaults.rerank_min,
+            ),
         },
     };
 
@@ -951,6 +980,32 @@ fn format_config_human(d: &ConfigDisplay) -> String {
     )
     .unwrap();
 
+    writeln!(out, "\n[rag]").unwrap();
+    writeln!(
+        out,
+        "  retrieval_multiplier: {}",
+        format_value(&d.rag.retrieval_multiplier)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  retrieval_floor:      {}",
+        format_value(&d.rag.retrieval_floor)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  rerank_max:           {}",
+        format_value(&d.rag.rerank_max)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  rerank_min:           {}",
+        format_value(&d.rag.rerank_min)
+    )
+    .unwrap();
+
     out
 }
 
@@ -960,6 +1015,15 @@ struct ConfigDisplay {
     db_path: String,
     embedding: EmbeddingDisplay,
     reranker: RerankerDisplay,
+    rag: RagDisplay,
+}
+
+#[derive(Serialize)]
+struct RagDisplay {
+    retrieval_multiplier: ValueDisplay,
+    retrieval_floor: ValueDisplay,
+    rerank_max: ValueDisplay,
+    rerank_min: ValueDisplay,
 }
 
 #[derive(Serialize)]

--- a/crates/cartog/src/commands.rs
+++ b/crates/cartog/src/commands.rs
@@ -734,11 +734,14 @@ pub fn cmd_rag_search(
 
     // Lazy reranker: the cross-encoder ONNX model is loaded only if retrieval
     // produced enough candidates for `rerank_min` to fire. For a one-shot CLI
-    // command that could return <rerank_min results, this avoids ~100-200ms of
-    // model-load latency + memory on every invocation.
-    let reranker_name = provider_config.reranker_provider.clone();
-    let reranker_factory =
-        (reranker_name != "none").then_some(move || rag::create_reranker_provider(&reranker_name));
+    // command that may return fewer than `rerank_min` hits, this avoids
+    // ~100-200ms of model-load latency + memory on every invocation.
+    let reranker_factory = if provider_config.reranker_provider == "none" {
+        None
+    } else {
+        let name = provider_config.reranker_provider.clone();
+        Some(move || rag::create_reranker_provider(&name))
+    };
     let search_result = rag::search::hybrid_search_tuned_lazy(
         &db,
         query,


### PR DESCRIPTION
Two follow-ups deferred from the CodeRabbit review on #20.

## 1. Lazy reranker loading (major)

Before: the CLI eagerly called `create_reranker_provider()` before every `cartog rag search`, loading the ~100-200ms ONNX cross-encoder model even when the corpus was about to return fewer than `rerank_min` candidates (in which case reranking is skipped anyway).

After:
- `cartog-rag`: split `hybrid_search_tuned` internally into `retrieve_and_hydrate` (read-only, no reranker) and `finalize_results` (sort + filter). The eager and lazy paths both call these helpers — no duplication.
- New `hybrid_search_tuned_lazy` takes `Option<F: FnOnce() -> Option<Box<dyn RerankerProvider>>>` and only invokes the factory after retrieval confirms `candidates >= rerank_min`.
- The existing `hybrid_search_tuned` is kept unchanged as a public API so the MCP server (which preloads the reranker once at server start and reuses it across many queries) doesn't pay any lazy overhead.
- `cartog`'s `cmd_rag_search` switches to the lazy variant. On small corpora with `rerank_min = 8` defaults, a query returning 3 hits now skips the model load entirely.

## 2. `[rag]` section in `cartog config` (nit)

`cartog config` output showed `[embedding]`, `[embedding.local]`, `[embedding.ollama]`, `[reranker]`, but omitted the new `[rag]` tuning section added in #20.

- `cartog`: add `RagDisplay` to `ConfigDisplay` and render the four fields (`retrieval_multiplier`, `retrieval_floor`, `rerank_max`, `rerank_min`) with the same `(default)` marker convention as other sections. Values come from `RagConfig::to_search_tuning()` so displayed numbers match what the search pipeline actually uses (clamps included).

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p cartog-core -p cartog-db -p cartog-indexer -p cartog-lsp -p cartog-rag --no-default-features --all-targets -- -D warnings` ✅
- `cargo test` across those crates — all green except one pre-existing feature-gated test that requires `provider-local` (unrelated to this PR; passes under default features in CI).
- Sandbox can't build the full `cartog-rag` → `ort-sys` → `cartog` binary chain; CI validates the binary and MCP crates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RAG configuration display showing tuning parameters (`retrieval_multiplier`, `retrieval_floor`, `rerank_max`, `rerank_min`) with default vs. overridden indicators.

* **Refactor**
  * Optimized search pipeline with lazy reranker initialization for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->