### PR TITLE
feat(db): move default database into .cartog/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.cartog/
 .cartog.db
 .fastembed_cache/
 .ruff_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ After implementation, mark checklist items complete — the spec stays as a desi
 ## Current State
 
 - **Languages**: Python, TypeScript/JavaScript, Rust, Go, Ruby, Java, Markdown
-- **CLI**: 19 top-level commands (`index`, `search`, `outline`, `refs`, `callees`, `impact`, `hierarchy`, `deps`, `stats`, `map`, `changes`, `config`, `doctor`, `watch`, `serve`, `completions`, `manpage`, plus `rag` with 3 subcommands and `self` with 3 subcommands) + MCP server (12 tools)
+- **CLI**: 19 top-level commands (`index`, `search`, `outline`, `refs`, `callees`, `impact`, `hierarchy`, `deps`, `stats`, `map`, `changes`, `config`, `doctor`, `watch`, `serve`, `completions`, `manpage`, plus `rag` with 3 subcommands and `self` with 4 subcommands) + MCP server (12 tools)
 - **Indexing**: incremental (git-based + SHA-256 + Merkle-tree symbol diffing), `--force` re-index. Stable symbol IDs (`file:kind:qualified_name`) survive line movements. Scoped edge resolution for changed files only
 - **Search**: symbol search (`cartog search`), hybrid FTS5+vector RAG search with RRF merge and cross-encoder re-ranking
 - **Watch**: `cartog watch` CLI + `cartog serve --watch` background mode, debounced re-index + deferred RAG embedding

--- a/README.md
+++ b/README.md
@@ -296,14 +296,14 @@ references  process  routes/auth.py:22
 ```mermaid
 graph LR
     A["Source files<br/>(py, ts, rs, go, rb, java, md)"] -->|parse| B["Symbols + Edges"]
-    B -->|write| C[".cartog.db<br/>(SQLite)"]
+    B -->|write| C[".cartog/db.sqlite<br/>(SQLite)"]
     C -->|query| D["search / refs / impact<br/>outline / callees / hierarchy"]
     C -->|embed locally| E["ONNX embeddings<br/>(sqlite-vec)"]
     E -->|query| F["rag search<br/>(FTS5 + vector KNN + reranker)"]
 ```
 
 1. **Index** — tree-sitter parses your code, extracts symbols (functions, classes, methods) and edges (calls, imports, inherits, type refs). Markdown is chunked by heading.
-2. **Store** — everything goes into a local `.cartog.db` SQLite file.
+2. **Store** — everything goes into a local `.cartog/db.sqlite` SQLite file.
 3. **Resolve (heuristic)** — links edges by name with scope-aware matching.
 4. **Resolve (LSP, optional)** — sends unresolved edges to language servers for compiler-grade precision. Results persist.
 5. **Embed (optional)** — generates vector embeddings via local ONNX or Ollama, stored in sqlite-vec.
@@ -342,8 +342,8 @@ Database path is resolved automatically — no config needed for standard use:
 
 1. `--db` flag / `CARTOG_DB` env var (highest priority)
 2. `.cartog.toml` at git root
-3. Auto git-root detection
-4. `.cartog.db` in current directory
+3. Auto git-root detection (`.cartog/db.sqlite`; legacy `.cartog.db` still read with a warning)
+4. `.cartog/db.sqlite` in current directory
 
 **`.cartog.toml`** (optional):
 

--- a/crates/cartog-db/README.md
+++ b/crates/cartog-db/README.md
@@ -49,7 +49,8 @@ rank = match_tier + kind_penalty
 | Export | Description |
 |--------|-------------|
 | `Database` | Main handle — open, query, insert, resolve |
-| `DB_FILE` | Default database filename (`.cartog.db`) |
+| `DB_DIR` / `DB_FILENAME` | Default DB location: `.cartog/db.sqlite` at the project root |
+| `LEGACY_DB_FILE` | Legacy DB filename (`.cartog.db`), kept for backwards-compat lookups |
 | `MAX_SEARCH_LIMIT` | Maximum results for search queries (100) |
 | `UnresolvedEdge` | Edge pending LSP resolution |
 | `IndexStats` | Aggregate statistics (files, symbols, edges, languages) |

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -205,12 +205,15 @@ pub const LEGACY_DB_FILE: &str = ".cartog.db";
 
 /// Run `PRAGMA wal_checkpoint(TRUNCATE)` on the SQLite file at `path`.
 /// No-op for missing files. Used before moving the DB to flush the WAL.
-pub fn checkpoint_wal(path: &std::path::Path) -> rusqlite::Result<()> {
+pub fn checkpoint_wal(path: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::Context;
     if !path.exists() {
         return Ok(());
     }
-    let conn = Connection::open(path)?;
-    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    let conn = Connection::open(path)
+        .with_context(|| format!("open {} for WAL checkpoint", path.display()))?;
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .with_context(|| format!("PRAGMA wal_checkpoint(TRUNCATE) on {}", path.display()))?;
     Ok(())
 }
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -34,6 +34,15 @@ pub enum DbError {
         source: rusqlite::Error,
     },
 
+    /// Failure preparing the on-disk layout (e.g. could not create the
+    /// `.cartog/` parent directory).
+    #[error("failed to prepare database directory {path}: {source}")]
+    PrepareDir {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     /// Could not apply one of the startup PRAGMAs (journal_mode, WAL, …).
     #[error("failed to set startup pragmas: {0}")]
     Pragma(#[source] rusqlite::Error),
@@ -183,8 +192,27 @@ fn rag_vec_schema(dim: usize) -> String {
     format!("CREATE VIRTUAL TABLE IF NOT EXISTS symbol_vec USING vec0(embedding float[{dim}])")
 }
 
-/// Default database filename, stored in the project root.
-pub const DB_FILE: &str = ".cartog.db";
+/// Default directory for cartog-generated artifacts, at the project root.
+/// Holds the SQLite database and its destructive-migration backups.
+pub const DB_DIR: &str = ".cartog";
+
+/// Default SQLite database filename, stored inside [`DB_DIR`].
+pub const DB_FILENAME: &str = "db.sqlite";
+
+/// Legacy database filename at the project root, kept for backwards-compatibility
+/// lookups. Never written to for new projects: use `DB_DIR`/`DB_FILENAME` instead.
+pub const LEGACY_DB_FILE: &str = ".cartog.db";
+
+/// Run `PRAGMA wal_checkpoint(TRUNCATE)` on the SQLite file at `path`.
+/// No-op for missing files. Used before moving the DB to flush the WAL.
+pub fn checkpoint_wal(path: &std::path::Path) -> rusqlite::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let conn = Connection::open(path)?;
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    Ok(())
+}
 
 /// Maximum number of results returned by [`Database::search`].
 /// Enforced here and referenced by CLI and MCP layers.
@@ -450,6 +478,15 @@ impl Database {
     pub fn open(path: impl AsRef<std::path::Path>, embedding_dim: usize) -> DbResult<Self> {
         register_sqlite_vec();
         let db_path = path.as_ref();
+        // SQLite::open fails on a missing parent tree, so materialize `.cartog/`.
+        if let Some(parent) = db_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|source| DbError::PrepareDir {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+        }
         let conn = Connection::open(db_path).map_err(|source| DbError::Open {
             path: db_path.to_path_buf(),
             source,
@@ -3892,13 +3929,17 @@ mod tests {
     #[test]
     fn test_db_error_open_variant_has_path() {
         // Give Database::open a path inside a non-writable location to force
-        // rusqlite::Error::SqliteFailure. The `Open` variant should preserve
-        // the path we asked it to touch.
+        // a failure. We accept either PrepareDir (mkdir failed on the parent)
+        // or Open (SQLite refused), since the failure point depends on the
+        // platform's handling of `/dev/null/…`.
         let bad_path = std::path::PathBuf::from("/dev/null/definitely/not/a/db.sqlite");
         let err = Database::open(&bad_path, DEFAULT_EMBEDDING_DIM).unwrap_err();
         match err {
             DbError::Open { path, .. } => assert_eq!(path, bad_path),
-            other => panic!("expected DbError::Open, got {other:?}"),
+            DbError::PrepareDir { path, .. } => {
+                assert_eq!(path, bad_path.parent().unwrap());
+            }
+            other => panic!("expected DbError::Open or PrepareDir, got {other:?}"),
         }
     }
 

--- a/crates/cartog/README.md
+++ b/crates/cartog/README.md
@@ -35,8 +35,8 @@ Database path is resolved with a 4-tier priority:
 
 1. `--db` CLI flag / `CARTOG_DB` environment variable
 2. `[database.path]` in `.cartog.toml` (found by walking up to git root)
-3. Auto git-root detection — `.cartog.db` next to `.git/`
-4. Fallback — `.cartog.db` in the current directory
+3. Auto git-root detection — `.cartog/db.sqlite` next to `.git/` (legacy `.cartog.db` is still read with a one-shot warning if only it exists; `cartog self migrate-db` moves it)
+4. Fallback — `.cartog/db.sqlite` in the current directory
 
 `.cartog.toml` also configures RAG providers via `[embedding]` (provider, model, dimension) and `[reranker]` (provider) sections. See `crates/cartog-rag/README.md` for details.
 

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -313,4 +313,17 @@ pub enum SelfCommand {
 
     /// Restore the previous binary saved at `<bin>.old`
     Rollback,
+
+    /// Move a legacy `.cartog.db` (+ WAL/SHM/backups) into `.cartog/db.sqlite`
+    ///
+    /// Detects the project root via the same rules as the rest of cartog
+    /// (walk up to the git root, or use cwd). Refuses to run while another
+    /// cartog process holds the peer lock, and never overwrites files at
+    /// the destination.
+    #[command(name = "migrate-db")]
+    MigrateDb {
+        /// Print the planned moves without touching the filesystem.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1417,7 +1417,7 @@ pub fn cmd_watch(
 }
 
 mod self_cmd;
-pub use self_cmd::{cmd_self_rollback, cmd_self_update, cmd_self_version};
+pub use self_cmd::{cmd_self_migrate_db, cmd_self_rollback, cmd_self_update, cmd_self_version};
 
 #[cfg(test)]
 mod tests {

--- a/crates/cartog/src/commands/self_cmd.rs
+++ b/crates/cartog/src/commands/self_cmd.rs
@@ -846,6 +846,15 @@ pub(crate) fn plan_migration(root: &Path) -> Result<Vec<PlannedMove>> {
         if to.exists() {
             anyhow::bail!("refusing to migrate: {} already exists", to.display());
         }
+        // Same symlink guard as legacy_db above: fs::rename moves the link, not the target.
+        let meta = std::fs::symlink_metadata(&from)
+            .map_err(|e| anyhow::anyhow!("stat {}: {e}", from.display()))?;
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "refusing to migrate {}: it is a symlink. Resolve or update it manually.",
+                from.display()
+            );
+        }
         moves.push(PlannedMove { from, to });
         Ok(())
     };
@@ -879,13 +888,24 @@ pub(crate) fn plan_migration(root: &Path) -> Result<Vec<PlannedMove>> {
     Ok(moves)
 }
 
-/// Test seam: when set, skips the peer-lock check.
+/// Test seam: when set, skips the peer-lock check. Only honored in `cfg(test)` builds.
+#[cfg(test)]
 const TEST_SKIP_PEER_LOCK_ENV: &str = "CARTOG_TEST_SKIP_PEER_LOCK";
+
+#[cfg(test)]
+fn peer_lock_check_skipped() -> bool {
+    std::env::var_os(TEST_SKIP_PEER_LOCK_ENV).is_some()
+}
+
+#[cfg(not(test))]
+fn peer_lock_check_skipped() -> bool {
+    false
+}
 
 /// `cartog self migrate-db [--dry-run]`. Moves legacy DB files into `.cartog/`.
 /// Refuses to run while another cartog peer holds the lock.
 pub fn cmd_self_migrate_db(root: &Path, dry_run: bool, json: bool) -> Result<()> {
-    if std::env::var_os(TEST_SKIP_PEER_LOCK_ENV).is_none() {
+    if !peer_lock_check_skipped() {
         if let Some(dir) = state::default_state_dir() {
             let active = cartog_process_lock::find_active_locks(&dir);
             if let Some(peer) = active.first() {
@@ -910,8 +930,15 @@ pub fn cmd_self_migrate_db(root: &Path, dry_run: bool, json: bool) -> Result<()>
     }
 
     // Checkpointing closes the WAL/SHM siblings, so re-plan afterwards.
+    // Non-fatal: the post-rename sweep picks up any siblings left behind.
     let legacy_db = root.join(cartog_db::LEGACY_DB_FILE);
-    let _ = cartog_db::checkpoint_wal(&legacy_db);
+    if let Err(e) = cartog_db::checkpoint_wal(&legacy_db) {
+        tracing::warn!(
+            path = %legacy_db.display(),
+            error = %e,
+            "WAL checkpoint failed before migrate-db; proceeding anyway",
+        );
+    }
     let moves = plan_migration(root)?;
 
     let new_dir = root.join(cartog_db::DB_DIR);
@@ -935,6 +962,14 @@ pub fn cmd_self_migrate_db(root: &Path, dry_run: bool, json: bool) -> Result<()>
     for suffix in ["-wal", "-shm"] {
         let from = root.join(format!("{}{suffix}", cartog_db::LEGACY_DB_FILE));
         if from.exists() {
+            let meta = std::fs::symlink_metadata(&from)
+                .map_err(|e| anyhow::anyhow!("stat {}: {e}", from.display()))?;
+            if meta.file_type().is_symlink() {
+                anyhow::bail!(
+                    "refusing to migrate {}: it is a symlink. Resolve or update it manually.",
+                    from.display()
+                );
+            }
             let to = new_dir.join(format!("{}{suffix}", cartog_db::DB_FILENAME));
             if !to.exists() {
                 std::fs::rename(&from, &to).map_err(|e| {

--- a/crates/cartog/src/commands/self_cmd.rs
+++ b/crates/cartog/src/commands/self_cmd.rs
@@ -812,6 +812,205 @@ fn smoke_test(bin: &Path) -> Result<()> {
     }
 }
 
+// ── migrate-db ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PlannedMove {
+    pub from: PathBuf,
+    pub to: PathBuf,
+}
+
+/// Plan the moves needed to migrate `.cartog.db` (+ -wal, -shm, .pre-v*.bak)
+/// at `root` into `.cartog/`. Empty vec when nothing to migrate. Errors when
+/// any destination already exists: we never overwrite.
+pub(crate) fn plan_migration(root: &Path) -> Result<Vec<PlannedMove>> {
+    let legacy_db = root.join(cartog_db::LEGACY_DB_FILE);
+    if !legacy_db.exists() {
+        return Ok(Vec::new());
+    }
+    // fs::rename moves the link, not the target. Symlinks usually point to a
+    // shared / network DB the user wants to keep where it is.
+    let meta = std::fs::symlink_metadata(&legacy_db)
+        .map_err(|e| anyhow::anyhow!("stat {}: {e}", legacy_db.display()))?;
+    if meta.file_type().is_symlink() {
+        anyhow::bail!(
+            "refusing to migrate {}: it is a symlink. Resolve or update it manually.",
+            legacy_db.display()
+        );
+    }
+    let new_dir = root.join(cartog_db::DB_DIR);
+    let new_db = new_dir.join(cartog_db::DB_FILENAME);
+
+    let mut moves = Vec::new();
+    let mut push_move = |from: PathBuf, to: PathBuf| -> Result<()> {
+        if to.exists() {
+            anyhow::bail!("refusing to migrate: {} already exists", to.display());
+        }
+        moves.push(PlannedMove { from, to });
+        Ok(())
+    };
+
+    push_move(legacy_db.clone(), new_db.clone())?;
+
+    for suffix in ["-wal", "-shm"] {
+        let from = root.join(format!("{}{suffix}", cartog_db::LEGACY_DB_FILE));
+        if from.exists() {
+            let to = new_dir.join(format!("{}{suffix}", cartog_db::DB_FILENAME));
+            push_move(from, to)?;
+        }
+    }
+
+    let entries = std::fs::read_dir(root)
+        .map_err(|e| anyhow::anyhow!("read_dir({}): {e}", root.display()))?;
+    let prefix = format!("{}.pre-v", cartog_db::LEGACY_DB_FILE);
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        let Some(suffix) = name_str.strip_prefix(&prefix) else {
+            continue;
+        };
+        let from = entry.path();
+        let to = new_dir.join(format!("{}.pre-v{suffix}", cartog_db::DB_FILENAME));
+        push_move(from, to)?;
+    }
+
+    Ok(moves)
+}
+
+/// Test seam: when set, skips the peer-lock check.
+const TEST_SKIP_PEER_LOCK_ENV: &str = "CARTOG_TEST_SKIP_PEER_LOCK";
+
+/// `cartog self migrate-db [--dry-run]`. Moves legacy DB files into `.cartog/`.
+/// Refuses to run while another cartog peer holds the lock.
+pub fn cmd_self_migrate_db(root: &Path, dry_run: bool, json: bool) -> Result<()> {
+    if std::env::var_os(TEST_SKIP_PEER_LOCK_ENV).is_none() {
+        if let Some(dir) = state::default_state_dir() {
+            let active = cartog_process_lock::find_active_locks(&dir);
+            if let Some(peer) = active.first() {
+                anyhow::bail!(
+                    "another cartog process is running ({slot}, PID {pid}); stop it before migrating",
+                    slot = peer.slot,
+                    pid = peer.pid,
+                );
+            }
+        }
+    }
+
+    let preview = plan_migration(root)?;
+    if preview.is_empty() {
+        emit_migrate_result(root, &preview, false, json, "nothing-to-do");
+        return Ok(());
+    }
+
+    if dry_run {
+        emit_migrate_result(root, &preview, false, json, "dry-run");
+        return Ok(());
+    }
+
+    // Checkpointing closes the WAL/SHM siblings, so re-plan afterwards.
+    let legacy_db = root.join(cartog_db::LEGACY_DB_FILE);
+    let _ = cartog_db::checkpoint_wal(&legacy_db);
+    let moves = plan_migration(root)?;
+
+    let new_dir = root.join(cartog_db::DB_DIR);
+    std::fs::create_dir_all(&new_dir)
+        .map_err(|e| anyhow::anyhow!("create_dir_all({}): {e}", new_dir.display()))?;
+
+    for mv in &moves {
+        std::fs::rename(&mv.from, &mv.to).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to move {} → {}: {e}",
+                mv.from.display(),
+                mv.to.display(),
+            )
+        })?;
+    }
+
+    // Sweep again: another SQLite reader may have re-created -wal/-shm
+    // between the checkpoint and the renames. Move them too so the new
+    // layout has the full set and the legacy path is empty.
+    let mut extra_moves = Vec::new();
+    for suffix in ["-wal", "-shm"] {
+        let from = root.join(format!("{}{suffix}", cartog_db::LEGACY_DB_FILE));
+        if from.exists() {
+            let to = new_dir.join(format!("{}{suffix}", cartog_db::DB_FILENAME));
+            if !to.exists() {
+                std::fs::rename(&from, &to).map_err(|e| {
+                    anyhow::anyhow!(
+                        "post-move sweep failed to move {} → {}: {e}",
+                        from.display(),
+                        to.display(),
+                    )
+                })?;
+                extra_moves.push(PlannedMove { from, to });
+            }
+        }
+    }
+    let mut all_moves = moves;
+    all_moves.extend(extra_moves);
+
+    emit_migrate_result(root, &all_moves, true, json, "migrated");
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct MigrateOutcome<'a> {
+    status: &'a str,
+    root: String,
+    performed: bool,
+    moves: Vec<MigrateMove>,
+}
+
+#[derive(Debug, Serialize)]
+struct MigrateMove {
+    from: String,
+    to: String,
+}
+
+fn emit_migrate_result(
+    root: &Path,
+    moves: &[PlannedMove],
+    performed: bool,
+    json: bool,
+    status: &str,
+) {
+    if json {
+        let outcome = MigrateOutcome {
+            status,
+            root: root.display().to_string(),
+            performed,
+            moves: moves
+                .iter()
+                .map(|m| MigrateMove {
+                    from: m.from.display().to_string(),
+                    to: m.to.display().to_string(),
+                })
+                .collect(),
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&outcome).expect("MigrateOutcome serialises")
+        );
+        return;
+    }
+    if moves.is_empty() {
+        println!(
+            "cartog: no legacy database found at {} — nothing to migrate.",
+            root.display()
+        );
+        return;
+    }
+    let verb = if performed { "Moved" } else { "Would move" };
+    for m in moves {
+        println!("{verb}: {} → {}", m.from.display(), m.to.display());
+    }
+    if !performed {
+        println!("(dry run — pass without --dry-run to apply)");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1277,5 +1476,115 @@ deadbeef *cartog-x86_64-unknown-linux-gnu.tar.gz
             Path::new("/home/u/.cargo-tools/bin/cartog"),
             None,
         ));
+    }
+
+    // ── migrate-db ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn plan_migration_no_legacy_returns_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let moves = plan_migration(dir.path()).expect("plan succeeds");
+        assert!(moves.is_empty());
+    }
+
+    #[test]
+    fn plan_migration_moves_db_and_wal_siblings() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join(".cartog.db"), b"db").unwrap();
+        std::fs::write(dir.path().join(".cartog.db-wal"), b"wal").unwrap();
+        std::fs::write(dir.path().join(".cartog.db-shm"), b"shm").unwrap();
+        std::fs::write(
+            dir.path().join(".cartog.db.pre-v3-20260101T000000Z.bak"),
+            b"bak",
+        )
+        .unwrap();
+
+        let moves = plan_migration(dir.path()).expect("plan succeeds");
+        let names: std::collections::BTreeSet<_> = moves
+            .iter()
+            .map(|m| m.to.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        let expected: std::collections::BTreeSet<_> = [
+            "db.sqlite".to_string(),
+            "db.sqlite-wal".to_string(),
+            "db.sqlite-shm".to_string(),
+            "db.sqlite.pre-v3-20260101T000000Z.bak".to_string(),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(names, expected);
+        for m in &moves {
+            assert_eq!(m.to.parent().unwrap(), dir.path().join(".cartog"));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plan_migration_refuses_symlinks() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::TempDir::new().unwrap();
+        let real_target = dir.path().join("real.db");
+        std::fs::write(&real_target, b"real").unwrap();
+        symlink(&real_target, dir.path().join(".cartog.db")).unwrap();
+
+        let err = plan_migration(dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink refusal, got: {err}"
+        );
+    }
+
+    #[test]
+    fn plan_migration_refuses_when_destination_exists() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join(".cartog.db"), b"db").unwrap();
+        std::fs::create_dir_all(dir.path().join(".cartog")).unwrap();
+        std::fs::write(dir.path().join(".cartog").join("db.sqlite"), b"existing").unwrap();
+
+        let err = plan_migration(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cmd_self_migrate_db_dry_run_does_not_move() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let legacy = dir.path().join(".cartog.db");
+        std::fs::write(&legacy, b"db").unwrap();
+
+        // Safety: tests using process env vars are serialised via #[serial].
+        unsafe { std::env::set_var(TEST_SKIP_PEER_LOCK_ENV, "1") };
+        let result = cmd_self_migrate_db(dir.path(), true, true);
+        unsafe { std::env::remove_var(TEST_SKIP_PEER_LOCK_ENV) };
+        result.expect("dry run succeeds");
+
+        assert!(legacy.exists(), "dry run must not touch the filesystem");
+        assert!(!dir.path().join(".cartog").exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cmd_self_migrate_db_moves_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let legacy = dir.path().join(".cartog.db");
+
+        // Create a real SQLite database so the WAL checkpoint can run without
+        // tripping on a malformed file. The DB content itself is irrelevant.
+        {
+            let db = cartog_db::Database::open(&legacy, 384).unwrap();
+            drop(db);
+        }
+        assert!(legacy.exists());
+
+        unsafe { std::env::set_var(TEST_SKIP_PEER_LOCK_ENV, "1") };
+        let result = cmd_self_migrate_db(dir.path(), false, true);
+        unsafe { std::env::remove_var(TEST_SKIP_PEER_LOCK_ENV) };
+        result.expect("migrate succeeds");
+
+        assert!(!legacy.exists());
+        let new_db = dir.path().join(".cartog").join("db.sqlite");
+        assert!(new_db.exists(), "main db moved into .cartog/");
+        // The migrated DB still opens cleanly.
+        let _ = cartog_db::Database::open(&new_db, 384).expect("migrated db opens");
     }
 }

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -4,10 +4,11 @@ use std::path::{Path, PathBuf};
 /// Top-level cartog configuration, loaded from `.cartog.toml`.
 ///
 /// Priority (highest to lowest):
-/// 1. `--db` CLI flag / `CARTOG_DB` env var  (handled in main)
-/// 2. `.cartog.toml` at git root or cwd      (`database.path`)
-/// 3. Auto git-root detection                (no config needed)
-/// 4. cwd fallback
+/// 1. `--db` CLI flag / `CARTOG_DB` env var       (handled in main)
+/// 2. `.cartog.toml` at git root or cwd           (`database.path`)
+/// 3. Auto git-root detection: prefer `.cartog/db.sqlite`,
+///    fall back to legacy `.cartog.db` if only it exists
+/// 4. cwd fallback to `.cartog/db.sqlite`
 #[derive(Debug, Default, Deserialize)]
 pub struct CartogConfig {
     pub database: Option<DatabaseConfig>,
@@ -218,8 +219,10 @@ fn read_config(path: &Path) -> Option<CartogConfig> {
 ///
 /// 1. `explicit` — from `--db` flag or `CARTOG_DB` env var (already merged by clap)
 /// 2. `config.database.path` — from `.cartog.toml` at git root / cwd
-/// 3. Auto git-root detection — walk up from cwd to `.git`, place DB there
-/// 4. cwd fallback — `.cartog.db` in the current directory
+/// 3. Auto git-root detection: prefer `<root>/.cartog/db.sqlite`, fall back to
+///    legacy `<root>/.cartog.db` if only it exists (warns once, points at
+///    `cartog self migrate-db`)
+/// 4. cwd fallback — `.cartog/db.sqlite` in the current directory
 pub fn resolve_db_path(explicit: Option<PathBuf>, config: &CartogConfig) -> PathBuf {
     // 1. Explicit override (--db / CARTOG_DB)
     if let Some(p) = explicit {
@@ -235,7 +238,7 @@ pub fn resolve_db_path(explicit: Option<PathBuf>, config: &CartogConfig) -> Path
     if let Ok(mut dir) = std::env::current_dir() {
         loop {
             if dir.join(".git").exists() {
-                return dir.join(cartog_db::DB_FILE);
+                return resolve_root_db_path(&dir);
             }
             if !dir.pop() {
                 break;
@@ -243,8 +246,50 @@ pub fn resolve_db_path(explicit: Option<PathBuf>, config: &CartogConfig) -> Path
         }
     }
 
-    // 4. Fallback: DB_FILE relative to cwd
-    PathBuf::from(cartog_db::DB_FILE)
+    // 4. Fallback relative to cwd
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    resolve_root_db_path(&cwd)
+}
+
+/// Prefer `.cartog/db.sqlite`; fall back to legacy `.cartog.db` with a warning.
+fn resolve_root_db_path(root: &Path) -> PathBuf {
+    let new_path = root.join(cartog_db::DB_DIR).join(cartog_db::DB_FILENAME);
+    let legacy = root.join(cartog_db::LEGACY_DB_FILE);
+    if new_path.exists() {
+        if legacy.exists() {
+            warn_orphan_legacy_once(&legacy);
+        }
+        return new_path;
+    }
+    if legacy.exists() {
+        warn_legacy_db_once(&legacy);
+        return legacy;
+    }
+    new_path
+}
+
+fn warn_legacy_db_once(path: &Path) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    tracing::warn!(
+        path = %path.display(),
+        "using legacy database location; run `cartog self migrate-db` to move it into .cartog/"
+    );
+}
+
+fn warn_orphan_legacy_once(path: &Path) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    tracing::warn!(
+        path = %path.display(),
+        "found legacy database alongside the new layout; the legacy file is being ignored"
+    );
 }
 
 /// Expand a leading `~/` to the user's home directory.
@@ -342,13 +387,19 @@ mod tests {
     #[serial]
     fn test_resolve_fallback_when_no_config_and_no_git() {
         let dir = tempfile::TempDir::new().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
         let original = std::env::current_dir().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();
 
         let result = resolve_db_path(None, &CartogConfig::default());
         std::env::set_current_dir(original).unwrap();
 
-        assert_eq!(result, PathBuf::from(cartog_db::DB_FILE));
+        assert_eq!(
+            result,
+            canonical
+                .join(cartog_db::DB_DIR)
+                .join(cartog_db::DB_FILENAME)
+        );
     }
 
     #[test]
@@ -367,7 +418,59 @@ mod tests {
         let result = resolve_db_path(None, &CartogConfig::default());
         std::env::set_current_dir(original).unwrap();
 
-        assert_eq!(result, canonical_root.join(cartog_db::DB_FILE));
+        assert_eq!(
+            result,
+            canonical_root
+                .join(cartog_db::DB_DIR)
+                .join(cartog_db::DB_FILENAME)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_prefers_new_layout_over_legacy() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let canonical_root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        // Both files exist — new layout wins.
+        std::fs::create_dir(dir.path().join(cartog_db::DB_DIR)).unwrap();
+        std::fs::write(
+            dir.path()
+                .join(cartog_db::DB_DIR)
+                .join(cartog_db::DB_FILENAME),
+            b"",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(cartog_db::LEGACY_DB_FILE), b"").unwrap();
+
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = resolve_db_path(None, &CartogConfig::default());
+        std::env::set_current_dir(original).unwrap();
+
+        assert_eq!(
+            result,
+            canonical_root
+                .join(cartog_db::DB_DIR)
+                .join(cartog_db::DB_FILENAME)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_falls_back_to_legacy_db_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let canonical_root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        // Only legacy file exists — picks it up (and warns once).
+        std::fs::write(dir.path().join(cartog_db::LEGACY_DB_FILE), b"").unwrap();
+
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = resolve_db_path(None, &CartogConfig::default());
+        std::env::set_current_dir(original).unwrap();
+
+        assert_eq!(result, canonical_root.join(cartog_db::LEGACY_DB_FILE));
     }
 
     // ── Embedding config tests ──

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -27,6 +27,23 @@ fn classify_command(cmd: &Command) -> CommandKind {
     }
 }
 
+/// Walk up from cwd to a `.git` directory; fall back to cwd. Used by
+/// `migrate-db` when the resolved DB path is outside the project.
+fn project_root_from_cwd() -> std::path::PathBuf {
+    use std::path::PathBuf;
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut dir = cwd.clone();
+    loop {
+        if dir.join(".git").exists() {
+            return dir;
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    cwd
+}
+
 fn run_auto_check_epilogue(command_kind: CommandKind) {
     let api_url = std::env::var("CARTOG_GITHUB_API_URL")
         .unwrap_or_else(|_| DEFAULT_GITHUB_LATEST_URL.to_string());
@@ -222,17 +239,25 @@ fn main() -> Result<()> {
             SelfCommand::Version => commands::cmd_self_version(cli.json),
             SelfCommand::Rollback => commands::cmd_self_rollback(),
             SelfCommand::MigrateDb { dry_run } => {
-                let resolved = config::resolve_db_path(cli.db.clone(), &cartog_config);
-                let parent = resolved
-                    .parent()
-                    .map(Path::to_path_buf)
-                    .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
-                // If resolved is inside `.cartog/`, climb one level to the project root.
-                let root = if parent.file_name().and_then(|n| n.to_str()) == Some(cartog_db::DB_DIR)
-                {
-                    parent.parent().map(Path::to_path_buf).unwrap_or(parent)
+                // Explicit --db/CARTOG_DB/[database].path can point outside the project;
+                // anchor at the project root in that case, not at the DB parent.
+                let explicit_override = cli.db.is_some()
+                    || cartog_config
+                        .database
+                        .as_ref()
+                        .is_some_and(|d| d.path.is_some());
+                let root = if explicit_override {
+                    project_root_from_cwd()
                 } else {
-                    parent
+                    let parent = db_path
+                        .parent()
+                        .map(Path::to_path_buf)
+                        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+                    if parent.file_name().and_then(|n| n.to_str()) == Some(cartog_db::DB_DIR) {
+                        parent.parent().map(Path::to_path_buf).unwrap_or(parent)
+                    } else {
+                        parent
+                    }
                 };
                 commands::cmd_self_migrate_db(&root, dry_run, cli.json)
             }

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use cartog_mcp as mcp;
 use clap::Parser;
 use std::io::IsTerminal;
+use std::path::Path;
 use std::time::SystemTime;
 
 use cli::{Cli, Command, RagCommand, SelfCommand};
@@ -220,6 +221,21 @@ fn main() -> Result<()> {
             }
             SelfCommand::Version => commands::cmd_self_version(cli.json),
             SelfCommand::Rollback => commands::cmd_self_rollback(),
+            SelfCommand::MigrateDb { dry_run } => {
+                let resolved = config::resolve_db_path(cli.db.clone(), &cartog_config);
+                let parent = resolved
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+                // If resolved is inside `.cartog/`, climb one level to the project root.
+                let root = if parent.file_name().and_then(|n| n.to_str()) == Some(cartog_db::DB_DIR)
+                {
+                    parent.parent().map(Path::to_path_buf).unwrap_or(parent)
+                } else {
+                    parent
+                };
+                commands::cmd_self_migrate_db(&root, dry_run, cli.json)
+            }
         },
     };
 

--- a/docs/spec-watch.md
+++ b/docs/spec-watch.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A long-running CLI command that watches filesystem events, debounces changes, and automatically re-indexes the code graph + RAG embeddings. Keeps the `.cartog.db` fresh without manual `cartog index` / `cartog rag index` cycles, especially useful during active development before commits.
+A long-running CLI command that watches filesystem events, debounces changes, and automatically re-indexes the code graph + RAG embeddings. Keeps `.cartog/db.sqlite` fresh without manual `cartog index` / `cartog rag index` cycles, especially useful during active development before commits.
 
 ## Architecture
 
@@ -138,7 +138,7 @@ When I press Ctrl+C
 Then pending embeddings are flushed before exit
 
 ### AC-008: Startup initial index
-Given `.cartog.db` exists but is stale
+Given `.cartog/db.sqlite` exists but is stale
 When I run `cartog watch`
 Then an initial incremental index runs before entering watch mode
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -75,7 +75,7 @@ cartog/
 │       │   ├── cli.rs       # Clap command definitions
 │       │   ├── commands/    # Command handlers
 │       │   │   ├── mod.rs   # Top-level: outline, refs, impact, search, …
-│       │   │   └── self_cmd.rs  # `cartog self` (update/version/rollback)
+│       │   │   └── self_cmd.rs  # `cartog self` (update/version/rollback/migrate-db)
 │       │   ├── config.rs    # .cartog.toml loading, DB path resolution
 │       │   ├── auto_check.rs # Daily background update probe (predicate + spawn)
 │       │   ├── state.rs     # `state.toml` (last update check, etc.)
@@ -137,7 +137,7 @@ cartog/
     └── demo.gif             # Generated demo animation
 ```
 
-**Generated artifacts** (gitignored): `.cartog.db` (SQLite index created in project root during development), `target/` (Rust build output), `benchmarks/results/`.
+**Generated artifacts** (gitignored): `.cartog/` (project-local index directory containing `db.sqlite` and migration backups; legacy `.cartog.db` at the project root is still read for backwards-compatibility), `target/` (Rust build output), `benchmarks/results/`.
 
 ## Dependency Graph
 
@@ -172,7 +172,7 @@ Each crate has a `README.md` with detailed technical documentation. Summary:
 - **[cartog-watch](../crates/cartog-watch/README.md)**: Debounced file watcher (`notify-debouncer-mini`), incremental re-index on changes, deferred RAG embedding with configurable timer. See [spec-watch.md](spec-watch.md) for design details.
 - **[cartog-mcp](../crates/cartog-mcp/README.md)**: MCP server over stdio (`rmcp`). 12 tool handlers with JSON Schema params, path validation (canonicalization), `Arc<Mutex<Database>>` for shared state. Writes a `serve.pid` file consumed by `cartog self update`.
 - **cartog-process-lock**: Cross-platform PID-file locks (`<state_dir>/{slot}.pid`) for long-lived commands. `is_alive(pid)` via `kill(pid, 0)` on unix and `OpenProcess` on windows. Consulted by `cartog self update` so an upgrade refuses to clobber a running peer.
-- **[cartog](../crates/cartog/README.md)**: Binary crate (19 CLI commands via clap, including `cartog self` with `update`/`version`/`rollback`) + lib.rs facade re-exporting all crates as `cartog::db`, `cartog::types`, etc. Config resolution, logging setup, tokio runtime for MCP serve, daily background update probe.
+- **[cartog](../crates/cartog/README.md)**: Binary crate (19 CLI commands via clap, including `cartog self` with `update`/`version`/`rollback`/`migrate-db`) + lib.rs facade re-exporting all crates as `cartog::db`, `cartog::types`, etc. Config resolution, logging setup, tokio runtime for MCP serve, daily background update probe.
 
 ## Conventions
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -39,7 +39,7 @@
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Parser | tree-sitter (CST + query API) | Incremental, multi-language, structural. JS/TS and Python use declarative tree-sitter queries for call/throw/type-ref extraction; other languages use cursor walks. Handles 90% of what LSP provides without running a language server |
-| Storage | SQLite (single `.cartog.db`) | Zero infra, ~1 MB, persists across sessions. WAL mode enables concurrent readers (watcher + MCP server) |
+| Storage | SQLite (single `.cartog/db.sqlite`) | Zero infra, ~1 MB, persists across sessions. WAL mode enables concurrent readers (watcher + MCP server). Legacy `.cartog.db` at the project root is still read for backwards-compatibility |
 | Packaging | Skill (primary) | Changes agent workflow, not just adds a tool. Works with any LLM that has bash access |
 | MCP server | `cartog serve` (stdio) | Skill remains primary; MCP as secondary for zero-context-cost tool access. 1:1 mapping with CLI commands — same `db.*()` code paths |
 | Change detection | Layered: git diff → file SHA-256 → symbol Merkle (+ `--force`) | Each layer prunes a different unit (files, then symbols). Full design, layer diagram, hash invariants, and failure modes in [architecture/incremental-indexing.md](architecture/incremental-indexing.md) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,8 +24,14 @@ cartog resolves the database path using the following priority (highest wins):
 |----------|--------|---------|
 | 1 | `--db` flag or `CARTOG_DB` env var | `cartog --db /tmp/proj.db index .` |
 | 2 | `.cartog.toml` in the project | `[database]\npath = "..."` |
-| 3 | Auto git-root detection | DB placed at the root of the git repo |
-| 4 | Current directory fallback | `.cartog.db` in cwd |
+| 3 | Auto git-root detection | `<root>/.cartog/db.sqlite` (legacy `<root>/.cartog.db` still read if only it exists) |
+| 4 | Current directory fallback | `.cartog/db.sqlite` in cwd |
+
+> **Migrating from `.cartog.db`** — older versions of cartog stored the database
+> as `.cartog.db` at the project root. New installs default to
+> `.cartog/db.sqlite`. Existing legacy files keep working (a one-shot warning
+> is printed). Run `cartog self migrate-db` (add `--dry-run` to preview) to
+> move the database and its WAL/SHM/backup siblings into `.cartog/`.
 
 ### Project config: `.cartog.toml`
 
@@ -324,7 +330,7 @@ cartog doctor
 ```
   [+] git: git repository at /home/user/project
   [+] config: loaded from /home/user/project/.cartog.toml
-  [+] database: 42 files, 387 symbols at /home/user/project/.cartog.db
+  [+] database: 42 files, 387 symbols at /home/user/project/.cartog/db.sqlite
   [+] embedding: local model cached
   [+] reranker: local model cached
 
@@ -406,18 +412,22 @@ cartog manpage > /usr/local/share/man/man1/cartog.1
 man cartog
 ```
 
-### `cartog self <update|version|rollback>`
+### `cartog self <update|version|rollback|migrate-db>`
 
-Manage the installed cartog binary in place: upgrade, inspect, or roll back.
+Manage the installed cartog binary in place: upgrade, inspect, roll back, or migrate the on-disk DB layout.
 
 ```bash
 cartog self update             # upgrade to the latest stable
 cartog self update --check     # report whether an update exists; exit 1 if outdated
 cartog self version            # version + target + install source + last check
 cartog self rollback           # restore the previous binary saved at <bin>.old
+cartog self migrate-db         # move legacy .cartog.db (+ -wal/-shm/.bak) into .cartog/
+cartog self migrate-db --dry-run  # preview the planned moves without touching the filesystem
 ```
 
 `cartog self update` refuses to overwrite a `cargo install cartog` binary (exit 3) and points at `cargo install cartog --force` instead. See [updates.md](updates.md) for the full exit-code matrix, env vars (`CARTOG_NO_UPDATE_CHECK`, `CARTOG_UPDATE_CHECK`), platform-specific state file location, and rollback contract.
+
+`cartog self migrate-db` refuses to overwrite an existing `.cartog/db.sqlite`, refuses to run while a peer cartog process (`serve` / `watch`) holds the lock, and refuses to migrate a symlinked `.cartog.db`.
 
 ### `cartog rag setup`
 

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -125,8 +125,8 @@ The index is stored in a SQLite database. cartog resolves the path automatically
 |----------|--------|
 | 1 | `--db <path>` flag or `CARTOG_DB` env var |
 | 2 | `.cartog.toml` → `[database] path = "..."` at git root |
-| 3 | Auto git-root: DB placed at the root of the current git repository |
-| 4 | `.cartog.db` in the current directory (fallback) |
+| 3 | Auto git-root: prefers `<root>/.cartog/db.sqlite`, falls back to legacy `<root>/.cartog.db` if only it exists |
+| 4 | `.cartog/db.sqlite` in the current directory (fallback) |
 
 For most projects, no configuration is needed — running `cartog index .` from any subdirectory will place the DB at the git root automatically.
 
@@ -312,15 +312,17 @@ cartog serve --watch --rag      # watcher + deferred RAG embedding
 
 When an agent calls `cartog_index` via MCP, LSP servers are started once and **kept warm** for the session. Subsequent index calls reuse warm servers (~2s instead of a cold 2-15s startup). Background watch re-indexing stays heuristic-only.
 
-### Self (upgrade / inspect / rollback)
+### Self (upgrade / inspect / rollback / migrate)
 ```bash
 cartog self update              # upgrade in place to latest stable
 cartog self update --check      # report whether an update exists; exit 1 if outdated
 cartog self version             # version + target + install source + last check
 cartog self rollback            # restore the previous binary saved at <bin>.old
+cartog self migrate-db          # move legacy .cartog.db (+ -wal/-shm/.bak) into .cartog/
+cartog self migrate-db --dry-run  # preview the planned moves
 ```
 
-User-facing maintenance commands. If the agent observes a "new cartog version available" hint or a stale binary, it can suggest the user run `cartog self update`. `cargo install cartog` users get an exit-3 refusal pointing at `cargo install cartog --force` instead.
+User-facing maintenance commands. If the agent observes a "new cartog version available" hint or a stale binary, it can suggest the user run `cartog self update`. `cargo install cartog` users get an exit-3 refusal pointing at `cargo install cartog --force` instead. If the agent sees a one-shot deprecation warning about a legacy `.cartog.db`, suggest `cartog self migrate-db`.
 
 ## Token Budget
 

--- a/skills/cartog/scripts/ensure_indexed.sh
+++ b/skills/cartog/scripts/ensure_indexed.sh
@@ -25,12 +25,11 @@ LOCK_DIR="${CARTOG_LOCK_DIR:-/tmp/cartog-rag-index.lock}"
 # Resolve the database path using the same priority as the Rust binary:
 #   1. CARTOG_DB env var (explicit override)
 #   2. .cartog.toml database.path (local project config)
-#   3. Git root detection (walk up from cwd to find .git, place DB there)
-#   4. cwd fallback (.cartog.db in the current directory)
+#   3. Git root: prefer .cartog/db.sqlite, fall back to legacy .cartog.db
+#   4. cwd fallback (.cartog/db.sqlite, or legacy .cartog.db if present)
 if [ -n "${CARTOG_DB:-}" ]; then
     DB_FILE="$CARTOG_DB"
 else
-    # Check .cartog.toml for database.path
     TOML_DB=""
     GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || true
     for _dir in "." "$GIT_ROOT"; do
@@ -40,15 +39,19 @@ else
         }
     done
     if [ -n "$TOML_DB" ]; then
-        # Expand leading ~/
         case "$TOML_DB" in
             "~/"*) DB_FILE="${HOME}${TOML_DB#\~}" ;;
             *)     DB_FILE="$TOML_DB" ;;
         esac
-    elif [ -n "$GIT_ROOT" ]; then
-        DB_FILE="${GIT_ROOT}/.cartog.db"
     else
-        DB_FILE=".cartog.db"
+        _root="${GIT_ROOT:-.}"
+        if [ -f "${_root}/.cartog/db.sqlite" ]; then
+            DB_FILE="${_root}/.cartog/db.sqlite"
+        elif [ -f "${_root}/.cartog.db" ]; then
+            DB_FILE="${_root}/.cartog.db"
+        else
+            DB_FILE="${_root}/.cartog/db.sqlite"
+        fi
     fi
 fi
 

--- a/skills/cartog/tests/golden_examples.yaml
+++ b/skills/cartog/tests/golden_examples.yaml
@@ -241,7 +241,7 @@
 - id: setup_non_blocking
   description: Setup should not block on RAG embedding
   user_query: "Help me explore this new codebase"
-  context: "First time using cartog on this project, no .cartog.db exists"
+  context: "First time using cartog on this project, no .cartog/db.sqlite exists"
   expected:
     tool_calls:
       - "bash scripts/ensure_indexed.sh"

--- a/skills/cartog/tests/test_ensure_indexed.sh
+++ b/skills/cartog/tests/test_ensure_indexed.sh
@@ -210,7 +210,7 @@ session_log() {
 # --- tests: indexing phases (versions in sync, no install/update path) ---
 
 test_fresh_index_shows_building() {
-    echo "TEST: fresh index (no .cartog.db) shows 'Building'"
+    echo "TEST: fresh index (no db) shows 'Building'"
     setup
     create_mock_cartog "0.14.1"
     local output
@@ -221,7 +221,20 @@ test_fresh_index_shows_building() {
 }
 
 test_existing_index_shows_updating() {
-    echo "TEST: existing .cartog.db shows 'Updating'"
+    echo "TEST: existing .cartog/db.sqlite shows 'Updating'"
+    setup
+    create_mock_cartog "0.14.1"
+    mkdir -p "$TEST_DIR/workdir/.cartog"
+    touch "$TEST_DIR/workdir/.cartog/db.sqlite"
+    local output
+    output=$(run_ensure_indexed)
+    wait_for_rag_index
+    assert_contains "shows 'Updating'" "Updating cartog index..." "$output"
+    teardown
+}
+
+test_legacy_db_file_shows_updating() {
+    echo "TEST: legacy .cartog.db at root shows 'Updating'"
     setup
     create_mock_cartog "0.14.1"
     mkdir -p "$TEST_DIR/workdir"
@@ -229,7 +242,7 @@ test_existing_index_shows_updating() {
     local output
     output=$(run_ensure_indexed)
     wait_for_rag_index
-    assert_contains "shows 'Updating'" "Updating cartog index..." "$output"
+    assert_contains "shows 'Updating' for legacy" "Updating cartog index..." "$output"
     teardown
 }
 
@@ -817,7 +830,7 @@ TOML
 }
 
 test_no_toml_falls_back_to_git_root() {
-    echo "TEST: no .cartog.toml falls back to git root"
+    echo "TEST: no .cartog.toml falls back to git root .cartog/db.sqlite"
     setup
     create_mock_cartog "0.14.1"
     local workdir="$TEST_DIR/workdir"
@@ -835,7 +848,56 @@ MOCK
     local output
     output=$(run_ensure_indexed_print_db "$workdir")
 
-    assert_contains "falls back to git root" "DB_FILE=$workdir/.cartog.db" "$output"
+    assert_contains "falls back to git root" "DB_FILE=$workdir/.cartog/db.sqlite" "$output"
+    teardown
+}
+
+test_legacy_root_db_used_when_only_legacy_exists() {
+    echo "TEST: legacy .cartog.db at git root is picked up when new layout missing"
+    setup
+    create_mock_cartog "0.14.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir"
+    touch "$workdir/.cartog.db"
+
+    cat > "$TEST_DIR/bin/git" <<MOCK
+#!/usr/bin/env bash
+if [ "\$1" = "rev-parse" ] && [ "\$2" = "--show-toplevel" ]; then
+    echo "$workdir"; exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/git"
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir")
+
+    assert_contains "legacy root path" "DB_FILE=$workdir/.cartog.db" "$output"
+    teardown
+}
+
+test_new_layout_wins_over_legacy() {
+    echo "TEST: .cartog/db.sqlite wins when both layouts exist"
+    setup
+    create_mock_cartog "0.14.1"
+    local workdir="$TEST_DIR/workdir"
+    mkdir -p "$workdir/.cartog"
+    touch "$workdir/.cartog.db"
+    touch "$workdir/.cartog/db.sqlite"
+
+    cat > "$TEST_DIR/bin/git" <<MOCK
+#!/usr/bin/env bash
+if [ "\$1" = "rev-parse" ] && [ "\$2" = "--show-toplevel" ]; then
+    echo "$workdir"; exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/git"
+
+    local output
+    output=$(run_ensure_indexed_print_db "$workdir")
+
+    assert_contains "new layout wins" "DB_FILE=$workdir/.cartog/db.sqlite" "$output"
     teardown
 }
 
@@ -847,6 +909,8 @@ echo ""
 test_fresh_index_shows_building
 echo ""
 test_existing_index_shows_updating
+echo ""
+test_legacy_db_file_shows_updating
 echo ""
 test_phase_order
 echo ""
@@ -899,6 +963,10 @@ echo ""
 test_cartog_db_env_overrides_toml
 echo ""
 test_no_toml_falls_back_to_git_root
+echo ""
+test_legacy_root_db_used_when_only_legacy_exists
+echo ""
+test_new_layout_wins_over_legacy
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Purpose

Consolidate cartog's generated artifacts under a single `.cartog/` directory at the project root. The default database becomes `.cartog/db.sqlite` instead of `.cartog.db`. SQLite WAL/SHM siblings and destructive-migration backups follow.

Legacy `.cartog.db` files keep working: the resolver still picks them up with a one-shot deprecation warning, and a new `cartog self migrate-db` subcommand moves them into `.cartog/` on demand.

## What changes

- **Resolver** (`crates/cartog/src/config.rs`): `--db` / `CARTOG_DB` and `.cartog.toml [database].path` keep absolute precedence. Auto-detection now prefers `.cartog/db.sqlite`, falls back to legacy `.cartog.db` (warns once), or creates the new layout. Warns when both coexist.
- **DB layer** (`crates/cartog-db/src/lib.rs`): new `DB_DIR`, `DB_FILENAME`, `LEGACY_DB_FILE` constants. `Database::open` now `create_dir_all`s the parent directory; new `DbError::PrepareDir` variant.
- **Migration command**: `cartog self migrate-db [--dry-run]` moves legacy DB + ``-wal``, ``-shm``, ``.pre-v*.bak`` siblings into `.cartog/`. Refuses to overwrite, refuses if a peer process holds the lock, refuses on symlinks. Post-rename sweep catches WAL/SHM files reborn by concurrent SQLite readers.
- **Skill helper**: `skills/cartog/scripts/ensure_indexed.sh` mirrors the new resolution order.
- **Docs**: README, docs/usage.md, docs/tech.md, docs/structure.md, docs/spec-watch.md, crates READMEs, SKILL.md, AGENTS.md all swept.
- **.gitignore**: adds `.cartog/`, keeps legacy `.cartog.db` line.

## Benefits

- One generated entry at the project root instead of four files (db + wal + shm + occasional bak).
- Aligns with prevalent tooling convention (`.git/`, `.vscode/`, `.cargo/`, `.terraform/`).
- Future-proofing: room to add sibling artifacts without re-littering the root.
- Simpler `.gitignore` for new users.

## Impacts

- New installs default to `.cartog/db.sqlite` immediately.
- Existing projects keep working unchanged. A one-shot ``warn!`` is emitted per process; users can run `cartog self migrate-db` (or `--dry-run` to preview) at their leisure.
- Config-driven explicit paths are never silently rewritten — only auto-detection switches layout.

## Risks (and mitigations)

- **Concurrent SQLite readers during migrate-db**: the peer-lock check catches cartog ``serve``/``watch`` peers. Other SQLite readers may recreate ``-wal``/``-shm`` between checkpoint and rename. Mitigation: post-rename sweep moves any reborn siblings; ``--dry-run`` available for inspection.
- **Symlinked legacy DBs**: `fs::rename` would move the link, not the target. Mitigation: explicit refusal with a clear error.
- **User scripts that grep ``.cartog.db``**: keep working in retro-compat mode; deprecation warning surfaces the new path.
- **`.cartog.toml` with explicit `[database].path`**: untouched by the resolver and by `migrate-db`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` (631 passing)
- [x] `bash skills/cartog/tests/test_ensure_indexed.sh` (56 passing — including 3 new resolution-order cases)
- [x] New unit tests cover: resolver priority, legacy fallback, both-layouts-coexist warning, `plan_migration` happy path + symlink refusal + destination-exists refusal, `cmd_self_migrate_db` dry-run + actual move
- [ ] Manual smoke (reviewer): create a fresh project, verify `.cartog/db.sqlite` is created; downgrade to a legacy `.cartog.db`, verify the warning fires and `migrate-db` moves everything

## Deferred (documented in scout report)

- Structured exit codes for `migrate-db` (today: 0/1, like other `Result`-returning commands)
- ``cd .cartog/subdir/`` edge case: silent no-op when no git repo present; non-destructive
- ``CARTOG_TEST_SKIP_PEER_LOCK`` env var: internal test seam, not surfaced in help/docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cartog self migrate-db` command to move legacy databases to the new `.cartog/db.sqlite` location with `--dry-run` flag support.

* **Documentation**
  * Updated all documentation to reflect new database location (`.cartog/db.sqlite`) while maintaining backward compatibility with legacy `.cartog.db`.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->