### PR TITLE
feat(cli): cartog --version prints build SHA + features

### DIFF
--- a/crates/cartog/build.rs
+++ b/crates/cartog/build.rs
@@ -38,7 +38,23 @@ fn main() {
     };
     println!("cargo:rustc-env=CARTOG_BUILD_FEATURES={features_str}");
 
-    // Re-run when git HEAD moves or a new commit is made.
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/refs");
+    // Re-run when git HEAD moves. Resolve the path via git itself so we
+    // handle git worktrees (where .git is a file, not a dir) and
+    // unusual layouts correctly. When git isn't available (e.g.
+    // `cargo install` from crates.io with no .git/), fall back to a
+    // rerun-if-env-changed so cargo can still cache deterministically.
+    let head_path = Command::new("git")
+        .args(["rev-parse", "--git-path", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    match head_path {
+        Some(p) => println!("cargo:rerun-if-changed={p}"),
+        // Keep the build script deterministic when we're not in a git
+        // checkout: let the user force a rebuild via CARTOG_BUILD_SHA.
+        None => println!("cargo:rerun-if-env-changed=CARTOG_BUILD_SHA"),
+    }
 }

--- a/crates/cartog/build.rs
+++ b/crates/cartog/build.rs
@@ -1,0 +1,44 @@
+//! Build script: emit compile-time env vars used by `cartog --version --verbose`.
+//!
+//! - `CARTOG_BUILD_SHA`: short git SHA, or "unknown" outside a git checkout.
+//! - `CARTOG_BUILD_FEATURES`: comma-separated list of enabled Cargo features,
+//!   or "none" when the crate is built with no extras.
+
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short=10", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=CARTOG_BUILD_SHA={sha}");
+
+    // Cargo sets CARGO_FEATURE_<UPPERCASE_NAME>=1 for each enabled feature.
+    // Collect them into a sorted, comma-joined string.
+    let mut features: Vec<String> = env::vars()
+        .filter_map(|(k, _)| {
+            k.strip_prefix("CARGO_FEATURE_").map(|rest| {
+                // Cargo uppercases and replaces `-` with `_`; restore the
+                // canonical form used in Cargo.toml.
+                rest.to_ascii_lowercase().replace('_', "-")
+            })
+        })
+        .collect();
+    features.sort();
+    let features_str = if features.is_empty() {
+        "none".to_string()
+    } else {
+        features.join(", ")
+    };
+    println!("cargo:rustc-env=CARTOG_BUILD_FEATURES={features_str}");
+
+    // Re-run when git HEAD moves or a new commit is made.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs");
+}

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -4,10 +4,24 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use cartog_core::{EdgeKind, SymbolKind};
 
+/// Extended version string printed by `cartog --version` (long form).
+/// Short form (`-V`) keeps the bare semver. Populated by `build.rs`.
+pub const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    "\nbuild:    ",
+    env!("CARTOG_BUILD_SHA"),
+    "\nfeatures: ",
+    env!("CARTOG_BUILD_FEATURES"),
+    "\nrustc:    ",
+    env!("CARGO_PKG_RUST_VERSION"),
+    " (MSRV)",
+);
+
 #[derive(Debug, Parser)]
 #[command(name = "cartog")]
 #[command(about = "Map your codebase. Navigate by graph, not grep.")]
 #[command(version)]
+#[command(long_version = LONG_VERSION)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,


### PR DESCRIPTION
Follow-up from the code-review plan (C5 item): extend `cartog --version` so the first line users copy into a bug report already carries build SHA and feature set.

```
$ cartog --version
cartog 0.12.2
build:    1208a9f7b4
features: lsp, ollama-embedding
rustc:    1.77 (MSRV)
```

`-V` (short) keeps the bare `cartog 0.12.2` for scripting.

## Mechanics

- New `crates/cartog/build.rs` emits two compile-time env vars:
  - `CARTOG_BUILD_SHA` from `git rev-parse --short=10 HEAD` (or `"unknown"` when built outside a git checkout — matches `cargo install` from crates.io).
  - `CARTOG_BUILD_FEATURES` assembled from `CARGO_FEATURE_<NAME>=1` env vars Cargo sets during the build, sorted and comma-joined (or `"none"` for the default-only build).
- `LONG_VERSION` in `cli.rs` is a `concat!` of those plus `CARGO_PKG_VERSION` and `CARGO_PKG_RUST_VERSION`, wired via `#[command(long_version = LONG_VERSION)]` on the `Cli` derive.
- `rerun-if-changed=.git/HEAD` + `.git/refs` so the SHA refreshes when you commit.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check` on the non-RAG crates ✅ (sandbox can't build `ort-sys`; CI validates the `cartog` binary)
- `long_version` uses `concat!` of `env!`s, so if the build.rs ever fails to emit a var the binary won't build — it's not a silent-fallback path.

## Scope notes

Intentionally static content only. Runtime info (which LSP binaries are actually on PATH, the live SQLite version) stays in `cartog doctor`, which is the right place for environment probes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `--version` command to display extended version information including the build commit SHA, enabled features, and Rust compiler details alongside the semantic version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->