### PR TITLE
docs: fix debounce default, add LSP recall caveat, add docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,13 +366,15 @@ Your code never leaves your machine.
 
 ## Documentation
 
+Full index: [docs/README.md](docs/README.md). Highlights:
+
 - **[Documentation site](https://jrollin.github.io/cartog/)** — quick start, CLI reference, configuration, MCP setup
 - [Usage](docs/usage.md) — full CLI reference and integration guides
 - [Editor integration](docs/editor-integration.md) — Neovim, VS Code, Emacs recipes
 - [Troubleshooting](docs/troubleshooting.md) — common issues and fixes
-- [Product Overview](docs/product.md)
-- [Technology Stack](docs/tech.md)
-- [Project Structure](docs/structure.md)
+- [Product Overview](docs/product.md) — vision, target users, benchmark caveats
+- [Technology Stack](docs/tech.md) — architecture and RAG design
+- [Project Structure](docs/structure.md) — workspace layout
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# cartog documentation
+
+Start here: the root [README](../README.md) for install and quick start.
+
+## Guides
+
+- [product.md](product.md) — vision, target users, positioning, benchmark caveats
+- [usage.md](usage.md) — complete CLI reference, MCP server setup, agent skill
+- [editor-integration.md](editor-integration.md) — Neovim, VS Code, Emacs, Zed recipes
+- [troubleshooting.md](troubleshooting.md) — common errors and fixes
+
+## Reference
+
+- [tech.md](tech.md) — technology stack, architecture decisions, RAG design
+- [structure.md](structure.md) — workspace layout, crate responsibilities, conventions
+
+## Specs
+
+- [spec-watch.md](spec-watch.md) — design record for the `cartog watch` feature
+
+## Assets
+
+- [demo.tape](demo.tape) — VHS script used to render `demo.gif`
+
+## See also
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — how to build, test, and contribute
+- [AGENTS.md](../AGENTS.md) — instructions for AI agents working on this repo
+- [CHANGELOG.md](../CHANGELOG.md) — release history

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -1,5 +1,7 @@
 # Editor integration
 
+> See [usage.md](usage.md) for the full CLI reference and [README — Install](../README.md#install) for installation.
+
 Two ways to wire cartog into an editor:
 
 1. **CLI shell-out** — run `cartog refs`, `cartog outline`, etc. from a keymap and show results in a quickfix / picker. Works with any editor. No MCP client required.

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,5 +1,7 @@
 # cartog — Product Overview
 
+> This document covers strategic positioning, target users, and outcomes. For installation and commands, see the [README](../README.md). For the full CLI reference, see [usage.md](usage.md).
+
 **Tagline:** Map your codebase. Navigate by graph, not grep.
 
 ## Purpose
@@ -20,6 +22,8 @@ Code is a graph of relationships (calls, imports, inherits, type references). Pr
 | **Transitive analysis** | impossible | `impact --depth 3` |
 
 Measured across 13 scenarios, 5 languages. Best gains on call chain tracing (88% token reduction) and caller lookup (95% reduction).
+
+> **Recall caveat:** The 97% figure requires cartog built with the `lsp` feature and a matching language server on `PATH` (`cargo install cartog --features lsp`). Without LSP, edge resolution falls to ~25–37% depending on language; with LSP it reaches 44–81%. See [README — Benchmark notes](../README.md#benchmark-notes) for methodology and per-language breakdown.
 
 ## Target Users
 

--- a/docs/spec-watch.md
+++ b/docs/spec-watch.md
@@ -7,13 +7,13 @@ A long-running CLI command that watches filesystem events, debounces changes, an
 ## Architecture
 
 ```
-cartog watch [path] [--debounce 2s] [--rag] [--rag-delay 30s]
+cartog watch [path] [--debounce 5s] [--rag] [--rag-delay 30s]
      |
      v
 notify crate (kqueue macOS / inotify Linux / ReadDirectoryChangesW Windows)
      |
      v
-Debounce filter (2s default) ──> code graph index (incremental, ~1-3s)
+Debounce filter (5s default) ──> code graph index (incremental, ~1-3s)
      |                                    |
      |                            symbols_needing_embeddings > 0?
      |                                    |
@@ -26,7 +26,9 @@ Debounce filter (2s default) ──> code graph index (incremental, ~1-3s)
 
 ### Key Design Decisions
 
-1. **Debounced file watcher** (not git polling): Uses `notify` crate with a configurable debounce window (default 2s). Responds to actual file saves, not periodic checks. The existing `is_ignored()` filter + `detect_language()` already handle skipping irrelevant files.
+1. **Debounced file watcher** (not git polling): Uses `notify` crate with a configurable debounce window (default 5s). Responds to actual file saves, not periodic checks. The existing `is_ignored()` filter + `detect_language()` already handle skipping irrelevant files.
+
+   > **Note:** Original spec proposed a 2s default. Raised to 5s during implementation to absorb bulk file changes (e.g. `git pull`, branch switches) without triggering re-index storms.
 
 2. **Deferred RAG embedding batch**: After each code graph re-index, if there are symbols needing embeddings (`symbols_needing_embeddings().len() > 0`), a timer starts. Resets on each new index cycle. When the timer fires (default 30s of inactivity), embeddings are generated in bulk. This amortizes the ~200ms model load and batches embedding calls.
 
@@ -40,7 +42,7 @@ Debounce filter (2s default) ──> code graph index (incremental, ~1-3s)
 When a supported source file (Python, TypeScript/JavaScript, Rust, Go, Ruby, Java) is created, modified, or deleted within the watched directory, the system shall queue a re-index after the debounce window expires.
 
 ### FR-002: Debounce Window
-While file change events are arriving within the debounce window (default 2s, configurable via `--debounce`), the system shall reset the timer and not trigger re-indexing until the window elapses without new events.
+While file change events are arriving within the debounce window (default 5s, configurable via `--debounce`), the system shall reset the timer and not trigger re-indexing until the window elapses without new events.
 
 ### FR-003: Incremental Code Graph Re-index
 When the debounce window expires, the system shall run `indexer::index_directory(db, root, false)` (incremental mode) and log the result (files indexed, skipped, removed, symbols, edges).
@@ -89,7 +91,7 @@ Arguments:
   [PATH]  Directory to watch (defaults to ".")
 
 Options:
-      --debounce <DURATION>   Debounce window for file changes [default: 2s]
+      --debounce <DURATION>   Debounce window for file changes [default: 5s]
       --rag                   Enable automatic RAG embedding after index
       --rag-delay <DURATION>  Delay before batch embedding after last index [default: 30s]
       --json                  Output events as JSON (global flag)
@@ -104,7 +106,7 @@ Then the code graph is re-indexed within debounce window + index time
 And the log shows files indexed count > 0
 
 ### AC-002: Rapid saves are debounced
-Given `cartog watch --debounce 2s` is running
+Given `cartog watch --debounce 2` is running
 When I save a file 5 times in 1 second
 Then re-indexing occurs only once (after the 2s debounce)
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -53,7 +53,7 @@
 | Async boundary | Manual `tokio::Runtime` for `serve` only | 95% of commands are sync. Avoids async overhead for index/search/refs. `spawn_blocking` offloads sync SQLite calls from the async MCP handler |
 | DB concurrency | `Arc<Mutex<Database>>` | Single connection, not a pool. MCP serves one agent session — contention is negligible. `std::sync::Mutex` (not tokio) because lock is never held across `.await` |
 | Path security | Canonical CWD validation | MCP tool parameters come from LLM agents. Rejects paths outside CWD subtree via `canonicalize` + `starts_with`. Defense-in-depth against prompt injection |
-| Watch mode | Debounced re-index + deferred RAG | 2s debounce, 30s RAG delay. Embedding only fires after editing stops — avoids embedding code that changes seconds later |
+| Watch mode | Debounced re-index + deferred RAG | 5s debounce, 30s RAG delay. Embedding only fires after editing stops — avoids embedding code that changes seconds later |
 | Vector search | sqlite-vec (opt-in) | Embedded in SQLite, no external infra. Models downloaded via `cartog rag setup` |
 | Model cache | `~/.cache/cartog/models` | XDG-compliant shared cache avoids downloading ~1.2 GB of models per project. Precedence: `FASTEMBED_CACHE_DIR` > `XDG_CACHE_HOME/cartog/models` > `~/.cache/cartog/models` |
 | Output format | Human default + `--json` flag (global) | Readable for humans, parseable for scripts. Both `cartog --json stats` and `cartog stats --json` work |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,8 @@ A living list of issues that turn up on first-run or after upgrades.
 If something here is out of date or you hit a new problem,
 [open an issue](https://github.com/jrollin/cartog/issues).
 
+> Related docs: [usage.md](usage.md) for the full CLI reference, [spec-watch.md](spec-watch.md) for `cartog watch` internals, [editor-integration.md](editor-integration.md) for editor-specific setup.
+
 ## Installation
 
 ### `cargo install cartog` is slow the first time

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,7 @@
 # cartog — Usage
 
+> For editor-specific setup (Neovim keymaps, VS Code tasks, Emacs compile-mode, Zed MCP), see [editor-integration.md](editor-integration.md). For common errors, see [troubleshooting.md](troubleshooting.md).
+
 ## Setup
 
 Requires Rust 1.77+ (`rustup update` if needed).
@@ -347,10 +349,10 @@ cartog watch                          # watch CWD, code graph only
 cartog watch src/                     # watch subdirectory
 cartog watch --rag                    # also auto-embed for semantic search
 cartog watch --rag --rag-delay 60     # embed after 60s of inactivity
-cartog watch --debounce 5             # 5s debounce window
+cartog watch --debounce 10            # 10s debounce window
 ```
 
-The watcher runs an initial incremental index on startup, then re-indexes when supported source files change. Changes are debounced (default 2s) to avoid re-indexing on every keystroke.
+The watcher runs an initial incremental index on startup, then re-indexes when supported source files change. Changes are debounced (default 5s) to avoid re-indexing on every keystroke and to absorb bulk file changes (e.g. `git pull`).
 
 When `--rag` is enabled, embedding generation is deferred until `--rag-delay` seconds (default 30) have elapsed without new file changes, batching all pending symbols in one pass.
 


### PR DESCRIPTION
## Summary

Review and tighten the `docs/` folder for accuracy and navigability.

- **Accuracy:** Correct `cartog watch` debounce default from `2s` → `5s` in `docs/spec-watch.md`, `docs/usage.md`, and `docs/tech.md`. Matches `crates/cartog/src/cli.rs:219` (`default_value = "5"`). Added a short migration note in `spec-watch.md` explaining the bump (absorb bulk file changes like `git pull` without re-index storms).
- **Accuracy:** Add LSP recall caveat to `docs/product.md`. The 97% figure requires the `lsp` feature; heuristic-only resolution is 25–37% and 44–81% with LSP (per README benchmark notes).
- **Navigation:** New `docs/README.md` index. Cross-links added at the top of `usage.md`, `editor-integration.md`, and `troubleshooting.md`. Root README's Documentation section now points at the docs index.
- **Clarity:** One-line note at the top of `product.md` delineates its role (strategic positioning) vs. the README (install/commands).
- **Verified (no change needed):** `cartog watch . --json` is a real, working flag — NDJSON events are wired through `WatchConfig.json_events` in `crates/cartog-watch/src/lib.rs`.

Files touched: 7 modified, 1 new (`docs/README.md`). +55 / −12.

## Test plan

- [ ] `grep -rn "2s" docs/` shows no remaining debounce-default references (only the migration note, the VHS `Sleep 2s`, and the AC-002 test case with `--debounce 2`).
- [ ] Render each modified doc in a markdown viewer; confirm new relative links resolve.
- [ ] From the root README only, confirm `docs/README.md` and each linked doc are reachable in one click.
- [ ] Re-read `crates/cartog/src/cli.rs` `Watch` variant to confirm debounce default remains `5`.

https://claude.ai/code/session_01PpcaZnqTpDXhfYu5KF8wqa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured documentation with improved navigation and cross-references across guides, references, and specifications.
  * Updated watch mode debounce default from 2 seconds to 5 seconds.
  * Added clarifications on recall conditions and feature requirements.
  * Enhanced troubleshooting and editor integration guidance with related documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->