### PR TITLE
docs(readme): add contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ Full index: [docs/README.md](docs/README.md). Highlights:
 - [Technology Stack](docs/tech.md) — architecture and RAG design
 - [Project Structure](docs/structure.md) — workspace layout
 
+## Contributors
+
+Thanks to everyone who has contributed to cartog.
+
+[![Contributors](https://contrib.rocks/image?repo=jrollin/cartog)](https://github.com/jrollin/cartog/graphs/contributors)
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, commit style, and how to add a new language extractor.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a Contributors section to the README using `contrib.rocks` and links to existing `CONTRIBUTING.md`.

## Why

- Surfaces contributors visually on the project landing page.
- Zero tooling: `contrib.rocks` regenerates the image on every push, no bot, no manual list to maintain.
- Image links to the GitHub contributors graph for full history.

## Diff

8 lines added to README.md, between the Documentation and License sections.

## Out of scope

- All Contributors spec / bot (adds bot + commit churn for a 3-contributor project — not worth it).
- CODE_OF_CONDUCT.md (separate concern, can land later if needed).