### PR TITLE
fix(db): add PRAGMA busy_timeout — WAL alone does not prevent SQLITE_BUSY

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repository.
+# Listed owners are auto-requested for review on matching pull requests.
+* @jrollin

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -203,6 +203,14 @@ pub const DB_FILENAME: &str = "db.sqlite";
 /// lookups. Never written to for new projects: use `DB_DIR`/`DB_FILENAME` instead.
 pub const LEGACY_DB_FILE: &str = ".cartog.db";
 
+/// Milliseconds a connection waits on a locked database before giving up.
+///
+/// WAL removes reader-vs-writer contention but not writer-vs-writer or
+/// reader-vs-checkpoint contention. Without a `busy_timeout` SQLite fails
+/// immediately with `SQLITE_BUSY`; this gives bounded retry instead. Applied
+/// to every on-disk connection.
+pub const BUSY_TIMEOUT_MS: u32 = 5000;
+
 /// Run `PRAGMA wal_checkpoint(TRUNCATE)` on the SQLite file at `path`.
 /// No-op for missing files. Used before moving the DB to flush the WAL.
 pub fn checkpoint_wal(path: &std::path::Path) -> anyhow::Result<()> {
@@ -212,8 +220,11 @@ pub fn checkpoint_wal(path: &std::path::Path) -> anyhow::Result<()> {
     }
     let conn = Connection::open(path)
         .with_context(|| format!("open {} for WAL checkpoint", path.display()))?;
-    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
-        .with_context(|| format!("PRAGMA wal_checkpoint(TRUNCATE) on {}", path.display()))?;
+    conn.execute_batch(&format!(
+        "PRAGMA busy_timeout={BUSY_TIMEOUT_MS};
+         PRAGMA wal_checkpoint(TRUNCATE);"
+    ))
+    .with_context(|| format!("PRAGMA wal_checkpoint(TRUNCATE) on {}", path.display()))?;
     Ok(())
 }
 
@@ -494,14 +505,15 @@ impl Database {
             path: db_path.to_path_buf(),
             source,
         })?;
-        conn.execute_batch(
+        conn.execute_batch(&format!(
             "PRAGMA journal_mode=WAL;
+             PRAGMA busy_timeout={BUSY_TIMEOUT_MS};
              PRAGMA foreign_keys=ON;
              PRAGMA synchronous=NORMAL;
              PRAGMA cache_size=-65536;
              PRAGMA temp_store=MEMORY;
-             PRAGMA mmap_size=268435456;",
-        )
+             PRAGMA mmap_size=268435456;"
+        ))
         .map_err(DbError::Pragma)?;
         conn.execute_batch(SCHEMA).map_err(DbError::Schema)?;
         conn.execute_batch(RAG_SCHEMA).map_err(DbError::RagSchema)?;
@@ -3914,6 +3926,61 @@ mod tests {
             backups.is_empty(),
             "fresh DB should not create a backup file"
         );
+    }
+
+    #[test]
+    fn test_busy_timeout_pragma_is_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("timeout.db");
+        let db = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        let timeout: i64 = db
+            .conn
+            .query_row("PRAGMA busy_timeout;", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(timeout, BUSY_TIMEOUT_MS as i64);
+    }
+
+    #[test]
+    fn test_busy_timeout_makes_second_writer_retry_instead_of_aborting() {
+        // Regression for #42. A second writer blocked by a held write lock
+        // should *wait* (bounded by busy_timeout) rather than abort instantly.
+        // Proven deterministically: against the same held lock, a connection
+        // with busy_timeout=0 fails immediately, one with a non-zero timeout
+        // only fails after waiting that long. No inter-thread timing race.
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("concurrent.db");
+        let _ = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        // Holder keeps an exclusive write lock for the whole test.
+        let holder = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+        holder
+            .conn
+            .execute_batch("BEGIN IMMEDIATE; INSERT INTO metadata (key, value) VALUES ('a', '1');")
+            .unwrap();
+
+        let attempt_write = |timeout_ms: u32| -> std::time::Duration {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(&format!("PRAGMA busy_timeout={timeout_ms};"))
+                .unwrap();
+            let start = std::time::Instant::now();
+            let res = conn.execute("INSERT INTO metadata (key, value) VALUES ('b', '2');", []);
+            assert!(res.is_err(), "write must fail while the lock is held");
+            start.elapsed()
+        };
+
+        // busy_timeout=0: SQLite aborts immediately, no retry.
+        assert!(
+            attempt_write(0) < std::time::Duration::from_millis(150),
+            "with busy_timeout=0 the writer must fail immediately"
+        );
+        // busy_timeout=300ms: SQLite retries for the full window before failing.
+        assert!(
+            attempt_write(300) >= std::time::Duration::from_millis(250),
+            "with a non-zero busy_timeout the writer must retry, not abort"
+        );
+
+        holder.conn.execute_batch("COMMIT;").unwrap();
     }
 
     // ── Typed error surface ──

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -162,6 +162,7 @@ The database is a regenerable index — crash-recovery safety is traded for thro
 | Pragma | Value | Rationale |
 |--------|-------|-----------|
 | `journal_mode` | WAL | Write-Ahead Logging enables concurrent readers. Watch thread and MCP server read while indexer writes |
+| `busy_timeout` | 5000 (5 s) | Bounded retry on a locked DB. WAL removes reader-vs-writer contention but not writer-vs-writer (one WAL writer at a time) or reader-vs-checkpoint contention. Without it, a connection hitting those locks fails immediately with `SQLITE_BUSY`. WAL and `busy_timeout` are both required: WAL for read concurrency, `busy_timeout` so the rarer write/checkpoint contention waits instead of aborting. Applied to every on-disk connection, including the WAL-checkpoint connection |
 | `foreign_keys` | ON | Enforce referential integrity |
 | `synchronous` | NORMAL | Reduced fsync frequency. Safe with WAL for a regenerable index — power failure loses at most the last transaction, recoverable via `cartog index --force` |
 | `cache_size` | -65536 (64 MB) | Large page cache for repeated queries in MCP sessions |


### PR DESCRIPTION
Closes #42.

## Problem

`Database::open` sets `journal_mode=WAL` but no `busy_timeout`. WAL only removes reader-vs-writer contention; it does **not** cover writer-vs-writer (one WAL writer at a time) or reader-vs-checkpoint contention. With SQLite's default `busy_timeout=0`, a connection hitting those locks fails immediately with `SQLITE_BUSY` instead of retrying — the reported hang/abort when the MCP server queries while a watcher re-indexes.

## Changes

- Add `PRAGMA busy_timeout=5000` to the `Database::open` PRAGMA batch and to the WAL-checkpoint connection, via a shared `BUSY_TIMEOUT_MS` constant in `cartog-db`.
- Regression tests:
  - `test_busy_timeout_pragma_is_set` — the PRAGMA is applied on `Database::open`.
  - `test_busy_timeout_makes_second_writer_retry_instead_of_aborting` — against a held write lock, a `busy_timeout=0` connection fails immediately while a non-zero one retries for the full window. Deterministic, no inter-thread timing race.
- `docs/tech.md` documents the PRAGMA and why WAL + `busy_timeout` are both required.

## Acceptance criteria

- [x] `busy_timeout` set on every on-disk connection (`open` + `checkpoint_wal`).
- [x] Regression test: second writer waits for the first instead of failing immediately.
- [x] `docs/tech.md` notes the PRAGMA set and the WAL/busy_timeout pairing.

## Deferred

`.cartog.toml` configurability. `cartog-db` is a storage adapter; reading config there would invert the dependency direction. If a configurable value is wanted later, the CLI/composition root should read `.cartog.toml` and pass it into `Database::open`. A constant (5000 ms) is used for now.

## Checks

`cargo fmt`, `cargo clippy --all-targets -D warnings` clean; full `cartog-db` suite 90/90; workspace builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database connection resilience during concurrent operations. When database locks are temporarily held, operations now automatically retry within a configured timeout window instead of failing immediately. This significantly improves reliability in high-concurrency scenarios.

* **Documentation**
  * Updated technical documentation to describe the new timeout behavior and how the system handles concurrent database access situations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->