### PR TITLE
docs: post-lsp-default sweep across README, docs, site, skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ See [docs/product.md](docs/product.md) for product context, [docs/tech.md](docs/
 ```bash
 cargo build              # debug build
 cargo build --release    # release build
-cargo test --workspace   # run all tests (380 tests across 9 crates)
+cargo test --workspace   # run all tests (~495 tests across 9 crates)
 cargo fmt --check        # check formatting
 cargo clippy --all-targets -- -D warnings  # lint
 ```
@@ -28,7 +28,7 @@ cargo check --features provider-ollama -p cartog-rag # verify Ollama feature
 ```bash
 make check            # all checks (Rust project + fixtures + skill)
 make check-rust       # cargo fmt + clippy + test
-make check-fixtures   # validate all 4 fixture codebases (py, go, rs, rb)
+make check-fixtures   # validate all fixture codebases (py, go, rs, rb, java)
 make check-skill      # skill tests (ensure_indexed.sh unit tests)
 make check-ts         # TypeScript fixtures (requires npx/tsc)
 make eval-skill       # LLM-as-judge skill evaluation (requires claude CLI)
@@ -58,7 +58,7 @@ crates/cartog/         (binary — CLI dispatch, config)
 ├── cartog-languages   (tree-sitter extractors, 8 languages)
 ├── cartog-indexer     (walk + extract + store, Merkle hashing)
 ├── cartog-rag         (embeddings, hybrid search, reranker)
-├── cartog-lsp         (optional LSP-based edge resolution)
+├── cartog-lsp         (LSP-based edge resolution — default feature)
 ├── cartog-watch       (debounced re-index + deferred RAG)
 └── cartog-mcp         (MCP server over stdio, 12 tools)
 ```
@@ -118,8 +118,8 @@ After implementation, mark checklist items complete — the spec stays as a desi
 
 ## Current State
 
-- **Languages**: Python, TypeScript/JavaScript, Rust, Go, Ruby, Java
-- **CLI**: 16 commands (13 top-level + 3 RAG subcommands) + MCP server (12 tools)
+- **Languages**: Python, TypeScript/JavaScript, Rust, Go, Ruby, Java, Markdown
+- **CLI**: 18 top-level commands (`index`, `search`, `outline`, `refs`, `callees`, `impact`, `hierarchy`, `deps`, `stats`, `map`, `changes`, `config`, `doctor`, `watch`, `serve`, `completions`, `manpage`, plus `rag` with 3 subcommands) + MCP server (12 tools)
 - **Indexing**: incremental (git-based + SHA-256 + Merkle-tree symbol diffing), `--force` re-index. Stable symbol IDs (`file:kind:qualified_name`) survive line movements. Scoped edge resolution for changed files only
 - **Search**: symbol search (`cartog search`), hybrid FTS5+vector RAG search with RRF merge and cross-encoder re-ranking
 - **Watch**: `cartog watch` CLI + `cartog serve --watch` background mode, debounced re-index + deferred RAG embedding
@@ -132,5 +132,5 @@ After implementation, mark checklist items complete — the spec stays as a desi
 - **Embedding format versioning**: auto-detects embedding strategy changes, triggers re-embed on next `rag index`
 - **Schema versioning**: metadata-based migration system for DB schema evolution
 - **Pluggable embedding providers**: local ONNX (default) and Ollama, configured via `.cartog.toml`
-- **Feature flags**: `provider-local` (default), `provider-ollama`
+- **Feature flags**: binary `cartog` — `lsp` (default, on), `ollama-embedding` (off). Crate `cartog-rag` — `provider-local` (default), `provider-ollama`
 - **Pending**: Java extractor improvements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,10 @@ docs(usage): add MCP Zed configuration example
 
 ## Feature flags
 
-| Flag | Description |
-|------|-------------|
-| `lsp` | Opt-in LSP-based edge resolution (requires `url` crate) |
+| Flag | Default | Description |
+|------|---------|-------------|
+| `lsp` | on | LSP-based edge resolution. Disable at build time with `--no-default-features` (runtime equivalent: `--no-lsp`) |
+| `ollama-embedding` | off | Enables Ollama as an embedding provider for RAG |
 
 ## Single maintainer
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ cartog serve --watch --rag       # with live re-indexing + semantic search
 
 Works with Claude Code, Cursor, Windsurf, Zed, OpenCode — any MCP client.
 
-### Optional LSP precision
+### LSP precision, built in
 
-Cartog auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph) and uses them to boost edge resolution from ~25% to **up to 81%**. Results persist in SQLite — pay the cost once.
+Cartog auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls) and uses them to boost edge resolution from ~25% to **up to 81%**. Enabled by default; results persist in SQLite — pay the cost once. Disable at runtime with `--no-lsp`, or omit at build time with `cargo install cartog --no-default-features`.
 
 ## Install
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -49,7 +49,7 @@ Measured across 13 scenarios, 5 languages. Best gains on call chain tracing (88%
 Pre-computed graph eliminates multi-step discovery. One `refs` call replaces grep + filter + read. Transitive analysis (`impact`) is impossible with grep.
 
 **vs language servers (LSP):**
-No startup time, no per-language server process, no config. Single binary covers 6 languages. Trade-off: ~90% name resolution accuracy vs LSP's full semantic analysis.
+No startup time, no per-language server process, no config. Single binary covers 7 code languages (plus Markdown documents). Trade-off: ~90% name resolution accuracy vs LSP's full semantic analysis.
 
 **vs alternatives (Serena MCP, codanna, Aider repo-map):**
 

--- a/docs/spec-watch.md
+++ b/docs/spec-watch.md
@@ -39,7 +39,7 @@ Debounce filter (5s default) ──> code graph index (incremental, ~1-3s)
 ## Functional Requirements
 
 ### FR-001: File Change Detection
-When a supported source file (Python, TypeScript/JavaScript, Rust, Go, Ruby, Java) is created, modified, or deleted within the watched directory, the system shall queue a re-index after the debounce window expires.
+When a supported source file (Python, TypeScript/JavaScript, Rust, Go, Ruby, Java, Markdown) is created, modified, or deleted within the watched directory, the system shall queue a re-index after the debounce window expires.
 
 ### FR-002: Debounce Window
 While file change events are arriving within the debounce window (default 5s, configurable via `--debounce`), the system shall reset the timer and not trigger re-indexing until the window elapses without new events.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -55,7 +55,7 @@ cartog/
 │   │       ├── indexer.rs   # Embed symbols, store vectors in sqlite-vec
 │   │       ├── reranker.rs  # Cross-encoder re-ranking (BGE-reranker-base)
 │   │       └── search.rs    # FTS5 + vector KNN, RRF merge, optional re-ranking
-│   ├── cartog-lsp/          # LSP-based edge resolution (optional)
+│   ├── cartog-lsp/          # LSP-based edge resolution (default feature)
 │   │   └── src/
 │   │       ├── lib.rs       # lsp_resolve_edges(), column detection
 │   │       ├── client.rs    # JSON-RPC over stdio (Content-Length framing)
@@ -112,10 +112,13 @@ cartog/
 │   └── fixtures/
 │       └── auth/            # Shared Python fixtures (referenced by cartog-indexer tests)
 └── docs/
+    ├── README.md            # Docs index
     ├── product.md           # Product overview
     ├── tech.md              # Technology decisions
     ├── structure.md         # This file
     ├── usage.md             # CLI commands + MCP server setup per client
+    ├── editor-integration.md # Neovim / VS Code / Emacs / Zed snippets
+    ├── troubleshooting.md   # Common issues
     ├── spec-watch.md        # Feature spec: file watcher (implemented)
     ├── demo.tape            # VHS terminal recording script
     └── demo.gif             # Generated demo animation
@@ -132,7 +135,7 @@ cartog-core          (tier 0 — no internal deps)
 │
 ├── cartog-indexer   (tier 2 — db + languages + core)
 ├── cartog-rag       (tier 2 — db + core)
-├── cartog-lsp       (tier 2 — db + core, optional)
+├── cartog-lsp       (tier 2 — db + core, default feature)
 │
 ├── cartog-watch     (tier 3 — db + indexer + rag + core)
 ├── cartog-mcp       (tier 3 — db + indexer + rag + watch + core)
@@ -140,7 +143,7 @@ cartog-core          (tier 0 — no internal deps)
 └── cartog           (tier 4 — binary, depends on all)
 ```
 
-The `lsp` feature propagates: `cartog` → `cartog-mcp` → `cartog-indexer` → `cartog-lsp`.
+The `lsp` feature (on by default) propagates: `cartog` → `cartog-mcp` → `cartog-indexer` → `cartog-lsp`. Build with `--no-default-features` to drop the whole branch.
 
 ## Crate Responsibilities
 
@@ -151,7 +154,7 @@ Each crate has a `README.md` with detailed technical documentation. Summary:
 - **[cartog-languages](../crates/cartog-languages/README.md)**: `Extractor` trait + 8 code language extractors (Python, TS, TSX, JS, Rust, Go, Ruby, Java) + Markdown document extractor. Code extractors use declarative tree-sitter S-expression queries via `CachedQuery`; Markdown extractor uses heading-based chunking.
 - **[cartog-indexer](../crates/cartog-indexer/README.md)**: Directory walking, 3-tier change detection (git diff → SHA-256 → force), Merkle tree hashing for surgical symbol-level updates. Optionally delegates to `cartog-lsp` for unresolved edges.
 - **[cartog-rag](../crates/cartog-rag/README.md)**: Pluggable embedding providers (local ONNX, Ollama), hybrid search (FTS5 + vector KNN → RRF merge → cross-encoder reranking), model cache management. Indexes both code symbols and Markdown documents.
-- **[cartog-lsp](../crates/cartog-lsp/README.md)**: Optional LSP-based edge resolution. Spawns language servers, sends `textDocument/definition`, maps responses to cartog symbol IDs.
+- **[cartog-lsp](../crates/cartog-lsp/README.md)**: LSP-based edge resolution (default feature). Spawns language servers, sends `textDocument/definition`, maps responses to cartog symbol IDs. Omitted when built with `--no-default-features`.
 - **[cartog-watch](../crates/cartog-watch/README.md)**: Debounced file watcher (`notify-debouncer-mini`), incremental re-index on changes, deferred RAG embedding with configurable timer. See [spec-watch.md](spec-watch.md) for design details.
 - **[cartog-mcp](../crates/cartog-mcp/README.md)**: MCP server over stdio (`rmcp`). 12 tool handlers with JSON Schema params, path validation (canonicalization), `Arc<Mutex<Database>>` for shared state.
 - **[cartog](../crates/cartog/README.md)**: Binary crate (16 CLI commands via clap) + lib.rs facade re-exporting all crates as `cartog::db`, `cartog::types`, etc. Config resolution, logging setup, tokio runtime for MCP serve.

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -9,7 +9,7 @@
 | Crate | Purpose | Notes |
 |-------|---------|-------|
 | `tree-sitter` 0.26 | Incremental parsing, CST traversal | Pinned — grammar crates lag by one minor |
-| `tree-sitter-{lang}` 0.23–0.25 | Per-language grammars (Python, TS/JS, Rust, Go, Ruby, Java) | Each ~1-2 MB of generated C |
+| `tree-sitter-{lang}` 0.23–0.25 | Per-language grammars (Python, TS/JS, Rust, Go, Ruby, Java, Markdown) | Each ~1-2 MB of generated C |
 | `rusqlite` (bundled) | SQLite storage, zero external deps | `bundled` compiles SQLite from C source — no system `libsqlite3-dev` required. Critical for cross-compilation to 5 targets |
 | `clap` (derive) | CLI argument parsing | `ValueEnum` derive for type-safe `--kind` filters with shell completion |
 | `serde` + `serde_json` | JSON serialization for `--json` output | `to_string_pretty` for readability in both terminal and agent contexts |
@@ -58,7 +58,9 @@
 | Model cache | `~/.cache/cartog/models` | XDG-compliant shared cache avoids downloading ~1.2 GB of models per project. Precedence: `FASTEMBED_CACHE_DIR` > `XDG_CACHE_HOME/cartog/models` > `~/.cache/cartog/models` |
 | Output format | Human default + `--json` flag (global) | Readable for humans, parseable for scripts. Both `cartog --json stats` and `cartog stats --json` work |
 | Distribution | `cargo install` + pre-built binaries | GitHub Releases for 5 targets (Linux x86/ARM, macOS x86/ARM, Windows), crates.io publish |
-| LSP | Auto-detected (default feature) | Index-time refinement for edges unresolved by heuristics. Auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls), sends `textDocument/definition`, shuts down after. Silently skips when no server found. Disable at runtime with `--no-lsp`; opt out at build time with `cargo install cartog --no-default-features` |
+| LSP | Auto-detected (default feature) | Index-time refinement for edges unresolved by heuristics. Auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls), sends `textDocument/definition`, shuts down after. Silently skips when no server found. Ready-timeout 20s (override via `CARTOG_LSP_READY_TIMEOUT_SECS`). Disable at runtime with `--no-lsp`; opt out at build time with `cargo install cartog --no-default-features` |
+| MCP response cap | 64 KB per tool result | Prevents oversized JSON from evicting agent context. Truncates at UTF-8 boundary with narrowing hint per tool. Override via `CARTOG_MCP_MAX_BYTES` |
+| RAG tuning | `[rag]` section in `.cartog.toml` | `retrieval_multiplier`, `retrieval_floor`, `rerank_max`, `rerank_min` control FTS5/vector candidate pool size and cross-encoder cost. See [usage.md](usage.md#configuration) |
 | Workspace | Cargo workspace (9 crates) | Incremental compilation, explicit dependency boundaries, independent crate reuse. See [structure.md](structure.md) for layout and dependency graph |
 | Monorepo | Deferred | Index from CWD, user can `cd` into subproject |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,11 +97,12 @@ document_prefix = "search_document: "
 provider = "none"
 ```
 
-**Compile-time feature flags** (for minimal binary size):
+**Compile-time feature flags**:
 
 ```bash
-cargo install cartog                                    # default: local ONNX provider
-cargo install cartog --features ollama-embedding         # + Ollama support
+cargo install cartog                                    # default: LSP + local ONNX provider
+cargo install cartog --no-default-features              # minimal: no LSP dependency
+cargo install cartog --features ollama-embedding        # + Ollama embedding provider
 ```
 
 ---
@@ -340,7 +341,7 @@ All 5 checks passed
 
 Exits with code 1 if any check is an error. Supports `--json` for structured output.
 
-### `cartog watch [path] [--debounce N] [--rag] [--rag-delay N]`
+### `cartog watch [path] [--debounce N] [--rag] [--rag-delay N] [--json]`
 
 Watch for file changes and auto-re-index. Keeps the code graph fresh during development.
 
@@ -350,11 +351,14 @@ cartog watch src/                     # watch subdirectory
 cartog watch --rag                    # also auto-embed for semantic search
 cartog watch --rag --rag-delay 60     # embed after 60s of inactivity
 cartog watch --debounce 10            # 10s debounce window
+cartog watch --json                   # NDJSON event stream on stdout
 ```
 
 The watcher runs an initial incremental index on startup, then re-indexes when supported source files change. Changes are debounced (default 5s) to avoid re-indexing on every keystroke and to absorb bulk file changes (e.g. `git pull`).
 
 When `--rag` is enabled, embedding generation is deferred until `--rag-delay` seconds (default 30) have elapsed without new file changes, batching all pending symbols in one pass.
+
+With `--json`, every lifecycle event is emitted as one NDJSON record on stdout (`started`, `reindex`, `reindex_failed`, `rag_embedded`, `rag_failed`, `shutdown`). Human-readable tracing still goes to stderr.
 
 Press Ctrl+C to stop. Pending RAG embeddings are flushed before exit.
 
@@ -369,6 +373,36 @@ cartog serve --watch --rag    # MCP server + watcher + auto RAG embedding
 ```
 
 When `--watch` is passed, a background file watcher keeps the code graph up to date as you edit. The MCP server and watcher share the same SQLite database via WAL mode (concurrent readers are safe).
+
+### `cartog config`
+
+Print the resolved configuration (merged defaults, `.cartog.toml`, and env overrides).
+
+```bash
+cartog config            # human-readable
+cartog config --json     # JSON for scripts
+```
+
+Useful for verifying `[rag]` tuning, watch debounce, and provider selection without running a full command.
+
+### `cartog completions <shell>`
+
+Generate shell completion scripts for `bash`, `zsh`, `fish`, `powershell`, or `elvish`.
+
+```bash
+cartog completions zsh   > ~/.zfunc/_cartog
+cartog completions bash  > /usr/local/etc/bash_completion.d/cartog
+cartog completions fish  > ~/.config/fish/completions/cartog.fish
+```
+
+### `cartog manpage`
+
+Emit a `roff` man page on stdout. Intended for packagers and distro maintainers.
+
+```bash
+cartog manpage > /usr/local/share/man/man1/cartog.1
+man cartog
+```
 
 ### `cartog rag setup`
 
@@ -547,8 +581,8 @@ cartog serve --watch --rag    # auto-re-index + auto-embed
 All clients need `cartog` on your `PATH` first:
 
 ```bash
-cargo install cartog            # latest version
-cargo install cartog@0.8.1      # specific version
+cargo install cartog             # latest version
+cargo install cartog@0.12.2      # specific version
 ```
 
 #### Claude Code

--- a/site/usage.html
+++ b/site/usage.html
@@ -19,7 +19,7 @@
     <ul class="nav-links">
       <li><a href="index.html#features">Features</a></li>
       <li><a href="index.html#why">Why Cartog</a></li>
-      <li><a href="index.html#why">Compare</a></li>
+      <li><a href="index.html#agents">Agents</a></li>
       <li><a href="index.html#install">Install</a></li>
       <li><a href="usage.html">Docs</a></li>
       <li>
@@ -496,7 +496,7 @@ cartog --tokens 200 outline src/db.rs</pre>
           <tr><td>JavaScript</td><td>.js, .jsx, .mjs, .cjs</td><td>functions, classes, methods, imports, variables</td><td>calls, imports, inherits, new</td></tr>
           <tr><td>Rust</td><td>.rs</td><td>functions, structs, traits, impls, imports</td><td>calls, imports, inherits, type refs</td></tr>
           <tr><td>Go</td><td>.go</td><td>functions, structs, interfaces, imports</td><td>calls, imports, type refs</td></tr>
-          <tr><td>Ruby</td><td>.rb</td><td>functions, classes, modules, imports</td><td>calls, imports, inherits, raises</td></tr>
+          <tr><td>Ruby</td><td>.rb</td><td>functions, classes, modules, imports</td><td>calls, imports, inherits, raises, rescue types</td></tr>
           <tr><td>Java</td><td>.java</td><td>classes, interfaces, enums, methods, imports</td><td>calls, imports, inherits, raises, type refs, new</td></tr>
           <tr><td>Markdown</td><td>.md</td><td>document sections (chunked by heading)</td><td>—</td></tr>
         </tbody>

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -94,7 +94,7 @@ bash "/home/user/.claude/skills/cartog/scripts/ensure_indexed.sh"
 The setup script checks for newer cartog versions (cached, at most once per 24h).
 If an update is available it prints a notice like:
 ```
-New cartog version available: 0.7.0 (installed: 0.6.1). Update with: bash "/path/to/skill/scripts/install.sh" 0.7.0
+New cartog version available: X.Y.Z (installed: A.B.C). Update with: bash "/path/to/skill/scripts/install.sh" X.Y.Z
 ```
 When you see this notice, ask the user if they want to update before continuing. If they agree, run the suggested command, then re-run `bash "/path/to/skill/scripts/ensure_indexed.sh"`.
 
@@ -308,7 +308,7 @@ cartog serve --watch            # with background file watcher
 cartog serve --watch --rag      # watcher + deferred RAG embedding
 ```
 
-When an agent calls `cartog_index` via MCP, LSP servers are started once and **kept warm** for the session. Subsequent index calls reuse warm servers (~2s instead of 60s). Background watch re-indexing stays heuristic-only.
+When an agent calls `cartog_index` via MCP, LSP servers are started once and **kept warm** for the session. Subsequent index calls reuse warm servers (~2s instead of a cold 2-15s startup). Background watch re-indexing stays heuristic-only.
 
 ## Token Budget
 
@@ -376,7 +376,7 @@ For the full 3-phase workflow (heuristic → LSP upgrade → verify), see `refer
 
 - **Default feature**: shipped by default. Installs with `--no-default-features` omit LSP entirely (equivalent to `--no-lsp` at runtime).
 - **Auto-detected**: if language servers are on PATH, they are used automatically during `cartog index`. Use `--no-lsp` to skip.
-- **Startup latency**: language servers take 15-60s to load a project on first call. Day-to-day indexing should use `--no-lsp`.
+- **Startup latency**: language servers typically reach ready in 2-15s on cold cache. The default ready-timeout is 20s — override via `CARTOG_LSP_READY_TIMEOUT_SECS` for very large projects. Day-to-day indexing should use `--no-lsp`.
 - **CLI vs MCP**: each `cartog index .` via Bash spawns and kills LSP servers (cold start). Use `cartog serve` (MCP mode) for sessions with multiple index calls — it keeps servers warm across tool calls.
 - **Supported servers**: rust-analyzer, pyright-langserver, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls. Install hints shown when servers are missing.
 - **External crate edges stay unresolved**: LSP resolves definitions within the project. Calls to std/external crates remain unresolved regardless.


### PR DESCRIPTION
## Summary

- Align all docs with the `feat(lsp): enable lsp feature by default` merge (LSP is now a default cargo feature, no longer opt-in).
- Document new CLI surface shipped since v0.12.0: `config`, `completions`, `manpage`, `watch --json`, the `[rag]` tuning section, and env vars `CARTOG_LSP_READY_TIMEOUT_SECS` / `CARTOG_MCP_MAX_BYTES`.
- Fix stale references: add Markdown to supported-language lists, refresh version pins (0.8.1 → 0.12.2), refresh test count (~495), complete the LSP server roster (ruby-lsp, solargraph, jdtls), fix site nav divergence between `index.html` and `usage.html`, fix Ruby edges row on the site.

10 files changed, +70/-30, docs-only.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] Cross-checked every claim against current CLI (`cartog --help`, `cartog watch --help`), source (`crates/cartog/src/cli.rs`, `crates/cartog/Cargo.toml`, `crates/cartog-lsp/src/manager.rs`, `crates/cartog-mcp/src/lib.rs`), and the just-merged LSP-default commit
- [x] No broken internal links (verified anchors and relative paths)
- [ ] Reviewer sanity-check on README rendering + `site/usage.html` nav parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded language support documentation to include Markdown and Java.
  * Clarified LSP as a built-in default feature (previously optional) with options to disable at build or runtime.
  * Updated feature flags documentation with new `ollama-embedding` option and default settings.
  * Enhanced CLI command coverage and added new command documentation (`config`, `completions`, `manpage`).
  * Added RAG configuration tuning details and MCP response handling specifications.
  * Refined LSP performance metrics and startup latency guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->