### PR TITLE
build(make): generalize Docker fallback to all fixture-validation targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,17 +26,21 @@ cargo check --features provider-ollama -p cartog-rag # verify Ollama feature
 ### Integrity checks
 
 ```bash
-make check            # all checks (Rust project + fixtures + skill)
-make check-rust       # cargo fmt + clippy + test
-make check-fixtures   # validate all fixture codebases (py, go, rs, rb, java)
-make check-skill      # skill tests (ensure_indexed.sh unit tests)
-make check-ts         # TypeScript fixtures (requires npx/tsc)
-make eval-skill       # LLM-as-judge skill evaluation (requires claude CLI)
-make eval-agents      # LLM-as-judge agent evaluation (requires claude CLI)
-make bench            # shell benchmark suite (13 scenarios x 5 languages)
-make bench-criterion  # Rust criterion benchmarks (query latency)
-make bench-rag        # RAG relevancy benchmarks (in-memory + shell scenario 13)
+make check                 # all checks (Rust project + fixtures + skill)
+make check-rust            # cargo fmt + clippy + test
+make check-fixtures        # validate all fixture codebases (py, ts, go, rs, rb, java, php)
+make check-fixtures-docker # same, forcing the Docker fallback for every language
+make check-skill           # skill tests (ensure_indexed.sh unit tests)
+make eval-skill            # LLM-as-judge skill evaluation (requires claude CLI)
+make eval-agents           # LLM-as-judge agent evaluation (requires claude CLI)
+make bench                 # shell benchmark suite (13 scenarios x 5 languages)
+make bench-criterion       # Rust criterion benchmarks (query latency)
+make bench-rag             # RAG relevancy benchmarks (in-memory + shell scenario 13)
 ```
+
+Each `check-fixtures` language target uses the native toolchain when present, else
+falls back to a pinned official Docker image, else fails. `check-ts` is now part of
+`make check`.
 
 Run `make check` before committing. Run `make eval-skill` after changing skill SKILL.md or search routing. Run `make eval-agents` after changing agent definitions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,16 @@ make check        # cargo fmt + clippy + test + fixture validation + skill tests
 Individual targets:
 
 ```bash
-make check-rust       # cargo fmt --check + clippy -D warnings + cargo test
-make check-fixtures   # validate all language fixture codebases (py, go, rs, rb, java)
-make check-skill      # bash unit tests for the agent skill
+make check-rust            # cargo fmt --check + clippy -D warnings + cargo test
+make check-fixtures        # validate all language fixture codebases (py, ts, go, rs, rb, java, php)
+make check-fixtures-docker # same, forcing the Docker fallback for every language
+make check-skill           # bash unit tests for the agent skill
 ```
+
+Each `check-fixtures` language target validates with the native toolchain when
+present, else a pinned official Docker image (`check-fixtures-docker` forces this
+path). No toolchain and no Docker is a hard fail. cartog's own `cargo test` needs
+no language toolchains.
 
 ## Commit style
 
@@ -88,8 +94,8 @@ the per-language wiring is shallow and the bulk of the work is the benchmark fix
    - Add a case to the `--fixture` filter in `benchmarks/run.sh` and `benchmarks/lib/common.sh`
    - Add `run_scenario "webapp_<lang>" ...` lines in every script under `benchmarks/scenarios/`
 8. Validate: `make check-fixtures`. If your language ships a syntax checker, add a
-   `check-<lang>` target to the `Makefile` (with a Docker fallback if no host tool exists,
-   mirroring `check-php`).
+   `check-<lang>` target to the `Makefile` via the `check_lang` function (native tool,
+   pinned Docker fallback, hard fail), and add it to the `check-fixtures` prerequisites.
 9. Run `make bench` and confirm the new fixture appears in the summary with non-zero
    recall on every scenario.
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,30 @@
-.PHONY: check check-rust check-fixtures check-skill check-py check-ts check-go check-rs check-rb check-java check-php bench bench-criterion bench-rag eval-skill eval-agents
+.PHONY: check check-rust check-fixtures check-fixtures-docker check-skill check-py check-ts check-go check-rs check-rb check-java check-php bench bench-criterion bench-rag eval-skill eval-agents
 
 # --- Full integrity check ---
 
 check: check-rust check-fixtures check-skill ## Run all integrity checks
+
+# --- Fixture validation helper ---
+#
+# Validates a fixture codebase with the native toolchain when present, else
+# falls back to a pinned official Docker image, else fails hard.
+# $(1)=probe tool  $(2)=docker image  $(3)=native command  $(4)=docker command
+# The Docker branch mounts benchmarks/fixtures at /fix as the working dir;
+# $(4) addresses the language subdir from there and directs any compiler
+# output to container-internal /tmp paths so runs leave no root-owned files
+# in the working tree. Set FORCE_DOCKER=1 to skip the native probe.
+define check_lang
+	@if [ -z "$(FORCE_DOCKER)" ] && command -v $(1) > /dev/null 2>&1; then \
+		$(3); \
+	elif command -v docker > /dev/null 2>&1; then \
+		echo "    $(1) not found, using Docker ($(2))"; \
+		docker run --rm --user $$(id -u):$$(id -g) \
+			-v "$(CURDIR)/benchmarks/fixtures:/fix" -w /fix $(2) sh -c '$(4)'; \
+	else \
+		echo "    ERROR: neither $(1) nor docker available"; exit 1; \
+	fi
+	@echo "    OK"
+endef
 
 # --- Rust project checks ---
 
@@ -13,48 +35,52 @@ check-rust: ## cargo fmt + clippy + test
 
 # --- Fixture syntax/build checks ---
 
-check-fixtures: check-py check-go check-rs check-rb check-java check-php ## Validate all fixture codebases
+check-fixtures: check-py check-ts check-go check-rs check-rb check-java check-php ## Validate all fixture codebases
 
-check-py: ## Validate Python fixtures (py_compile)
+check-fixtures-docker: ## Validate all fixture codebases via Docker (reproducible)
+	@$(MAKE) check-fixtures FORCE_DOCKER=1
+
+check-py: ## Validate Python fixtures (py_compile, falls back to Docker)
 	@echo "==> Checking Python fixtures..."
-	@find benchmarks/fixtures/webapp_py -name '*.py' -exec python3 -m py_compile {} +
-	@echo "    OK"
+	$(call check_lang,python3,python:3.12-slim,\
+		find benchmarks/fixtures/webapp_py -name "*.py" -exec python3 -m py_compile {} +,\
+		find webapp_py -name "*.py" -exec python3 -m py_compile {} +)
 
-check-ts: ## Validate TypeScript fixtures (tsc --noEmit)
+check-ts: ## Validate TypeScript fixtures (tsc -p, falls back to Docker)
 	@echo "==> Checking TypeScript fixtures..."
-	@cd benchmarks/fixtures/webapp_ts && npx tsc --noEmit --strict --esModuleInterop --skipLibCheck
-	@echo "    OK"
+	$(call check_lang,npx,node:22-slim,\
+		cd benchmarks/fixtures/webapp_ts && npx --yes --package typescript@5 -- tsc -p tsconfig.json,\
+		cd webapp_ts && HOME=/tmp npm_config_cache=/tmp/npm npx --yes --package typescript@5 -- tsc -p tsconfig.json)
 
-check-go: ## Validate Go fixtures (go build)
+check-go: ## Validate Go fixtures (go build, falls back to Docker)
 	@echo "==> Checking Go fixtures..."
-	@cd benchmarks/fixtures/webapp_go && go build ./...
-	@echo "    OK"
+	$(call check_lang,go,golang:1.23,\
+		cd benchmarks/fixtures/webapp_go && go build ./...,\
+		cd webapp_go && GOCACHE=/tmp/gocache GOPATH=/tmp/gopath go build ./...)
 
-check-rs: ## Validate Rust fixtures (cargo check)
+check-rs: ## Validate Rust fixtures (cargo check, falls back to Docker)
 	@echo "==> Checking Rust fixtures..."
-	@cd benchmarks/fixtures/webapp_rs && cargo check 2>/dev/null
-	@echo "    OK"
+	$(call check_lang,cargo,rust:slim,\
+		cd benchmarks/fixtures/webapp_rs && cargo check 2>/dev/null,\
+		cd webapp_rs && CARGO_TARGET_DIR=/tmp/target CARGO_HOME=/tmp/cargo cargo check 2>/dev/null)
 
-check-rb: ## Validate Ruby fixtures (ruby -c)
+check-rb: ## Validate Ruby fixtures (ruby -c, falls back to Docker)
 	@echo "==> Checking Ruby fixtures..."
-	@find benchmarks/fixtures/webapp_rb -name '*.rb' -exec ruby -c {} + > /dev/null
-	@echo "    OK"
+	$(call check_lang,ruby,ruby:3.3-slim,\
+		find benchmarks/fixtures/webapp_rb -name "*.rb" -exec ruby -c {} + > /dev/null,\
+		find webapp_rb -name "*.rb" -exec ruby -c {} + > /dev/null)
 
-check-java: ## Validate Java fixtures (javac)
+check-java: ## Validate Java fixtures (javac, falls back to Docker)
 	@echo "==> Checking Java fixtures..."
-	@mkdir -p /tmp/cartog_java_check && cd benchmarks/fixtures/webapp_java && javac -sourcepath . $$(find . -name "*.java" | sort) -d /tmp/cartog_java_check
-	@echo "    OK"
+	$(call check_lang,javac,eclipse-temurin:21-jdk,\
+		mkdir -p /tmp/cartog_java_check && cd benchmarks/fixtures/webapp_java && javac -sourcepath . $$(find . -name "*.java" | sort) -d /tmp/cartog_java_check,\
+		cd webapp_java && javac -sourcepath . $$(find . -name "*.java" | sort) -d /tmp/out)
 
 check-php: ## Validate PHP fixtures (php -l, falls back to Docker)
 	@echo "==> Checking PHP fixtures..."
-	@if command -v php > /dev/null 2>&1; then \
-		find benchmarks/fixtures/webapp_php -name '*.php' -exec php -l {} + > /dev/null; \
-	else \
-		echo "    php not found, using Docker (php:8.3-cli)"; \
-		docker run --rm -v "$$PWD/benchmarks/fixtures/webapp_php:/app" -w /app php:8.3-cli \
-			sh -c 'for f in $$(find . -name "*.php"); do php -l "$$f" > /dev/null || exit 1; done'; \
-	fi
-	@echo "    OK"
+	$(call check_lang,php,php:8.3-cli,\
+		find benchmarks/fixtures/webapp_php -name '*.php' -exec php -l {} + > /dev/null,\
+		for f in $$(find webapp_php -name "*.php"); do php -l "$$f" > /dev/null || exit 1; done)
 
 # --- Skill tests ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,7 +16,7 @@ Compares cartog graph queries vs grep/cat approaches for common code navigation 
 | Fixture | Language | Files | LOC |
 |---------|----------|-------|-----|
 | `fixtures/webapp_py/` | Python | 69 | ~4,000 |
-| `fixtures/webapp_ts/` | TypeScript | 48 | ~2,500 |
+| `fixtures/webapp_ts/` | TypeScript | 49 | ~2,500 |
 | `fixtures/webapp_go/` | Go | 45 | ~3,300 |
 | `fixtures/webapp_rs/` | Rust | 65 | ~3,200 |
 | `fixtures/webapp_rb/` | Ruby | 51 | ~2,300 |

--- a/benchmarks/fixtures/webapp_ts/src/env.d.ts
+++ b/benchmarks/fixtures/webapp_ts/src/env.d.ts
@@ -1,0 +1,19 @@
+/** Minimal ambient declarations so the fixture type-checks without @types/node or DOM lib. */
+declare const process: {
+    env: Record<string, string | undefined>;
+};
+
+declare const console: {
+    log(...args: unknown[]): void;
+    info(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+    debug(...args: unknown[]): void;
+};
+
+declare const Buffer: {
+    from(input: string, encoding?: string): { toString(encoding?: string): string };
+};
+
+declare function setTimeout(handler: (...args: unknown[]) => void, ms: number): unknown;
+declare function clearTimeout(handle: unknown): void;

--- a/benchmarks/fixtures/webapp_ts/tsconfig.json
+++ b/benchmarks/fixtures/webapp_ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Closes #46.

## Summary

- Reusable `check_lang` Make function: native toolchain → pinned Docker image → hard fail
- All 7 fixture-validation targets (py, ts, go, rs, rb, java, php) converted onto it
- New `make check-fixtures-docker` forces the Docker branch for every language
- `check-ts` restored to `make check` (was excluded because it had no fallback, and its old invocation was silently broken anyway)

## Details

Docker runs pass `--user $(id -u):$(id -g)` and direct compiler output to container-internal `/tmp` paths so they leave no root-owned files in the working tree. Images pinned: `python:3.12-slim`, `node:22-slim`, `golang:1.23`, `rust:slim`, `ruby:3.3-slim`, `eclipse-temurin:21-jdk`, `php:8.3-cli`.

CI runners have the toolchains natively and keep hitting the fast path — Docker is purely the local-dev safety net. A Rust-only contributor pulls nothing; touching Go fixtures pulls one slim image.

### `check-ts` recovery

The previous `npx tsc --noEmit --strict ...` resolved a **deprecated stub package** named `tsc` that just printed help — the TS fixture was never actually type-checked. Restoring it to `make check` required:

- New `benchmarks/fixtures/webapp_ts/tsconfig.json` (target es2020, strict, noEmit, types: [])
- New `benchmarks/fixtures/webapp_ts/src/env.d.ts` declaring the Node/DOM globals the fixture uses (`process`, `console`, `Buffer`, `setTimeout`, `clearTimeout`) — dependency-free, no `@types/node` or `node_modules`

Bench `webapp_ts` was rerun before/after: identical token counts and 96.2% recall — the ambient declarations don't shift ground-truth matching.

## Limitations

- First Docker run per language requires network (image pull); cached afterwards
- `check-ts` Docker run re-fetches `typescript@5` each time (~10s) — acceptable for occasional local validation
- `command -v` only checks the binary exists, not that it works — a broken local JDK still picks the native branch; use `FORCE_DOCKER=1` to bypass

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --all-targets -- -D warnings` — pass
- [x] `cargo test --workspace` — 674 tests pass
- [x] `make check-fixtures` on host with native tools — all OK
- [x] `make check-fixtures-docker` — all 7 OK via Docker, tree clean (no root-owned files)
- [x] Bench `webapp_ts` (13 scenarios) — 96.2% recall, identical to baseline without new fixture files
- [ ] CI green on the PR