### PR TITLE
ci: trim Benchmarks job from ~7min to ~4min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,27 @@ jobs:
     runs-on: ubuntu-latest
     # Benchmarks on shared GitHub runners are noisy — never fail a PR on a
     # variance-driven regression, but surface results as an artifact so
-    # reviewers can spot outliers.
+    # reviewers can spot outliers. Tuned for ~1 min of actual measurement
+    # across the whole suite on top of the ~3 min compile:
+    # - `--sample-size 10` is criterion's minimum (default is 100).
+    # - `--warm-up-time 1 --measurement-time 1` trims each benchmark to
+    #   roughly 2 s of wall-clock. Statistical confidence intervals widen,
+    #   which is fine for catching order-of-magnitude regressions rather
+    #   than µs-level shifts.
+    # - `--noplot` skips SVG rendering; `estimates.json` still lands in
+    #   `target/criterion/` so the artifact stays useful.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run criterion benches
-        run: cargo bench --bench queries -- --warm-up-time 1 --measurement-time 3
+        run: >-
+          cargo bench --bench queries --
+          --sample-size 10
+          --warm-up-time 1
+          --measurement-time 1
+          --noplot
       - uses: actions/upload-artifact@v7
         with:
           name: criterion-report


### PR DESCRIPTION
The `Benchmarks` job added in #21 runs ~7.5 min per PR (~3 min compile + ~4.5 min measurement). For an informational regression-spotting signal on noisy shared runners, that's disproportionate to its value.

Trim criterion's args to the minimum useful shape:

- **`--sample-size 10`** (default 100) — criterion's floor. Enough to catch order-of-magnitude regressions, which is all this signal can reliably flag given runner variance.
- **`--warm-up-time 1 --measurement-time 1`** (was `--warm-up-time 1 --measurement-time 3`). Each benchmark now takes ~2 s of wall clock instead of ~4 s.
- **`--noplot`** — skip SVG rendering. `estimates.json` still lands in `target/criterion/` so the uploaded artifact remains useful for drilling into raw numbers.

Expected total measurement ≈ 1 min across the full bench suite.

## Verification

- YAML re-checked locally.
- No code changes; can't regress anything downstream.
- Benchmarks is already `continue-on-error: true`, so a pathological case where `--sample-size 10` flakes on a specific bench won't block a PR.

## Not changed

- Still runs on every PR. Spot-checking regressions on each PR is the point of the job; skipping it entirely loses that.
- No path-based skips at the workflow level. Docstring-in-code changes should still exercise Clippy/Test even though Benchmarks would be a false alarm for them — acceptable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal benchmark configuration to improve build pipeline efficiency.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->