### PR TITLE
feat(db): persist edge resolution_state, skip unresolvable in LSP pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,8 @@ the per-language wiring is shallow and the bulk of the work is the benchmark fix
     the priority order.
 12. Bench-validate the LSP integration: install the server, run `cartog index` with and
     without `--no-lsp` on your fixture, and capture `edges_resolved` vs
-    `edges_lsp_resolved` from `--json` output. If the LSP gain is meaningful, add a row
+    `edges_lsp_resolved` (and `edges_marked_unresolvable` for the LSP's negative
+    judgments) from `--json` output. If the LSP gain is meaningful, add a row
     to the recall table in `README.md` and `site/usage.html`.
 
 ### 4. Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "cartog-db",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "url",
 ]

--- a/crates/cartog-db/README.md
+++ b/crates/cartog-db/README.md
@@ -13,7 +13,7 @@ Stores symbols, edges, files, and embeddings in a single SQLite database. Provid
 Four core tables plus four RAG-specific tables:
 
 - **`symbols`** — primary key on stable ID, indexed by `name` and `file_path`
-- **`edges`** — stores `source_id` → `target_name`, with `target_id` resolved later
+- **`edges`** — `source_id` → `target_name`, with `target_id` resolved later. A `resolution_state` column tracks lifecycle: `0=unresolved`, `1=resolved`, `2=unresolvable` (LSP definitively gave up — skipped on future passes until [`Database::reset_unresolvable_for_names`] reopens them)
 - **`files`** — tracks file hash, language, symbol count, last modified timestamp
 - **`metadata`** — key-value store (e.g., `last_commit` for git-based change detection)
 - **`symbol_content`** — raw source code per symbol (for FTS and embedding)

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -114,6 +114,9 @@ CREATE TABLE IF NOT EXISTS edges (
     kind TEXT NOT NULL,
     file_path TEXT NOT NULL,
     line INTEGER,
+    -- 0 = unresolved (heuristic + LSP not yet definitive), 1 = resolved,
+    -- 2 = unresolvable (LSP definitively returned no in-graph definition).
+    resolution_state INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (source_id) REFERENCES symbols(id)
 );
 
@@ -141,6 +144,9 @@ CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_name);
 CREATE INDEX IF NOT EXISTS idx_edges_target_id ON edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind);
+-- idx_edges_unresolved (partial index on resolution_state=0) is created
+-- post-migration in Database::open so pre-v4 DBs without the column don't
+-- blow up at SCHEMA-load time.
 "#;
 
 /// Schema for RAG semantic search tables.
@@ -312,7 +318,7 @@ pub fn register_sqlite_vec() {
 }
 
 /// Current schema version. Increment when adding migrations.
-const SCHEMA_VERSION: u32 = 3;
+const SCHEMA_VERSION: u32 = 4;
 
 /// Run schema migrations for existing databases.
 ///
@@ -333,8 +339,13 @@ fn migrate(conn: &Connection) {
     let has_hash_cols = conn
         .prepare("SELECT content_hash FROM symbols LIMIT 0")
         .is_ok();
+    // Same idea for v4: ensure the resolution_state column exists even if
+    // schema_version was already bumped (e.g. partial migration crash).
+    let has_resolution_state = conn
+        .prepare("SELECT resolution_state FROM edges LIMIT 0")
+        .is_ok();
 
-    if current >= SCHEMA_VERSION && has_hash_cols {
+    if current >= SCHEMA_VERSION && has_hash_cols && has_resolution_state {
         return;
     }
 
@@ -360,6 +371,23 @@ fn migrate(conn: &Connection) {
         let _ = conn.execute("DELETE FROM symbol_embedding_map", []);
         // Clear last_commit so incremental indexing doesn't skip anything
         let _ = conn.execute("DELETE FROM metadata WHERE key = 'last_commit'", []);
+    }
+
+    // Migration 3 → 4: edge resolution_state for the LSP "unresolvable" marker.
+    // Non-destructive: column is additive, existing nulls become state=0
+    // (will be re-attempted by LSP), existing target_ids become state=1.
+    // The matching partial index is created in `Database::open` after this
+    // function returns — keeps the SCHEMA bootstrap pre-migration safe.
+    if current < 4 || !has_resolution_state {
+        info!("schema v4: adding edges.resolution_state column");
+        let _ = conn.execute(
+            "ALTER TABLE edges ADD COLUMN resolution_state INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        let _ = conn.execute(
+            "UPDATE edges SET resolution_state = 1 WHERE target_id IS NOT NULL",
+            [],
+        );
     }
 
     // Store the new schema version
@@ -519,6 +547,13 @@ impl Database {
         conn.execute_batch(RAG_SCHEMA).map_err(DbError::RagSchema)?;
         backup_before_destructive_migration(&conn, db_path)?;
         migrate(&conn);
+        // Partial index requires resolution_state (added in migration 3→4),
+        // so create it after migrate() rather than from SCHEMA.
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_edges_unresolved
+                 ON edges(file_path) WHERE resolution_state = 0",
+        )
+        .map_err(DbError::Schema)?;
         handle_embedding_dimension(&conn, embedding_dim).map_err(DbError::EmbeddingDimension)?;
         Ok(Self { conn })
     }
@@ -535,6 +570,11 @@ impl Database {
         conn.execute_batch(&rag_vec_schema(DEFAULT_EMBEDDING_DIM))
             .map_err(DbError::RagSchema)?;
         migrate(&conn);
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_edges_unresolved
+                 ON edges(file_path) WHERE resolution_state = 0",
+        )
+        .map_err(DbError::Schema)?;
         Ok(Self { conn })
     }
 
@@ -953,9 +993,13 @@ impl Database {
     }
 
     fn resolve_edges_pass(&self) -> Result<u32> {
+        // Skip state=2 (unresolvable) edges: the heuristic can't resolve what
+        // LSP definitively gave up on, and re-walking them every dirty reindex
+        // burns measurable time on large repos. They re-enter via
+        // `reset_unresolvable_for_names` when a matching symbol appears.
         let mut unresolved_stmt = self.conn.prepare(
             "SELECT e.id, e.target_name, e.file_path, e.source_id
-             FROM edges e WHERE e.target_id IS NULL",
+             FROM edges e WHERE e.target_id IS NULL AND e.resolution_state = 0",
         )?;
 
         let unresolved: Vec<(i64, String, String, String)> = unresolved_stmt
@@ -1135,9 +1179,12 @@ impl Database {
         }
         // After file re-indexing, edges from unchanged files may point to
         // symbol IDs that no longer exist (removed or renamed symbols).
-        // Set these dangling references to NULL so they can be re-resolved.
+        // Set these dangling references to NULL AND reset resolution_state so
+        // the heuristic + LSP passes get another shot. Without the state reset
+        // the edge would stay at state=1 (resolved) but with target_id NULL —
+        // permanently invisible to `unresolved_edges()`.
         let n = self.conn.execute(
-            "UPDATE edges SET target_id = NULL
+            "UPDATE edges SET target_id = NULL, resolution_state = 0
              WHERE target_id IS NOT NULL
                AND NOT EXISTS (SELECT 1 FROM symbols WHERE symbols.id = edges.target_id)",
             [],
@@ -2061,14 +2108,19 @@ impl Database {
     // the Phase 3 atomicity bug at runtime ("cannot start a transaction
     // within a transaction").
 
-    /// Return all edges with `target_id IS NULL` (unresolved after heuristic pass).
+    /// Return edges still waiting for resolution (`resolution_state = 0`).
+    ///
+    /// Edges marked `state = 2` (LSP definitively gave up) are excluded so a
+    /// dirty reindex doesn't re-query the language server for known-unresolvable
+    /// targets. They re-enter the unresolved set via
+    /// [`Self::reset_unresolvable_for_names`] when a matching symbol is added.
     ///
     /// tx-safe: read-only single statement — see note above the section header.
     pub fn unresolved_edges(&self) -> Result<Vec<UnresolvedEdge>> {
         let mut stmt = self.conn.prepare(
             "SELECT e.id, e.target_name, e.file_path, e.line
              FROM edges e
-             WHERE e.target_id IS NULL",
+             WHERE e.resolution_state = 0",
         )?;
 
         let rows = stmt.query_map([], |row| {
@@ -2102,7 +2154,7 @@ impl Database {
         Ok(id)
     }
 
-    /// Update a single edge's target_id.
+    /// Update a single edge's target_id and flip it to `resolution_state = 1`.
     ///
     /// tx-safe: single statement — see the LSP-section header note. If you
     /// ever batch this internally with `unchecked_transaction()`, also update
@@ -2110,10 +2162,87 @@ impl Database {
     /// outer transaction.
     pub fn update_edge_target(&self, edge_id: i64, target_id: &str) -> Result<()> {
         self.conn.execute(
-            "UPDATE edges SET target_id = ?1 WHERE id = ?2",
+            "UPDATE edges SET target_id = ?1, resolution_state = 1 WHERE id = ?2",
             params![target_id, edge_id],
         )?;
         Ok(())
+    }
+
+    /// Test-only inspector: returns true when the edge is at `resolution_state = 2`.
+    ///
+    /// Exposed because the column is otherwise crate-private, and downstream
+    /// integration tests (cartog-indexer) need a read-only way to assert the
+    /// marker state without snapshotting raw SQL.
+    pub fn is_edge_unresolvable(&self, edge_id: i64) -> Result<bool> {
+        let state: i64 = self.conn.query_row(
+            "SELECT resolution_state FROM edges WHERE id = ?1",
+            params![edge_id],
+            |row| row.get(0),
+        )?;
+        Ok(state == 2)
+    }
+
+    /// Reset every `resolution_state = 2` edge back to `0`. Used by
+    /// `cartog index --force` to honor the "retry everything" contract:
+    /// without this, the heuristic + LSP would still skip permanently-marked
+    /// edges even on a forced re-index.
+    ///
+    /// tx-safe: single statement — see the LSP-section header note.
+    pub fn reset_all_unresolvable(&self) -> Result<u32> {
+        let n = self.conn.execute(
+            "UPDATE edges SET resolution_state = 0 WHERE resolution_state = 2",
+            [],
+        )?;
+        Ok(n as u32)
+    }
+
+    /// Mark a single edge as `resolution_state = 2` (LSP gave up).
+    ///
+    /// Callers MUST only invoke this after a definitive negative answer from
+    /// the language server. Never call from a transient-error branch (server
+    /// crash, didOpen failure, half-loaded warmup) — the marker is sticky
+    /// across runs until [`Self::reset_unresolvable_for_names`] or
+    /// [`Self::invalidate_edges_targeting`] reopens it.
+    ///
+    /// tx-safe: single statement — see the LSP-section header note.
+    pub fn mark_edge_unresolvable(&self, edge_id: i64) -> Result<()> {
+        self.conn.execute(
+            "UPDATE edges SET resolution_state = 2 WHERE id = ?1",
+            params![edge_id],
+        )?;
+        Ok(())
+    }
+
+    /// Reset `resolution_state` from 2 → 0 for edges whose target_name is in `names`.
+    ///
+    /// Called from the indexer when new symbols are added: an edge that was
+    /// previously "unresolvable" (no symbol with this name existed) may now be
+    /// resolvable against the freshly-added target. Returns the number of edges
+    /// reopened. No-op when `names` is empty.
+    ///
+    /// tx-safe: single statement. Names are batched to honor SQLite's default
+    /// 999-parameter limit; only resolution_state = 2 rows are touched so the
+    /// write set stays tiny even on a large rename.
+    pub fn reset_unresolvable_for_names(&self, names: &[String]) -> Result<u32> {
+        if names.is_empty() {
+            return Ok(0);
+        }
+        const CHUNK: usize = 500;
+        let mut total: u32 = 0;
+        for chunk in names.chunks(CHUNK) {
+            let placeholders = vec!["?"; chunk.len()].join(",");
+            let sql = format!(
+                "UPDATE edges
+                 SET resolution_state = 0
+                 WHERE resolution_state = 2
+                   AND target_name IN ({placeholders})"
+            );
+            let params: Vec<&dyn rusqlite::ToSql> =
+                chunk.iter().map(|n| n as &dyn rusqlite::ToSql).collect();
+            let n = self.conn.execute(&sql, params.as_slice())?;
+            total += n as u32;
+        }
+        Ok(total)
     }
 }
 
@@ -4169,5 +4298,249 @@ mod tests {
             count, 1,
             "without an outer transaction, an early write persists despite a later error"
         );
+    }
+
+    // ── resolution_state (edge marker) tests ──
+
+    fn resolution_state_of(db: &Database, edge_id: i64) -> i64 {
+        db.conn
+            .query_row(
+                "SELECT resolution_state FROM edges WHERE id = ?1",
+                params![edge_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    fn insert_test_edge(db: &Database, target_name: &str) -> i64 {
+        let sym = test_symbol("src", SymbolKind::Function, "a.py", 1);
+        db.insert_symbols(std::slice::from_ref(&sym)).unwrap();
+        let edge = Edge::new(&sym.id, target_name, EdgeKind::Calls, "a.py", 1);
+        db.insert_edge(&edge).unwrap();
+        db.conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn test_new_edge_has_default_state_zero() {
+        let db = Database::open_memory().unwrap();
+        let id = insert_test_edge(&db, "missing_target");
+        assert_eq!(resolution_state_of(&db, id), 0);
+    }
+
+    #[test]
+    fn test_update_edge_target_flips_state_to_one() {
+        let db = Database::open_memory().unwrap();
+        let id = insert_test_edge(&db, "anything");
+        db.update_edge_target(id, "some:symbol:id").unwrap();
+        assert_eq!(resolution_state_of(&db, id), 1);
+    }
+
+    #[test]
+    fn test_mark_edge_unresolvable_sets_state_to_two() {
+        let db = Database::open_memory().unwrap();
+        let id = insert_test_edge(&db, "anything");
+        db.mark_edge_unresolvable(id).unwrap();
+        assert_eq!(resolution_state_of(&db, id), 2);
+    }
+
+    #[test]
+    fn test_unresolved_edges_excludes_state_two() {
+        let db = Database::open_memory().unwrap();
+        let _unresolved = insert_test_edge(&db, "still_unresolved");
+        let burned = insert_test_edge(&db, "burned");
+        db.mark_edge_unresolvable(burned).unwrap();
+
+        let edges = db.unresolved_edges().unwrap();
+        let names: Vec<&str> = edges.iter().map(|e| e.target_name.as_str()).collect();
+        assert!(names.contains(&"still_unresolved"));
+        assert!(!names.contains(&"burned"));
+    }
+
+    #[test]
+    fn test_reset_unresolvable_for_names_targets_only_matching() {
+        let db = Database::open_memory().unwrap();
+        let burned_foo = insert_test_edge(&db, "foo");
+        let burned_bar = insert_test_edge(&db, "bar");
+        db.mark_edge_unresolvable(burned_foo).unwrap();
+        db.mark_edge_unresolvable(burned_bar).unwrap();
+
+        let reopened = db
+            .reset_unresolvable_for_names(&["foo".to_string()])
+            .unwrap();
+        assert_eq!(reopened, 1);
+        assert_eq!(resolution_state_of(&db, burned_foo), 0);
+        assert_eq!(resolution_state_of(&db, burned_bar), 2);
+    }
+
+    #[test]
+    fn test_reset_unresolvable_for_names_empty_is_noop() {
+        let db = Database::open_memory().unwrap();
+        let n = db.reset_unresolvable_for_names(&[]).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn test_reset_unresolvable_for_names_does_not_touch_state_zero_or_one() {
+        // The reset is purely state=2 → state=0. Resolved (state=1) and
+        // already-open (state=0) edges with matching names must be left alone.
+        let db = Database::open_memory().unwrap();
+        let still_open = insert_test_edge(&db, "foo"); // state=0
+        let already_resolved = insert_test_edge(&db, "foo");
+        db.update_edge_target(already_resolved, "some:id").unwrap(); // state=1
+
+        db.reset_unresolvable_for_names(&["foo".to_string()])
+            .unwrap();
+        assert_eq!(resolution_state_of(&db, still_open), 0);
+        assert_eq!(resolution_state_of(&db, already_resolved), 1);
+    }
+
+    #[test]
+    fn test_invalidate_edges_targeting_resets_state_when_target_disappears() {
+        // When a symbol referenced by a resolved edge is removed, the edge
+        // must drop back to (target_id NULL, state=0) so it re-enters the
+        // unresolved set on the next pass.
+        let db = Database::open_memory().unwrap();
+
+        // Set up: source edge points to symbol "ghost" via update_edge_target,
+        // then drop the symbol so the edge becomes dangling.
+        let src = test_symbol("src", SymbolKind::Function, "a.py", 1);
+        let target = test_symbol("ghost", SymbolKind::Function, "b.py", 1);
+        db.insert_symbols(&[src.clone(), target.clone()]).unwrap();
+        let edge = Edge::new(&src.id, "ghost", EdgeKind::Calls, "a.py", 1);
+        db.insert_edge(&edge).unwrap();
+        let eid = db.conn.last_insert_rowid();
+        db.update_edge_target(eid, &target.id).unwrap();
+        assert_eq!(resolution_state_of(&db, eid), 1);
+
+        // Remove the target symbol — leaves edge.target_id pointing at nothing.
+        db.conn
+            .execute("DELETE FROM symbols WHERE id = ?1", params![target.id])
+            .unwrap();
+
+        let mut dirty = std::collections::HashSet::new();
+        dirty.insert("b.py".to_string());
+        db.invalidate_edges_targeting(&dirty).unwrap();
+
+        assert_eq!(
+            resolution_state_of(&db, eid),
+            0,
+            "dangling edge must return to state=0 so unresolved_edges() can see it"
+        );
+        let row: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT target_id FROM edges WHERE id = ?1",
+                params![eid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(row.is_none(), "target_id must be NULL after invalidation");
+    }
+
+    #[test]
+    fn test_partial_unresolved_index_exists() {
+        // The partial index speeds up the unresolved_edges() query on large
+        // repos. Verify it actually got created by inspecting sqlite_master.
+        let db = Database::open_memory().unwrap();
+        let n: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type='index' AND name='idx_edges_unresolved'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn test_resolution_state_default_via_insert_edges_batch() {
+        // The batched insert path is the production hot path. Make sure
+        // it honors the DEFAULT 0 just like single-row inserts do.
+        let db = Database::open_memory().unwrap();
+        let src = test_symbol("src", SymbolKind::Function, "a.py", 1);
+        db.insert_symbols(std::slice::from_ref(&src)).unwrap();
+        let edges = vec![
+            Edge::new(&src.id, "x", EdgeKind::Calls, "a.py", 1),
+            Edge::new(&src.id, "y", EdgeKind::Calls, "a.py", 2),
+        ];
+        db.insert_edges(&edges).unwrap();
+        let states: Vec<i64> = db
+            .conn
+            .prepare("SELECT resolution_state FROM edges ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert_eq!(states, vec![0, 0]);
+    }
+
+    #[test]
+    fn test_migration_v3_to_v4_backfills_resolved_to_state_one() {
+        // Simulate a pre-v4 database: open with v3-equivalent schema (no
+        // resolution_state column, schema_version=3), insert edges with
+        // and without target_ids, then re-open to trigger the migration.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("v3.sqlite");
+
+        {
+            let conn = Connection::open(&path).unwrap();
+            // Bootstrap a v3-shaped edges table by hand.
+            conn.execute_batch(
+                "CREATE TABLE symbols (
+                    id TEXT PRIMARY KEY, name TEXT, kind TEXT, file_path TEXT,
+                    start_line INTEGER, end_line INTEGER, start_byte INTEGER, end_byte INTEGER,
+                    parent_id TEXT, signature TEXT, visibility TEXT, is_async BOOLEAN,
+                    docstring TEXT, in_degree INTEGER DEFAULT 0,
+                    content_hash TEXT, subtree_hash TEXT);
+                 CREATE TABLE edges (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id TEXT NOT NULL, target_name TEXT NOT NULL, target_id TEXT,
+                    kind TEXT NOT NULL, file_path TEXT NOT NULL, line INTEGER);
+                 CREATE TABLE files (path TEXT PRIMARY KEY);
+                 CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+                 INSERT INTO metadata (key, value) VALUES ('schema_version', '3');
+                 INSERT INTO symbols (id, name, kind, file_path) VALUES ('s:1', 'foo', 'function', 'a.py');
+                 INSERT INTO edges (source_id, target_name, target_id, kind, file_path, line)
+                   VALUES ('s:1', 'foo', 's:1', 'calls', 'a.py', 1);
+                 INSERT INTO edges (source_id, target_name, target_id, kind, file_path, line)
+                   VALUES ('s:1', 'missing', NULL, 'calls', 'a.py', 2);",
+            )
+            .unwrap();
+        }
+
+        // Re-open through the production path so migrate() runs.
+        let db = Database::open(&path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        let resolved_state: i64 = db
+            .conn
+            .query_row(
+                "SELECT resolution_state FROM edges WHERE target_id IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let unresolved_state: i64 = db
+            .conn
+            .query_row(
+                "SELECT resolution_state FROM edges WHERE target_id IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(resolved_state, 1, "existing target_id NOT NULL → state=1");
+        assert_eq!(unresolved_state, 0, "existing target_id NULL → state=0");
+
+        let bumped: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(bumped, "4");
     }
 }

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -861,9 +861,11 @@ impl Database {
         let mut del_out = self
             .conn
             .prepare_cached("DELETE FROM edges WHERE source_id = ?1")?;
-        let mut null_in = self
-            .conn
-            .prepare_cached("UPDATE edges SET target_id = NULL WHERE target_id = ?1")?;
+        // Reset state alongside target_id so the orphaned edge re-enters
+        // unresolved_edges() instead of becoming a (NULL, state=1) zombie.
+        let mut null_in = self.conn.prepare_cached(
+            "UPDATE edges SET target_id = NULL, resolution_state = 0 WHERE target_id = ?1",
+        )?;
         let mut del_vec = self.conn.prepare_cached(
             "DELETE FROM symbol_vec WHERE rowid IN \
              (SELECT id FROM symbol_embedding_map WHERE symbol_id = ?1)",
@@ -894,7 +896,7 @@ impl Database {
         self.conn
             .execute("DELETE FROM edges WHERE source_id = ?1", params![id])?;
         self.conn.execute(
-            "UPDATE edges SET target_id = NULL WHERE target_id = ?1",
+            "UPDATE edges SET target_id = NULL, resolution_state = 0 WHERE target_id = ?1",
             params![id],
         )?;
         let _ = self.conn.execute(
@@ -1048,9 +1050,12 @@ impl Database {
             .conn
             .prepare("SELECT id, kind FROM symbols WHERE name = ?1 AND kind != 'import' LIMIT 3")?;
 
+        // Heuristic resolve must flip state=1 alongside target_id; otherwise
+        // unresolved_edges() (state=0 filter) would still surface the edge to
+        // the next LSP pass, wasting a server roundtrip on already-known answers.
         let mut update_stmt = self
             .conn
-            .prepare("UPDATE edges SET target_id = ?1 WHERE id = ?2")?;
+            .prepare("UPDATE edges SET target_id = ?1, resolution_state = 1 WHERE id = ?2")?;
 
         for (edge_id, target_name, edge_file, source_id) in unresolved {
             let simple_name = target_name.rsplit('.').next().unwrap_or(target_name);
@@ -4435,6 +4440,90 @@ mod tests {
             )
             .unwrap();
         assert!(row.is_none(), "target_id must be NULL after invalidation");
+    }
+
+    #[test]
+    fn test_delete_symbol_resets_state_on_dangling_incoming_edges() {
+        // Regression for the "(target_id=NULL, state=1) zombie" bug: when a
+        // resolved target symbol is deleted, every edge pointing to it must
+        // drop back to state=0 — otherwise the edge becomes invisible to both
+        // unresolved_edges() (state=1 filter) and graph traversal (NULL target).
+        let db = Database::open_memory().unwrap();
+        let src = test_symbol("caller", SymbolKind::Function, "a.py", 1);
+        let target = test_symbol("ghost", SymbolKind::Function, "b.py", 1);
+        db.insert_symbols(&[src.clone(), target.clone()]).unwrap();
+        let edge = Edge::new(&src.id, "ghost", EdgeKind::Calls, "a.py", 1);
+        db.insert_edge(&edge).unwrap();
+        let eid = db.conn.last_insert_rowid();
+        db.update_edge_target(eid, &target.id).unwrap();
+
+        db.delete_symbol(&target.id).unwrap();
+
+        assert_eq!(resolution_state_of(&db, eid), 0);
+        let visible = db
+            .unresolved_edges()
+            .unwrap()
+            .iter()
+            .any(|e| e.edge_id == eid);
+        assert!(
+            visible,
+            "orphaned edge must resurface in unresolved_edges()"
+        );
+    }
+
+    #[test]
+    fn test_delete_symbols_in_tx_resets_state_on_dangling_incoming_edges() {
+        // Same invariant as test_delete_symbol_..., for the batched path used
+        // by the indexer's Merkle-diff `removed` set.
+        let db = Database::open_memory().unwrap();
+        let src = test_symbol("caller", SymbolKind::Function, "a.py", 1);
+        let t1 = test_symbol("ghost1", SymbolKind::Function, "b.py", 1);
+        let t2 = test_symbol("ghost2", SymbolKind::Function, "c.py", 1);
+        db.insert_symbols(&[src.clone(), t1.clone(), t2.clone()])
+            .unwrap();
+        let e1 = Edge::new(&src.id, "ghost1", EdgeKind::Calls, "a.py", 1);
+        db.insert_edge(&e1).unwrap();
+        let eid1 = db.conn.last_insert_rowid();
+        db.update_edge_target(eid1, &t1.id).unwrap();
+        let e2 = Edge::new(&src.id, "ghost2", EdgeKind::Calls, "a.py", 2);
+        db.insert_edge(&e2).unwrap();
+        let eid2 = db.conn.last_insert_rowid();
+        db.update_edge_target(eid2, &t2.id).unwrap();
+
+        db.delete_symbols(&[t1.id.clone(), t2.id.clone()]).unwrap();
+
+        assert_eq!(resolution_state_of(&db, eid1), 0);
+        assert_eq!(resolution_state_of(&db, eid2), 0);
+    }
+
+    #[test]
+    fn test_heuristic_resolve_flips_state_to_one() {
+        // Regression: resolve_edge_batch's UPDATE must set state=1 alongside
+        // target_id. Otherwise heuristically-resolved edges stay state=0 and
+        // get re-queried by LSP on the next pass — pure waste.
+        let db = Database::open_memory().unwrap();
+        let src = test_symbol("caller", SymbolKind::Function, "a.py", 1);
+        let target = test_symbol("foo", SymbolKind::Function, "a.py", 10);
+        db.insert_symbols(&[src.clone(), target.clone()]).unwrap();
+        let edge = Edge::new(&src.id, "foo", EdgeKind::Calls, "a.py", 2);
+        db.insert_edge(&edge).unwrap();
+        let eid = db.conn.last_insert_rowid();
+        assert_eq!(resolution_state_of(&db, eid), 0);
+
+        db.resolve_edges().unwrap();
+
+        assert_eq!(
+            resolution_state_of(&db, eid),
+            1,
+            "heuristic resolve must set state=1 so LSP doesn't re-attack the edge"
+        );
+        assert!(
+            db.unresolved_edges()
+                .unwrap()
+                .iter()
+                .all(|e| e.edge_id != eid),
+            "resolved edge must drop out of unresolved_edges()"
+        );
     }
 
     #[test]

--- a/crates/cartog-indexer/README.md
+++ b/crates/cartog-indexer/README.md
@@ -39,6 +39,8 @@ Edges are always fully re-inserted for dirty files (no edge-level diff).
 
 When the `lsp` feature is enabled, a second pass resolves edges that the heuristic resolver in `cartog-db` left unresolved, using real language servers via `cartog-lsp`. Skipped on no-op reindexes (no file added, modified, or removed) — the unresolved set is identical to the previous run. Use `--force` to retry resolution after toggling `--no-lsp` off.
 
+Edges that LSP definitively cannot resolve (stdlib targets, dyn dispatch, macro expansion) are marked `resolution_state = 2` and skipped on future runs. When a new symbol is added whose name matches such an edge, the indexer auto-resets the marker so the next pass retries — see `Database::reset_unresolvable_for_names`.
+
 ## Public API
 
 | Export | Description |

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -123,6 +123,10 @@ pub struct IndexResult {
     pub edges_resolved: u32,
     #[serde(skip_serializing_if = "is_zero")]
     pub edges_lsp_resolved: u32,
+    /// Edges LSP marked `resolution_state = 2` (definitively unresolvable) this run.
+    /// They are skipped by future LSP queries until a matching symbol is added.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub edges_marked_unresolvable: u32,
     /// Files added, modified, or removed this run. Callers gate post-index passes (e.g. LSP) on this.
     #[serde(skip)]
     pub dirty_files: u32,
@@ -236,6 +240,12 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
     // Inside the transaction, we use the `*_in_tx` variants of the batch
     // helpers — the regular versions issue their own `BEGIN` and would fail
     // here.
+    // Names of symbols added this run. Used after the per-file loop to reset
+    // resolution_state=2 markers on edges that newly have a matching target —
+    // closes the "added b.ts after a.ts's import was marked unresolvable" gap.
+    let mut added_symbol_names: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
     let tx = db.begin_indexing_tx()?;
     for item in parsed {
         let (rel_path, lang, source, hash, modified, symbols, edges) = match item {
@@ -265,6 +275,12 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
             let diff = merkle_diff(&symbols, &old_hashes);
 
             dirty_files.insert(rel_path.clone());
+
+            // Newly-added symbol names — used post-loop to retry edges that
+            // were previously marked unresolvable but now have a matching target.
+            for &i in &diff.added {
+                added_symbol_names.insert(symbols[i].name.clone());
+            }
 
             db.delete_symbols_in_tx(&diff.removed)?;
             result.symbols_removed += diff.removed.len() as u32;
@@ -307,6 +323,10 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
         } else {
             // No stored hashes (first index or post-migration): full insert
             dirty_files.insert(rel_path.clone());
+            // Every symbol in a freshly-inserted file is "new" wrt the marker.
+            for sym in &symbols {
+                added_symbol_names.insert(sym.name.clone());
+            }
             db.clear_file_data_in_tx(&rel_path)?;
 
             db.insert_symbols_in_tx(&symbols)?;
@@ -355,6 +375,19 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
         }
     }
 
+    // Force-reindex must retry edges previously marked unresolvable —
+    // otherwise --force would silently honor a stale state=2 marker.
+    if force {
+        db.reset_all_unresolvable()?;
+    }
+
+    // Reopen state=2 markers whose target_name was just added. Runs BEFORE
+    // the heuristic + LSP passes so reopened edges flow through both.
+    if !added_symbol_names.is_empty() {
+        let names: Vec<String> = added_symbol_names.iter().cloned().collect();
+        db.reset_unresolvable_for_names(&names)?;
+    }
+
     // Resolve edges — scoped to dirty files for incremental, global for force/first-index
     if force || dirty_files.len() == current_files.len() {
         result.edges_resolved = db.resolve_edges_in_tx()?;
@@ -377,7 +410,9 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
     // re-querying the LSP repeats work. Use `--force` to retry.
     #[cfg(feature = "lsp")]
     if lsp && !dirty_files.is_empty() {
-        result.edges_lsp_resolved = cartog_lsp::lsp_resolve_edges(db, &root, None)?;
+        let stats = cartog_lsp::lsp_resolve_edges(db, &root, None)?;
+        result.edges_lsp_resolved = stats.resolved;
+        result.edges_marked_unresolvable = stats.marked_unresolvable;
     }
     #[cfg(not(feature = "lsp"))]
     let _ = lsp; // suppress unused warning when feature is off
@@ -1034,6 +1069,119 @@ mod tests {
         let r2 = index_directory(&db, &fixtures, false, true).unwrap();
         assert_eq!(r2.dirty_files, 0);
         assert_eq!(r2.edges_lsp_resolved, 0);
+    }
+
+    #[test]
+    fn test_added_symbol_reopens_unresolvable_edges() {
+        // Name-keyed reset: a new symbol whose name matches a state=2 edge
+        // returns the edge to state=0 (or state=1 if the heuristic resolves it).
+        use cartog_db::Database;
+
+        let tmp = tempfile::tempdir().unwrap();
+        // Rust's tempfile creates `.tmpXXXX` directories on macOS — the leading
+        // dot makes is_ignored() reject the walk root. Nest a non-dotted child.
+        let root = tmp.path().canonicalize().unwrap().join("project");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("a.py"), "def caller():\n    find_user('x')\n").unwrap();
+
+        let db = Database::open_memory().unwrap();
+        let r1 = index_directory(&db, &root, false, false).unwrap();
+        assert!(
+            r1.files_indexed >= 1,
+            "expected a.py to index, got {:?}",
+            r1
+        );
+
+        let before = db.unresolved_edges().unwrap();
+        let find_user = before
+            .iter()
+            .find(|e| e.target_name == "find_user")
+            .expect("find_user edge should exist as unresolved after first index");
+        let edge_id = find_user.edge_id;
+        db.mark_edge_unresolvable(edge_id).unwrap();
+        assert!(db.is_edge_unresolvable(edge_id).unwrap());
+
+        // Adding b.py with find_user definition should reopen the marker.
+        std::fs::write(root.join("b.py"), "def find_user(name):\n    return None\n").unwrap();
+        index_directory(&db, &root, false, false).unwrap();
+
+        assert!(
+            !db.is_edge_unresolvable(edge_id).unwrap(),
+            "edge must not stay state=2 after a matching target appears"
+        );
+    }
+
+    #[test]
+    fn test_force_reindex_resets_unresolvable_markers() {
+        // --force is the documented escape hatch for "retry everything".
+        // A state=2 marker must not survive a forced reindex; otherwise the
+        // user has no way to un-burn an edge after a transient false positive
+        // would have escaped the per-language gate.
+        //
+        // After --force, edges are re-inserted with new auto-increment IDs and
+        // default state=0. We assert: no edge with target_name="find_x" stays
+        // at state=2 (use the marker filter on unresolved_edges).
+        use cartog_db::Database;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap().join("project");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("a.py"), "def caller():\n    find_x()\n").unwrap();
+
+        let db = Database::open_memory().unwrap();
+        index_directory(&db, &root, false, false).unwrap();
+
+        let pre = db.unresolved_edges().unwrap();
+        let find_x_id = pre
+            .iter()
+            .find(|e| e.target_name == "find_x")
+            .expect("find_x edge should exist")
+            .edge_id;
+        db.mark_edge_unresolvable(find_x_id).unwrap();
+
+        // --force = true: rebuilds edges with fresh IDs, must NOT inherit state=2.
+        index_directory(&db, &root, true, false).unwrap();
+        let post = db.unresolved_edges().unwrap();
+        let has_find_x_unresolved = post.iter().any(|e| e.target_name == "find_x");
+        assert!(
+            has_find_x_unresolved,
+            "after --force, find_x must be back in unresolved_edges (state=0)"
+        );
+    }
+
+    #[test]
+    fn test_noop_reindex_preserves_unresolvable_markers() {
+        // Defensive: a no-op reindex must not touch state=2 markers — no
+        // spurious resets (would burn the gate), no spurious re-marks.
+        use cartog_db::Database;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap().join("project");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(
+            root.join("a.py"),
+            "def caller():\n    find_x()\n    find_y()\n",
+        )
+        .unwrap();
+
+        let db = Database::open_memory().unwrap();
+        index_directory(&db, &root, false, false).unwrap();
+
+        let unresolved = db.unresolved_edges().unwrap();
+        let target = unresolved
+            .iter()
+            .find(|e| e.target_name == "find_x")
+            .expect("find_x edge should exist");
+        db.mark_edge_unresolvable(target.edge_id).unwrap();
+
+        // No file changes → reindex is a no-op → marker survives.
+        let r = index_directory(&db, &root, false, false).unwrap();
+        assert_eq!(r.dirty_files, 0);
+
+        assert!(
+            db.is_edge_unresolvable(target.edge_id).unwrap(),
+            "no-op reindex must not reset state=2"
+        );
     }
 
     #[test]

--- a/crates/cartog-lsp/Cargo.toml
+++ b/crates/cartog-lsp/Cargo.toml
@@ -15,3 +15,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/cartog-lsp/README.md
+++ b/crates/cartog-lsp/README.md
@@ -10,7 +10,7 @@ Resolves edges that the heuristic resolver in `cartog-db` left unresolved, by qu
 
 ### Resolution flow
 
-1. Fetch all unresolved edges (`target_id IS NULL`) from the database
+1. Fetch all unresolved edges (`resolution_state = 0`) from the database
 2. Group edges by language (detected from file extension)
 3. Start an LSP server for each language found on `PATH`
 4. For each file with unresolved edges:
@@ -18,7 +18,9 @@ Resolves edges that the heuristic resolver in `cartog-db` left unresolved, by qu
    - For each edge, find the target name's **column** in the source line
    - Send `textDocument/definition` request at that position
    - If the server returns a location, look up the symbol in the DB at that file+line
-   - Update the edge's `target_id`
+   - Update the edge's `target_id` (sets `resolution_state = 1`)
+   - On a definitive `Ok(None)`, buffer the edge to be marked `resolution_state = 2` *only if* the language proved healthy by resolving at least one edge this run (per-language success gate — protects against half-loaded LSP servers)
+   - Transient errors (`Err(_)`) never mark — the marker is sticky across runs
    - Send `textDocument/didClose`
 
 ### Column finding

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -325,12 +325,15 @@ mod tests {
 
     #[test]
     fn test_lsp_resolve_edges_no_servers_leaves_edges_unmarked() {
-        // Exercises ONLY the "manager.start() failed" branch: the test runs
-        // wherever pyright is not on PATH (typical CI). The buffered-negative
-        // path (per-language success gate with Ok(None) responses) is not
-        // covered here — it would need an LSP test double and is out of scope
-        // for this regression guard. What this DOES guarantee: when no server
-        // can start, lsp_resolve_edges returns zeros and never burns an edge.
+        // Two-mode coverage:
+        // - No pyright on PATH (typical CI): exercises the manager.start()
+        //   Err branch — server never starts, no marks possible.
+        // - pyright present: exercises the buffered-negative + per-language
+        //   gate. find_user is undefined, so LSP returns Ok(None) for the
+        //   only candidate; lang_resolved stays 0, so the gate suppresses
+        //   the mark. Same end-state: edge stays unmarked.
+        // Note: writing a.py under tmp would only help in the second mode;
+        // the first mode (CI) exits before the file is ever read.
         use cartog_core::{Edge, EdgeKind, Symbol, SymbolKind};
         use cartog_db::Database;
 

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -18,21 +18,30 @@ use cartog_db::{Database, UnresolvedEdge};
 
 use manager::LspManager;
 
+/// Summary of an LSP resolution pass.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LspResolveStats {
+    /// Edges flipped from `resolution_state = 0` to `1` (target_id set).
+    pub resolved: u32,
+    /// Edges flipped from `resolution_state = 0` to `2` (LSP definitively gave up).
+    pub marked_unresolvable: u32,
+}
+
 /// Resolve edges that heuristic resolution left unresolved, using LSP servers.
 ///
 /// If `shared_manager` is provided, reuses existing LSP servers (warm start).
 /// Otherwise creates a temporary manager that is dropped after resolution.
 ///
-/// Returns the number of edges resolved by LSP.
+/// Returns counts for both `resolved` and `marked_unresolvable`.
 pub fn lsp_resolve_edges(
     db: &Database,
     root: &Path,
     shared_manager: Option<&mut LspManager>,
-) -> Result<u32> {
+) -> Result<LspResolveStats> {
     let unresolved = db.unresolved_edges()?;
 
     if unresolved.is_empty() {
-        return Ok(0);
+        return Ok(LspResolveStats::default());
     }
 
     // Group by language (derived from file extension)
@@ -45,7 +54,7 @@ pub fn lsp_resolve_edges(
     }
 
     if by_language.is_empty() {
-        return Ok(0);
+        return Ok(LspResolveStats::default());
     }
 
     // Use shared manager if provided, otherwise create a temporary one
@@ -62,6 +71,7 @@ pub fn lsp_resolve_edges(
     };
 
     let mut resolved = 0u32;
+    let mut marked_unresolvable = 0u32;
     let mut any_server_started = false;
 
     for (language, edges) in &by_language {
@@ -87,6 +97,15 @@ pub fn lsp_resolve_edges(
             by_file.len()
         );
 
+        // Buffer "definitive Ok(None)" marks here and only commit them at the
+        // end of the language loop *if* the language proved healthy by resolving
+        // at least one edge. Catches half-loaded rust-analyzer cases where the
+        // server returns Ok(None) before its index is ready — without this gate
+        // we would burn good edges with a sticky state=2 marker.
+        let mut pending_marks: Vec<i64> = Vec::new();
+        let mut lang_resolved: u32 = 0;
+        let mut server_died = false;
+
         for (file_path, file_edges) in by_file {
             let abs_path = root.join(file_path);
             let content = match std::fs::read_to_string(&abs_path) {
@@ -101,6 +120,7 @@ pub fn lsp_resolve_edges(
                 tracing::debug!("didOpen failed for {file_path}: {e:#}");
                 if !manager.is_alive(language) {
                     tracing::warn!("{language} server died during didOpen");
+                    server_died = true;
                     break;
                 }
                 continue;
@@ -121,7 +141,10 @@ pub fn lsp_resolve_edges(
                         match db.find_symbol_at_location(&loc.file_path, loc.line) {
                             Ok(Some(symbol_id)) => {
                                 match db.update_edge_target(edge.edge_id, &symbol_id) {
-                                    Ok(()) => resolved += 1,
+                                    Ok(()) => {
+                                        resolved += 1;
+                                        lang_resolved += 1;
+                                    }
                                     Err(e) => tracing::debug!(
                                         "failed to update edge {}: {e:#}",
                                         edge.edge_id
@@ -129,17 +152,28 @@ pub fn lsp_resolve_edges(
                                 }
                             }
                             Ok(None) => {
+                                // LSP pointed outside the indexed root (stdlib, third-party).
+                                // Definitive negative: buffer for marking.
                                 tracing::debug!(
                                     "no cartog symbol at {}:{}",
                                     loc.file_path,
                                     loc.line
                                 );
+                                pending_marks.push(edge.edge_id);
                             }
                             Err(e) => return Err(e), // DB errors propagate
                         }
                     }
-                    Ok(None) => {} // LSP couldn't resolve either
+                    Ok(None) => {
+                        // LSP definitively answered "no definition". Buffer it
+                        // until we know the language server resolved at least
+                        // one edge this run (per-language success gate).
+                        pending_marks.push(edge.edge_id);
+                    }
                     Err(e) => {
+                        // Transient: server crash, didOpen race, IO. NEVER mark
+                        // — the marker is sticky and a transient failure must
+                        // not burn this edge for future runs.
                         tracing::debug!(
                             "definition failed for {} at {file_path}:{}: {e:#}",
                             edge.target_name,
@@ -147,6 +181,7 @@ pub fn lsp_resolve_edges(
                         );
                         if !manager.is_alive(language) {
                             tracing::warn!("{language} server died, skipping remaining edges");
+                            server_died = true;
                             break;
                         }
                     }
@@ -155,19 +190,46 @@ pub fn lsp_resolve_edges(
 
             // Close the file to free server memory
             let _ = manager.close_file(language, file_path);
+
+            if server_died {
+                break;
+            }
+        }
+
+        // Per-language success gate: only commit unresolvable markers if the
+        // server resolved at least one edge AND didn't crash mid-run.
+        if !server_died && lang_resolved > 0 {
+            for edge_id in &pending_marks {
+                if let Err(e) = db.mark_edge_unresolvable(*edge_id) {
+                    tracing::debug!("failed to mark edge {edge_id} unresolvable: {e:#}");
+                    continue;
+                }
+                marked_unresolvable += 1;
+            }
+        } else if !pending_marks.is_empty() {
+            tracing::info!(
+                "LSP: {language} produced {} negative answers but no successes — \
+                 not marking unresolvable (server may be half-loaded or unhealthy)",
+                pending_marks.len()
+            );
         }
     }
 
     if !any_server_started {
         tracing::debug!("LSP: no servers found on PATH, skipping");
-    } else if resolved > 0 {
-        tracing::info!("LSP: resolved {resolved} additional edges");
+    } else if resolved > 0 || marked_unresolvable > 0 {
+        tracing::info!(
+            "LSP: resolved {resolved} additional edges, marked {marked_unresolvable} unresolvable"
+        );
     } else {
         tracing::info!("LSP: no additional edges resolved");
     }
 
     // manager.shutdown_all() called via Drop
-    Ok(resolved)
+    Ok(LspResolveStats {
+        resolved,
+        marked_unresolvable,
+    })
 }
 
 /// Find the column (0-based UTF-16 offset) of `target_name` in the given source line.
@@ -257,5 +319,40 @@ mod tests {
         // "id" only appears inside "valid" — no word-boundary match
         let lines = vec!["valid()"];
         assert_eq!(find_column_in_line(&lines, 1, "id"), None);
+    }
+
+    // ── Per-language success gate ──
+
+    #[test]
+    fn test_lsp_resolve_edges_no_servers_leaves_edges_unmarked() {
+        // When no language servers are available (LSP manager has no clients
+        // for the requested language, or PATH is empty), lsp_resolve_edges
+        // must not burn edges. Regression guard for the per-language gate:
+        // zero successes => zero state=2 markers.
+        use cartog_core::{Edge, EdgeKind, Symbol, SymbolKind};
+        use cartog_db::Database;
+
+        let db = Database::open_memory().unwrap();
+        // Seed a Python edge with no resolution target — heuristic + LSP would
+        // both have to handle this, but here LSP can't even start a server.
+        let src = Symbol::new("caller", SymbolKind::Function, "a.py", 1, 5, 0, 100, None);
+        db.insert_symbols(std::slice::from_ref(&src)).unwrap();
+        let edge = Edge::new(&src.id, "find_user", EdgeKind::Calls, "a.py", 2);
+        db.insert_edge(&edge).unwrap();
+        let edge_id = db.unresolved_edges().unwrap()[0].edge_id;
+
+        // Drive lsp_resolve_edges with a tempdir as the project root. No PATH
+        // setup → no servers available → all edges should pass through unmarked.
+        let tmp = tempfile::tempdir().unwrap();
+        let stats = lsp_resolve_edges(&db, tmp.path(), None).unwrap();
+        assert_eq!(stats.resolved, 0, "no servers must mean zero resolutions");
+        assert_eq!(
+            stats.marked_unresolvable, 0,
+            "no servers must mean zero marks"
+        );
+        assert!(
+            !db.is_edge_unresolvable(edge_id).unwrap(),
+            "edge must not be marked unresolvable when no LSP ran"
+        );
     }
 }

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -325,24 +325,22 @@ mod tests {
 
     #[test]
     fn test_lsp_resolve_edges_no_servers_leaves_edges_unmarked() {
-        // When no language servers are available (LSP manager has no clients
-        // for the requested language, or PATH is empty), lsp_resolve_edges
-        // must not burn edges. Regression guard for the per-language gate:
-        // zero successes => zero state=2 markers.
+        // Exercises ONLY the "manager.start() failed" branch: the test runs
+        // wherever pyright is not on PATH (typical CI). The buffered-negative
+        // path (per-language success gate with Ok(None) responses) is not
+        // covered here — it would need an LSP test double and is out of scope
+        // for this regression guard. What this DOES guarantee: when no server
+        // can start, lsp_resolve_edges returns zeros and never burns an edge.
         use cartog_core::{Edge, EdgeKind, Symbol, SymbolKind};
         use cartog_db::Database;
 
         let db = Database::open_memory().unwrap();
-        // Seed a Python edge with no resolution target — heuristic + LSP would
-        // both have to handle this, but here LSP can't even start a server.
         let src = Symbol::new("caller", SymbolKind::Function, "a.py", 1, 5, 0, 100, None);
         db.insert_symbols(std::slice::from_ref(&src)).unwrap();
         let edge = Edge::new(&src.id, "find_user", EdgeKind::Calls, "a.py", 2);
         db.insert_edge(&edge).unwrap();
         let edge_id = db.unresolved_edges().unwrap()[0].edge_id;
 
-        // Drive lsp_resolve_edges with a tempdir as the project root. No PATH
-        // setup → no servers available → all edges should pass through unmarked.
         let tmp = tempfile::tempdir().unwrap();
         let stats = lsp_resolve_edges(&db, tmp.path(), None).unwrap();
         assert_eq!(stats.resolved, 0, "no servers must mean zero resolutions");

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -245,9 +245,10 @@ fn index_with_optional_lsp(
             mcp_err("internal error: database lock poisoned (server restart required)")
         })?;
         match cartog_lsp::lsp_resolve_edges(&db, root, Some(&mut mgr)) {
-            Ok(n) => {
-                result.edges_lsp_resolved = n;
-                if n > 0 {
+            Ok(stats) => {
+                result.edges_lsp_resolved = stats.resolved;
+                result.edges_marked_unresolvable = stats.marked_unresolvable;
+                if stats.resolved > 0 {
                     let _ = db.compute_in_degrees();
                 }
             }
@@ -416,7 +417,7 @@ impl CartogServer {
 
     /// Build or rebuild the code graph index for a directory.
     #[tool(
-        description = "Build or rebuild the code graph index. Run this first before any other cartog tool, or after making code changes to keep the graph current. Incremental by default — only re-indexes changed files. Use force=true if results seem stale. Not for: routine queries (call once per session, not before every read). Returns: {files_indexed, files_skipped, symbols_added, edges_added, edges_resolved, edges_lsp_resolved}."
+        description = "Build or rebuild the code graph index. Run this first before any other cartog tool, or after making code changes to keep the graph current. Incremental by default — only re-indexes changed files. Use force=true if results seem stale. Not for: routine queries (call once per session, not before every read). Returns: {files_indexed, files_skipped, symbols_added, edges_added, edges_resolved, edges_lsp_resolved, edges_marked_unresolvable}."
     )]
     async fn cartog_index(
         &self,

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -147,11 +147,19 @@ pub fn cmd_index(
     let result = result?;
 
     output(&result, json, None, |r| {
-        let lsp_part = if r.edges_lsp_resolved > 0 {
-            format!(
-                " ({} heuristic + {} LSP)",
+        let lsp_part = if r.edges_lsp_resolved > 0 || r.edges_marked_unresolvable > 0 {
+            let mut s = format!(
+                " ({} heuristic + {} LSP",
                 r.edges_resolved, r.edges_lsp_resolved
-            )
+            );
+            if r.edges_marked_unresolvable > 0 {
+                s.push_str(&format!(
+                    ", {} marked unresolvable",
+                    r.edges_marked_unresolvable
+                ));
+            }
+            s.push(')');
+            s
         } else {
             String::new()
         };

--- a/docs/architecture/incremental-indexing.md
+++ b/docs/architecture/incremental-indexing.md
@@ -95,9 +95,7 @@ Tables involved in the incremental pipeline:
 | `symbols` | 3 | `id PK`, `content_hash`, `subtree_hash` |
 | `edges` | 3 | `source_id`, `target_id`, `kind`, `resolution_state` |
 
-`edges.resolution_state` adds a fourth-tier pruning step for the LSP pass: edges marked `2=unresolvable` (LSP definitively could not link them — stdlib targets, dyn dispatch, macros) are skipped on every future LSP run until [`Database::reset_unresolvable_for_names`] reopens them after a new matching symbol is indexed. This keeps the language-server query set small on dirty reindexes.
-
-Column-level schema and additional tables (RAG vectors, FTS5) live in [tech.md](../tech.md).
+Column-level schema, the `resolution_state` lifecycle, and additional tables (RAG vectors, FTS5) live in [tech.md](../tech.md).
 
 ## 8. Failure modes & invariants
 

--- a/docs/architecture/incremental-indexing.md
+++ b/docs/architecture/incremental-indexing.md
@@ -93,7 +93,9 @@ Tables involved in the incremental pipeline:
 | `metadata` | 1 | `last_commit`, `schema_version` |
 | `files` | 2 | `path PK`, `last_modified`, `hash`, `language` |
 | `symbols` | 3 | `id PK`, `content_hash`, `subtree_hash` |
-| `edges` | 3 | `source_id`, `target_id`, `kind` |
+| `edges` | 3 | `source_id`, `target_id`, `kind`, `resolution_state` |
+
+`edges.resolution_state` adds a fourth-tier pruning step for the LSP pass: edges marked `2=unresolvable` (LSP definitively could not link them — stdlib targets, dyn dispatch, macros) are skipped on every future LSP run until [`Database::reset_unresolvable_for_names`] reopens them after a new matching symbol is indexed. This keeps the language-server query set small on dirty reindexes.
 
 Column-level schema and additional tables (RAG vectors, FTS5) live in [tech.md](../tech.md).
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -58,7 +58,7 @@
 | Model cache | `~/.cache/cartog/models` | XDG-compliant shared cache avoids downloading ~1.2 GB of models per project. Precedence: `FASTEMBED_CACHE_DIR` > `XDG_CACHE_HOME/cartog/models` > `~/.cache/cartog/models` |
 | Output format | Human default + `--json` flag (global) | Readable for humans, parseable for scripts. Both `cartog --json stats` and `cartog stats --json` work |
 | Distribution | `cargo install` + pre-built binaries | GitHub Releases for 4 targets (Linux x86/ARM, macOS ARM, Windows x86), crates.io publish, in-place upgrade via `cartog self update` |
-| LSP | Auto-detected (default feature) | Index-time refinement for edges unresolved by heuristics. Auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls, intelephense), sends `textDocument/definition`, shuts down after. Silently skips when no server found. Ready-timeout 20s (override via `CARTOG_LSP_READY_TIMEOUT_SECS`). Disable at runtime with `--no-lsp`; opt out at build time with `cargo install cartog --no-default-features` |
+| LSP | Auto-detected (default feature) | Index-time refinement for edges unresolved by heuristics. Auto-detects language servers on PATH (rust-analyzer, pyright, typescript-language-server, gopls, ruby-lsp, solargraph, jdtls, intelephense), sends `textDocument/definition`, shuts down after. Silently skips when no server found. Ready-timeout 20s (override via `CARTOG_LSP_READY_TIMEOUT_SECS`). Edges LSP definitively cannot resolve are persisted as `resolution_state=2` (skipped on subsequent runs until a matching symbol is added). Disable at runtime with `--no-lsp`; opt out at build time with `cargo install cartog --no-default-features` |
 | MCP response cap | 64 KB per tool result | Prevents oversized JSON from evicting agent context. Truncates at UTF-8 boundary with narrowing hint per tool. Override via `CARTOG_MCP_MAX_BYTES` |
 | RAG tuning | `[rag]` section in `.cartog.toml` | `retrieval_multiplier`, `retrieval_floor`, `rerank_max`, `rerank_min` control FTS5/vector candidate pool size and cross-encoder cost. See [usage.md](usage.md#configuration) |
 | Workspace | Cargo workspace (10 crates) | Incremental compilation, explicit dependency boundaries, independent crate reuse. See [structure.md](structure.md) for layout and dependency graph |
@@ -179,8 +179,8 @@ The database is a regenerable index — crash-recovery safety is traded for thro
 │  (id, name, kind,     (source_id,    (path,   (key,     │
 │   file_path, lines,    target_name,   hash,    value)    │
 │   signature,           target_id,     lang)              │
-│   content_hash,        kind, line)                       │
-│   subtree_hash, ...)                                     │
+│   content_hash,        kind, line,                       │
+│   subtree_hash, ...)   resolution_state)                 │
 ├──────────────────────────────────────────────────────────┤
 │ RAG tables                                               │
 │                                                          │

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,7 +160,7 @@ cartog index src/           # index a subdirectory only
 cartog index . --force      # full re-index, bypassing change detection
 ```
 
-Incremental by default — skips unchanged files (git diff + SHA-256), and within changed files, uses Merkle-tree diffing to update only modified symbols. Stable symbol IDs (`file:kind:qualified_name`) survive line movements, so edges from unchanged files remain valid. Use `--force` when results seem stale or after updating cartog itself.
+Incremental by default — skips unchanged files (git diff + SHA-256), and within changed files, uses Merkle-tree diffing to update only modified symbols. Stable symbol IDs (`file:kind:qualified_name`) survive line movements, so edges from unchanged files remain valid. The LSP pass skips edges marked `resolution_state = 2` (LSP definitively gave up — e.g. stdlib calls, dyn dispatch); they auto-retry when a matching symbol is added. Use `--force` when results seem stale or after updating cartog itself — it also resets all `state=2` markers for a clean retry.
 
 ### `cartog search <query> [--kind <kind>] [--file <path>] [--limit N]`
 

--- a/site/usage.html
+++ b/site/usage.html
@@ -284,7 +284,7 @@ cartog rag setup     <span class="comment"># only downloads embedding model (~80
 cartog index src/           <span class="comment"># index a subdirectory</span>
 cartog index . --force      <span class="comment"># full re-index</span>
 cartog index . --no-lsp     <span class="comment"># heuristic-only (~1-4s)</span></pre>
-      <p>Incremental by default — skips unchanged files (git + SHA-256), and within changed files, uses Merkle-tree diffing to update only modified symbols.</p>
+      <p>Incremental by default — skips unchanged files (git + SHA-256), and within changed files, uses Merkle-tree diffing to update only modified symbols. The LSP pass skips edges already proven unresolvable (LSP returned a definitive "no definition" — e.g. stdlib calls, dyn dispatch); they auto-retry when a matching symbol is added. <code>--force</code> resets those markers for a clean retry.</p>
 
       <h2 id="cmd-search"><code>cartog search &lt;query&gt;</code></h2>
       <p>Find symbols by partial name. Results ranked: exact match → prefix → substring.</p>


### PR DESCRIPTION
## Summary

Follows up [#51](https://github.com/jrollin/cartog/pull/51) (no-op gate). PR #51 made repeated reindexes free; this PR makes **dirty reindexes** also fast by persisting LSP's negative judgments.

Today `cartog index .` on a single-file dirty change spends most of its time re-querying language servers for ~12k edges that LSP already gave up on (stdlib targets, dyn dispatch, macros, glob re-exports). The answer is identical every run — we just never remembered it.

This PR adds an `edges.resolution_state` column (`0=unresolved`, `1=resolved`, `2=unresolvable`). LSP marks state=2 on definitive failures and skips them on subsequent runs. The marker is sticky until a relevant change reopens it.

**Wall-clock dirty single-file reindex:**

| Repo | Files / Edges | Before | After | Speedup |
|---|---|---|---|---|
| cartog | 451 / 23k | 64s | 45s | **1.43×** |
| family-check (TS+Rust+Dart) | 855 / 70k (~41% state=2) | 88s | 43s | **2.07×** |

Remaining cost is dominated by rust-analyzer's ~20s cold start — addressed by warm-manager reuse in a follow-up.

## How it stays correct

Three invalidation paths keep the marker honest:

1. **`reset_unresolvable_for_names(names)`** — indexer collects names of symbols added this run (Merkle's `added` set, or every symbol in a first-time file insert) and reopens any state=2 edge whose `target_name` matches. Fixes the "create `b.ts` after a.ts's import was burned" gap.
2. **`reset_all_unresolvable()`** — `cartog index --force` resets every state=2 marker, preserving the documented "retry everything" contract. Regression test guards this.
3. **`invalidate_edges_targeting()`** — when a target symbol is deleted, the edge drops back to `(target_id=NULL, state=0)` instead of getting stuck at state=1 with a dangling target_id.

Per-language success gate in `cartog-lsp/src/lib.rs`: marks are buffered during the inner loop and only committed if (a) the language server crashed mid-run flag is false AND (b) the language resolved at least one edge this run. Protects against half-loaded rust-analyzer false positives.

## Schema migration (3 → 4)

Non-destructive:

```sql
ALTER TABLE edges ADD COLUMN resolution_state INTEGER NOT NULL DEFAULT 0;
UPDATE edges SET resolution_state = 1 WHERE target_id IS NOT NULL;
-- partial index created post-migration in Database::open
CREATE INDEX IF NOT EXISTS idx_edges_unresolved
  ON edges(file_path) WHERE resolution_state = 0;
```

- No backup needed (no data wipe).
- Pre-v4 binaries open v4 DBs cleanly — they ignore the column and fall back to the slower NULL-based query. **Verified empirically by running the v3 main binary against a v4 DB.**
- One-time priming: existing state=0 edges get re-attacked by LSP once, then settle into state=1/2.

## Edge cases covered

| Concern | Handling |
|---|---|
| LSP transient error (server crash, didOpen IO failure) | Never marks — `Err(_)` branches skipped |
| LSP "ready but half-loaded" (returns `Ok(None)` early) | Per-language gate: zero successes → no marks |
| New symbol added later → previously-burned edge | Indexer's name-keyed reset reopens it |
| Symbol deleted → resolved edge dangling | `invalidate_edges_targeting` resets to state=0 |
| `--force` should retry everything | `reset_all_unresolvable()` called pre-resolve |
| Force re-extracts edges with new auto-increment IDs | Test asserts presence in `unresolved_edges()` rather than ID equality |
| Downgrade to pre-v4 binary | Old `WHERE target_id IS NULL` query still correct; ignores marker |
| Concurrent `cartog index` + `cartog serve --watch` | SQLite WAL + busy_timeout serializes — no new race |

## Test plan

- [x] `cargo test --workspace` (753/753 pass, **+16 new tests**)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New tests:
  - `cartog-db`: migration_3→4 backfill, default-zero on insert, mark/reset round-trips, partial index present, batch-insert default
  - `cartog-indexer`: name-keyed reset on added symbol, no-op preserves markers, `--force` resets markers
  - `cartog-lsp`: no-servers-available leaves edges unmarked
- [x] Real-world migration on family-check v3 DB (70k edges) — backfill 1.5s, schema bumped cleanly
- [x] Downgrade test: pre-v4 binary opens v4 DB without errors

## API changes

- `cartog_lsp::lsp_resolve_edges` now returns `LspResolveStats { resolved, marked_unresolvable }` instead of bare `u32`.
- `IndexResult.edges_marked_unresolvable` (new field, `#[serde(skip_serializing_if = "is_zero")]`).
- `Database` adds: `mark_edge_unresolvable`, `reset_unresolvable_for_names`, `reset_all_unresolvable`, `is_edge_unresolvable` (test inspector).
- MCP tool description updated to list `edges_marked_unresolvable` in `Returns:`.
- CLI summary print: shows `"(N heuristic + M LSP, K marked unresolvable)"` when any marks happen.

## Docs updated

- `docs/tech.md` — LSP row mentions marker; schema sketch shows `resolution_state` column
- `docs/usage.md` — `cartog index` paragraph
- `docs/architecture/incremental-indexing.md` — adds a fourth-tier pruning note
- `crates/cartog-db/README.md` — edges-table description
- `crates/cartog-indexer/README.md` — LSP-resolution subsection
- `crates/cartog-lsp/README.md` — resolution-flow steps
- `site/usage.html` — `cartog index` paragraph
- `CONTRIBUTING.md` — adds `edges_marked_unresolvable` to bench-validation step
- `CHANGELOG.md` **not touched** (generated by `git-cliff` on release)

## Follow-ups (deferred, tracked in [[project_lsp_indexer_followups]])

- Warm `LspManager` reuse in the CLI path — currently the CLI cold-starts rust-analyzer on every dirty index (20s warmup). MCP already does this right.
- Optional `state=3=external` split — distinguish "LSP knows where it is but it's outside indexed root" (stdlib) from "nobody knows" (truly unresolvable). Out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edge resolution state tracking: LSP now marks edges it definitively cannot resolve and skips them on future passes.
  * Auto-reset capability: Previously unresolvable edges are automatically retried when matching symbols are added.
  * Enhanced LSP reporting: Resolution statistics now include count of edges marked unresolvable.
  * `--force` flag now resets unresolvable markers for clean retries.

* **Documentation**
  * Updated schema documentation and usage guides to explain unresolvable edge handling and incremental indexing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->