### PR TITLE
ci(release): add x86_64-apple-darwin to the release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
             os: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
             os: macos-latest
+          # Intel Macs: `macos-latest` is Apple Silicon since GitHub moved
+          # the default runner. `macos-13` is the last Intel-hosted image
+          # and is the one to use for native x86_64 builds (no cross).
+          - target: x86_64-apple-darwin
+            os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 


### PR DESCRIPTION
Closes the only remaining actionable item from Track A of the code-review plan: the Intel Mac prebuilt binary.

`README.md:119-121` already instructs users to

```bash
curl -L .../cartog-x86_64-apple-darwin.tar.gz | tar xz
```

but the release workflow never produced that artifact — Intel Mac users had to `cargo install cartog`, which is a multi-minute build the first time because of the tree-sitter grammars + ort-sys download.

Add the target to the release matrix:

```yaml
- target: x86_64-apple-darwin
  os: macos-13
```

`macos-latest` is Apple Silicon since GitHub moved the default runner, so this pins `macos-13` — the last Intel-hosted image — and builds natively (no cross-compilation, consistent with the other matrix entries).

## Not in this PR

- Homebrew tap and Scoop bucket (also mentioned in the plan) need external repos I can't set up from here; they can be added as separate follow-ups once the prebuilt artifact exists.

## Verification

This workflow only runs on tag pushes; CI doesn't exercise it on PR. Locally, the matrix shape validates as well-formed YAML. The new step reuses the existing smoke-test / package / manpage steps unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure to provide native Intel macOS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->