### PR TITLE
feat(mcp): notifications/progress for cartog_index and cartog_rag_index

### DIFF
--- a/crates/cartog-indexer/README.md
+++ b/crates/cartog-indexer/README.md
@@ -45,8 +45,9 @@ Edges that LSP definitively cannot resolve (stdlib targets, dyn dispatch, macro 
 
 | Export | Description |
 |--------|-------------|
-| `index_directory()` | Main entry point — index a directory into the database |
+| `index_directory()` | Main entry point — index a directory into the database. Optional `progress: Option<ProgressCallback>` fires at coarse phase boundaries (`Walking`, `Parsing`, `Storing`); pass `None` for the no-op default. |
 | `IndexResult` | Summary: files indexed/skipped/removed, symbols added/modified, edges resolved |
+| `ProgressUpdate` / `ProgressCallback` | Plain-data callback types for in-flight phase reporting (transport-agnostic) |
 | `is_ignored_dirname()` | Check if a directory name should be skipped (`.git`, `node_modules`, `target`, etc.) |
 | `git_recently_changed_files()` | List files changed in the last N git commits |
 

--- a/crates/cartog-indexer/benches/indexing.rs
+++ b/crates/cartog-indexer/benches/indexing.rs
@@ -40,7 +40,7 @@ fn bench_indexing(c: &mut Criterion) {
     c.bench_function("index_full_force", |b| {
         b.iter(|| {
             let db = Database::open_memory().unwrap();
-            index_directory(&db, &fixture, true, false).unwrap();
+            index_directory(&db, &fixture, true, false, None).unwrap();
         });
     });
 
@@ -48,9 +48,9 @@ fn bench_indexing(c: &mut Criterion) {
     // before parsing.
     c.bench_function("index_incremental_noop", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture, true, false).unwrap();
+        index_directory(&db, &fixture, true, false, None).unwrap();
         b.iter(|| {
-            index_directory(&db, &fixture, false, false).unwrap();
+            index_directory(&db, &fixture, false, false, None).unwrap();
         });
     });
 
@@ -58,7 +58,7 @@ fn bench_indexing(c: &mut Criterion) {
     // and exercises the Merkle-diff path inside Phase 3.
     c.bench_function("index_incremental_one_file", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture, true, false).unwrap();
+        index_directory(&db, &fixture, true, false, None).unwrap();
         b.iter(|| {
             db.upsert_file(&FileInfo {
                 path: "auth/service.py".to_string(),
@@ -68,7 +68,7 @@ fn bench_indexing(c: &mut Criterion) {
                 num_symbols: 0,
             })
             .unwrap();
-            index_directory(&db, &fixture, false, false).unwrap();
+            index_directory(&db, &fixture, false, false, None).unwrap();
         });
     });
 }

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -136,13 +136,50 @@ fn is_zero(v: &u32) -> bool {
     *v == 0
 }
 
+/// Coarse-grained progress events emitted by [`index_directory`].
+///
+/// Plain data — no transport or runtime types — so callers (CLI, watcher,
+/// MCP, tests) can adapt these to whatever channel they like.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgressUpdate {
+    /// Phase 1 starting: walking the directory tree, collecting candidates.
+    Walking,
+    /// Phase 2 starting: `total` candidates queued for parallel parse/extract.
+    Parsing { total: u32 },
+    /// Phase 3 starting: `total` parsed files about to be written in the
+    /// indexing transaction.
+    Storing { total: u32 },
+}
+
+/// Optional progress callback type accepted by [`index_directory`].
+///
+/// Called synchronously from inside the indexer (never on an async runtime).
+/// Implementations must be cheap and non-blocking.
+pub type ProgressCallback<'a> = &'a (dyn Fn(ProgressUpdate) + Send + Sync);
+
 /// Index a directory, updating the database incrementally.
 ///
 /// Change detection strategy (in order):
 /// 1. `force = true` → re-index everything, no checks
 /// 2. Git-based → diff `last_commit..HEAD` to find changed files, skip the rest without reading
 /// 3. SHA-256 fallback → read file, hash it, compare to stored hash
-pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Result<IndexResult> {
+///
+/// When `progress` is `Some`, the callback fires at each coarse phase boundary
+/// (see [`ProgressUpdate`]). Pass `None` for the no-op default — behavior is
+/// otherwise identical.
+pub fn index_directory(
+    db: &Database,
+    root: &Path,
+    force: bool,
+    lsp: bool,
+    progress: Option<ProgressCallback<'_>>,
+) -> Result<IndexResult> {
+    let emit = |u: ProgressUpdate| {
+        if let Some(cb) = progress {
+            cb(u);
+        }
+    };
+
     let mut result = IndexResult::default();
 
     let root = root.canonicalize().context("Failed to resolve root path")?;
@@ -174,6 +211,7 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
     };
 
     // ── Phase 1: walk + filter candidates (cheap, single-threaded) ──
+    emit(ProgressUpdate::Walking);
     let mut candidates: Vec<(PathBuf, String, &'static str)> = Vec::new();
     for entry in WalkDir::new(&root)
         .follow_links(true)
@@ -216,6 +254,9 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
     }
 
     // ── Phase 2: parallel parse + extract (CPU-bound, rayon-worker pool) ──
+    emit(ProgressUpdate::Parsing {
+        total: candidates.len() as u32,
+    });
     let parsed: Vec<ParseOutput> = candidates
         .par_iter()
         .map(|(abs, rel, lang)| {
@@ -246,6 +287,9 @@ pub fn index_directory(db: &Database, root: &Path, force: bool, lsp: bool) -> Re
     let mut added_symbol_names: std::collections::HashSet<String> =
         std::collections::HashSet::new();
 
+    emit(ProgressUpdate::Storing {
+        total: parsed.len() as u32,
+    });
     let tx = db.begin_indexing_tx()?;
     for item in parsed {
         let (rel_path, lang, source, hash, modified, symbols, edges) = match item {
@@ -1025,12 +1069,12 @@ mod tests {
 
         if fixtures.exists() {
             // First index
-            let r1 = index_directory(&db, &fixtures, false, false).unwrap();
+            let r1 = index_directory(&db, &fixtures, false, false, None).unwrap();
             assert!(r1.files_indexed > 0);
             assert!(r1.dirty_files > 0);
 
             // Second index without force — should skip all files (no-op)
-            let r2 = index_directory(&db, &fixtures, false, false).unwrap();
+            let r2 = index_directory(&db, &fixtures, false, false, None).unwrap();
             assert_eq!(r2.files_indexed, 0);
             assert!(r2.files_skipped > 0);
             assert_eq!(
@@ -1043,7 +1087,7 @@ mod tests {
             );
 
             // Force re-index — dirty_files matches files_indexed
-            let r3 = index_directory(&db, &fixtures, true, false).unwrap();
+            let r3 = index_directory(&db, &fixtures, true, false, None).unwrap();
             assert_eq!(r3.files_indexed, r1.files_indexed);
             assert_eq!(r3.files_skipped, 0);
             assert_eq!(r3.dirty_files, r3.files_indexed);
@@ -1064,9 +1108,9 @@ mod tests {
 
         // Prime, then re-run. Don't assert LSP found anything (depends on
         // whether pyright is on PATH in CI) — only that the second pass skips it.
-        let _ = index_directory(&db, &fixtures, false, true).unwrap();
+        let _ = index_directory(&db, &fixtures, false, true, None).unwrap();
 
-        let r2 = index_directory(&db, &fixtures, false, true).unwrap();
+        let r2 = index_directory(&db, &fixtures, false, true, None).unwrap();
         assert_eq!(r2.dirty_files, 0);
         assert_eq!(r2.edges_lsp_resolved, 0);
     }
@@ -1085,7 +1129,7 @@ mod tests {
         std::fs::write(root.join("a.py"), "def caller():\n    find_user('x')\n").unwrap();
 
         let db = Database::open_memory().unwrap();
-        let r1 = index_directory(&db, &root, false, false).unwrap();
+        let r1 = index_directory(&db, &root, false, false, None).unwrap();
         assert!(
             r1.files_indexed >= 1,
             "expected a.py to index, got {:?}",
@@ -1103,7 +1147,7 @@ mod tests {
 
         // Adding b.py with find_user definition should reopen the marker.
         std::fs::write(root.join("b.py"), "def find_user(name):\n    return None\n").unwrap();
-        index_directory(&db, &root, false, false).unwrap();
+        index_directory(&db, &root, false, false, None).unwrap();
 
         assert!(
             !db.is_edge_unresolvable(edge_id).unwrap(),
@@ -1129,7 +1173,7 @@ mod tests {
         std::fs::write(root.join("a.py"), "def caller():\n    find_x()\n").unwrap();
 
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &root, false, false).unwrap();
+        index_directory(&db, &root, false, false, None).unwrap();
 
         let pre = db.unresolved_edges().unwrap();
         let find_x_id = pre
@@ -1140,7 +1184,7 @@ mod tests {
         db.mark_edge_unresolvable(find_x_id).unwrap();
 
         // --force = true: rebuilds edges with fresh IDs, must NOT inherit state=2.
-        index_directory(&db, &root, true, false).unwrap();
+        index_directory(&db, &root, true, false, None).unwrap();
         let post = db.unresolved_edges().unwrap();
         let has_find_x_unresolved = post.iter().any(|e| e.target_name == "find_x");
         assert!(
@@ -1165,7 +1209,7 @@ mod tests {
         .unwrap();
 
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &root, false, false).unwrap();
+        index_directory(&db, &root, false, false, None).unwrap();
 
         let unresolved = db.unresolved_edges().unwrap();
         let target = unresolved
@@ -1175,7 +1219,7 @@ mod tests {
         db.mark_edge_unresolvable(target.edge_id).unwrap();
 
         // No file changes → reindex is a no-op → marker survives.
-        let r = index_directory(&db, &root, false, false).unwrap();
+        let r = index_directory(&db, &root, false, false, None).unwrap();
         assert_eq!(r.dirty_files, 0);
 
         assert!(
@@ -1509,7 +1553,7 @@ def main():
         let db = Database::open_memory().unwrap();
 
         // ── Index 1: initial full index ──
-        let r1 = index_directory(&db, &dir, true, false).unwrap();
+        let r1 = index_directory(&db, &dir, true, false, None).unwrap();
         assert_eq!(r1.files_indexed, 2);
         assert!(r1.symbols_added > 0, "should have symbols");
 
@@ -1558,7 +1602,7 @@ def standalone():
         )
         .unwrap();
 
-        let r2 = index_directory(&db, &dir, false, false).unwrap();
+        let r2 = index_directory(&db, &dir, false, false, None).unwrap();
         assert_eq!(r2.files_indexed, 1, "only a.py changed");
         assert!(r2.files_skipped > 0, "b.py should be skipped");
         assert_eq!(r2.symbols_added, 1, "standalone is new");
@@ -1605,7 +1649,7 @@ def standalone():
         )
         .unwrap();
 
-        let r3 = index_directory(&db, &dir, false, false).unwrap();
+        let r3 = index_directory(&db, &dir, false, false, None).unwrap();
         assert_eq!(r3.files_indexed, 1);
         assert!(r3.symbols_removed >= 1, "goodbye should be removed");
 
@@ -1659,7 +1703,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         .unwrap();
 
         let db = Database::open_memory().unwrap();
-        let result = index_directory(&db, &dir, false, false).unwrap();
+        let result = index_directory(&db, &dir, false, false, None).unwrap();
 
         assert_eq!(result.files_indexed, 1);
         assert!(result.symbols_added >= 3, "should have at least 3 sections");
@@ -1737,7 +1781,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         std::fs::write(dir.join("seed.py"), "def keep_me():\n    return 1\n").unwrap();
 
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &dir, true, false).expect("seed index should succeed");
+        index_directory(&db, &dir, true, false, None).expect("seed index should succeed");
 
         // Snapshot the seed state so we can assert it is preserved across the
         // failed run.
@@ -1768,7 +1812,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         // new functions through Phase 3.
         db.set_max_page_count_for_tests(30).unwrap();
 
-        let result = index_directory(&db, &dir, false, false);
+        let result = index_directory(&db, &dir, false, false, None);
         assert!(
             result.is_err(),
             "Phase 3 must fail when SQLite runs out of pages; got Ok({result:?})"
@@ -1806,5 +1850,90 @@ We use PostgreSQL with connection pooling via pgbouncer.
             .find(|s| s.id == seed_keep_me_id)
             .unwrap();
         assert_eq!(kept.kind, SymbolKind::Function);
+    }
+
+    // ── progress callback ──
+
+    fn tiny_python_project() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap().join("project");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("a.py"), "def f():\n    pass\n").unwrap();
+        std::fs::write(root.join("b.py"), "def g():\n    pass\n").unwrap();
+        (tmp, root)
+    }
+
+    #[test]
+    fn progress_callback_fires_in_phase_order() {
+        use cartog_db::Database;
+        use std::sync::Mutex;
+
+        let (_tmp, root) = tiny_python_project();
+        let db = Database::open_memory().unwrap();
+
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        let result = index_directory(&db, &root, true, false, Some(&cb)).unwrap();
+
+        assert!(result.files_indexed >= 2);
+        let events = events.into_inner().unwrap();
+        assert_eq!(events.len(), 3, "expected 3 phase events, got {events:?}");
+        assert_eq!(events[0], ProgressUpdate::Walking);
+        assert!(matches!(events[1], ProgressUpdate::Parsing { total } if total >= 2));
+        assert!(matches!(events[2], ProgressUpdate::Storing { total } if total >= 2));
+    }
+
+    #[test]
+    fn progress_callback_none_matches_some_for_result() {
+        use cartog_db::Database;
+
+        let (_t1, root1) = tiny_python_project();
+        let db1 = Database::open_memory().unwrap();
+        let r_none = index_directory(&db1, &root1, true, false, None).unwrap();
+
+        let (_t2, root2) = tiny_python_project();
+        let db2 = Database::open_memory().unwrap();
+        let cb = |_: ProgressUpdate| {};
+        let r_some = index_directory(&db2, &root2, true, false, Some(&cb)).unwrap();
+
+        // Different temp dirs → different file modified-times can shift, but the
+        // count-based fields of IndexResult are deterministic on a fresh DB.
+        assert_eq!(r_none.files_indexed, r_some.files_indexed);
+        assert_eq!(r_none.symbols_added, r_some.symbols_added);
+        assert_eq!(r_none.edges_added, r_some.edges_added);
+    }
+
+    /// Realistic-repo smoke. Opt in by setting CARTOG_INTEGRATION_FIXTURE
+    /// to a directory containing real source (e.g. the cartog repo itself
+    /// or any sibling project on the local machine). Skipped otherwise so
+    /// CI and tree-clean runs never depend on external paths.
+    #[test]
+    fn progress_callback_realistic_repo() {
+        use cartog_db::Database;
+        use std::sync::Mutex;
+
+        let Ok(fixture) = std::env::var("CARTOG_INTEGRATION_FIXTURE") else {
+            eprintln!("skipped: CARTOG_INTEGRATION_FIXTURE not set");
+            return;
+        };
+        let root = PathBuf::from(fixture);
+        if !root.is_dir() {
+            eprintln!("skipped: CARTOG_INTEGRATION_FIXTURE is not a directory");
+            return;
+        }
+
+        let db = Database::open_memory().unwrap();
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        index_directory(&db, &root, true, false, Some(&cb)).unwrap();
+
+        let events = events.into_inner().unwrap();
+        assert!(matches!(events.first(), Some(ProgressUpdate::Walking)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ProgressUpdate::Parsing { total } if *total > 0)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ProgressUpdate::Storing { total } if *total > 0)));
     }
 }

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -287,8 +287,16 @@ pub fn index_directory(
     let mut added_symbol_names: std::collections::HashSet<String> =
         std::collections::HashSet::new();
 
+    // `total` here is the number of files that will actually be written, not
+    // the parsed-vec length: `ParseOutput::Skipped` short-circuits before the
+    // DB write and `ParseOutput::Failed` is dropped. Without this filter a
+    // warm re-index reports `storing N` where N is the full candidate set.
+    let storing_total = parsed
+        .iter()
+        .filter(|p| matches!(p, ParseOutput::Parsed { .. }))
+        .count() as u32;
     emit(ProgressUpdate::Storing {
-        total: parsed.len() as u32,
+        total: storing_total,
     });
     let tx = db.begin_indexing_tx()?;
     for item in parsed {

--- a/crates/cartog-mcp/README.md
+++ b/crates/cartog-mcp/README.md
@@ -42,6 +42,10 @@ All user-supplied paths are validated against the project root:
 - Tool handlers run on `tokio::task::spawn_blocking` to avoid blocking the async runtime during SQLite queries
 - Optional background watch thread via `cartog-watch` for live re-indexing during MCP sessions
 
+### Progress notifications
+
+`cartog_index` and `cartog_rag_index` emit standard MCP `notifications/progress` events when the client supplies a `progressToken` in the request's `_meta`. The bridge lives in `src/progress.rs`: a bounded mpsc channel decouples the blocking indexer (best-effort `try_send`) from an async forwarder that calls `Peer::notify_progress` with a monotonic counter. Clients that don't subscribe see byte-identical behavior to the no-token path.
+
 ## Public API
 
 | Export | Description |

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -10,9 +10,10 @@ use rmcp::schemars;
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::*,
+    service::RequestContext,
     tool, tool_handler, tool_router,
     transport::stdio,
-    ErrorData as McpError, ServerHandler, ServiceExt,
+    ErrorData as McpError, RoleServer, ServerHandler, ServiceExt,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -24,6 +25,8 @@ use cartog_indexer as indexer;
 use cartog_rag as rag;
 use cartog_watch as watch;
 use cartog_watch::{WatchConfig, WatchHandle};
+
+mod progress;
 
 const MAX_IMPACT_DEPTH: u32 = 10;
 
@@ -228,16 +231,25 @@ fn index_with_optional_lsp(
     lsp_manager: &Arc<Mutex<cartog_lsp::manager::LspManager>>,
     root: &Path,
     force: bool,
+    progress_tx: Option<tokio::sync::mpsc::Sender<progress::Phase>>,
 ) -> Result<indexer::IndexResult, McpError> {
+    let indexer_cb = progress_tx
+        .as_ref()
+        .map(|tx| progress::indexer_callback(tx.clone()));
     let mut result = {
         let db = db.lock().map_err(|_| {
             mcp_err("internal error: database lock poisoned (server restart required)")
         })?;
-        indexer::index_directory(&db, root, force, false, None)
+        let cb_ref: Option<&(dyn Fn(indexer::ProgressUpdate) + Send + Sync)> =
+            indexer_cb.as_ref().map(|f| f as _);
+        indexer::index_directory(&db, root, force, false, cb_ref)
             .map_err(|e| mcp_err(format!("indexing failed: {e}")))?
     };
 
     if result.dirty_files > 0 {
+        if let Some(tx) = progress_tx.as_ref() {
+            let _ = tx.try_send(progress::Phase::Custom("resolving with LSP"));
+        }
         let mut mgr = lsp_manager.lock().map_err(|_| {
             mcp_err("internal error: LSP manager lock poisoned (server restart required)")
         })?;
@@ -267,11 +279,17 @@ fn index_with_optional_lsp(
     _lsp_manager: &(),
     root: &Path,
     force: bool,
+    progress_tx: Option<tokio::sync::mpsc::Sender<progress::Phase>>,
 ) -> Result<indexer::IndexResult, McpError> {
+    let indexer_cb = progress_tx
+        .as_ref()
+        .map(|tx| progress::indexer_callback(tx.clone()));
     let db = db
         .lock()
         .map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
-    indexer::index_directory(&db, root, force, false, None)
+    let cb_ref: Option<&(dyn Fn(indexer::ProgressUpdate) + Send + Sync)> =
+        indexer_cb.as_ref().map(|f| f as _);
+    indexer::index_directory(&db, root, force, false, cb_ref)
         .map_err(|e| mcp_err(format!("indexing failed: {e}")))
 }
 
@@ -554,6 +572,7 @@ impl CartogServer {
     async fn cartog_index(
         &self,
         Parameters(params): Parameters<IndexParams>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(err) = self.refuse_if_read_only("cartog_index") {
             return Err(err);
@@ -567,10 +586,20 @@ impl CartogServer {
         #[cfg(not(feature = "lsp"))]
         let lsp_manager: () = ();
 
-        tokio::task::spawn_blocking(move || {
+        let (progress_tx, forwarder) = match ctx.meta.get_progress_token() {
+            Some(token) => {
+                let notifier = progress::peer_notifier(ctx.peer.clone());
+                let fwd = progress::spawn_forwarder(token, notifier);
+                (Some(fwd.tx.clone()), Some(fwd))
+            }
+            None => (None, None),
+        };
+
+        let result = tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "indexing directory");
-            let result = index_with_optional_lsp(&db, &lsp_manager, &validated, force)?;
+            let result =
+                index_with_optional_lsp(&db, &lsp_manager, &validated, force, progress_tx)?;
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -582,7 +611,18 @@ impl CartogServer {
             Ok(CallToolResult::success(vec![Content::text(text)]))
         })
         .await
-        .map_err(|e| mcp_err(format!("task join failed: {e}")))?
+        .map_err(|e| mcp_err(format!("task join failed: {e}")))?;
+
+        // Drain the forwarder before returning so all queued notifications
+        // are written to the transport. The blocking closure already dropped
+        // its progress_tx clone; the Forwarder still holds one — drop it now
+        // so recv() can return None and the forwarder can exit.
+        if let Some(fwd) = forwarder {
+            drop(fwd.tx);
+            let _ = fwd.join.await;
+        }
+
+        result
     }
 
     /// Show symbols and structure of a file without reading its content.
@@ -978,6 +1018,7 @@ impl CartogServer {
     async fn cartog_rag_index(
         &self,
         Parameters(params): Parameters<RagIndexParams>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(err) = self.refuse_if_read_only("cartog_rag_index") {
             return Err(err);
@@ -988,7 +1029,16 @@ impl CartogServer {
         let cwd = Arc::clone(&self.cwd);
         let provider = Arc::clone(&self.embedding_provider);
 
-        tokio::task::spawn_blocking(move || {
+        let (progress_tx, forwarder) = match ctx.meta.get_progress_token() {
+            Some(token) => {
+                let notifier = progress::peer_notifier(ctx.peer.clone());
+                let fwd = progress::spawn_forwarder(token, notifier);
+                (Some(fwd.tx.clone()), Some(fwd))
+            }
+            None => (None, None),
+        };
+
+        let result = tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "rag index");
 
@@ -996,7 +1046,10 @@ impl CartogServer {
                 mcp_err("internal error: database lock poisoned (server restart required)")
             })?;
 
-            // Ensure the code graph index is up to date first
+            // Ensure the code graph index is up to date first. Inner phases are
+            // intentionally suppressed: the RAG tool exposes only rag-specific
+            // phases (preparing/embedding/storing) so the client-facing
+            // vocabulary stays stable.
             let _ = indexer::index_directory(&db, &validated, false, false, None)
                 .map_err(|e| mcp_err(format!("code graph indexing failed: {e}")))?;
 
@@ -1005,7 +1058,14 @@ impl CartogServer {
                     "internal error: embedding provider lock poisoned (server restart required)",
                 )
             })?;
-            let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force, None)
+
+            let rag_cb = progress_tx
+                .as_ref()
+                .map(|tx| progress::rag_callback(tx.clone()));
+            let cb_ref: Option<&(dyn Fn(rag::indexer::ProgressUpdate) + Send + Sync)> =
+                rag_cb.as_ref().map(|f| f as _);
+
+            let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force, cb_ref)
                 .map_err(|e| mcp_err(format!("embedding indexing failed: {e}")))?;
 
             let json = serde_json::to_string_pretty(&result)
@@ -1013,7 +1073,14 @@ impl CartogServer {
             Ok(CallToolResult::success(vec![Content::text(json)]))
         })
         .await
-        .map_err(|e| mcp_err(format!("task join failed: {e}")))?
+        .map_err(|e| mcp_err(format!("task join failed: {e}")))?;
+
+        if let Some(fwd) = forwarder {
+            drop(fwd.tx);
+            let _ = fwd.join.await;
+        }
+
+        result
     }
 
     /// Semantic search over code symbols using hybrid FTS5 + vector search.
@@ -2108,7 +2175,7 @@ mod tests {
 
         // First call primes the index. dirty_files > 0 → LSP is allowed (it may
         // resolve nothing if pyright isn't on PATH, but the gate must let it run).
-        let r1 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false).unwrap();
+        let r1 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false, None).unwrap();
         assert!(
             r1.dirty_files > 0,
             "first index must report dirty files (got {})",
@@ -2116,7 +2183,7 @@ mod tests {
         );
 
         // Second call without changes must be a no-op AND must skip LSP.
-        let r2 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false).unwrap();
+        let r2 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false, None).unwrap();
         assert_eq!(r2.dirty_files, 0);
         assert_eq!(
             r2.edges_lsp_resolved, 0,

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -1005,7 +1005,7 @@ impl CartogServer {
                     "internal error: embedding provider lock poisoned (server restart required)",
                 )
             })?;
-            let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force)
+            let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force, None)
                 .map_err(|e| mcp_err(format!("embedding indexing failed: {e}")))?;
 
             let json = serde_json::to_string_pretty(&result)

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -595,7 +595,7 @@ impl CartogServer {
             None => (None, None),
         };
 
-        let result = tokio::task::spawn_blocking(move || {
+        let join = tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "indexing directory");
             let result =
@@ -610,19 +610,18 @@ impl CartogServer {
             }
             Ok(CallToolResult::success(vec![Content::text(text)]))
         })
-        .await
-        .map_err(|e| mcp_err(format!("task join failed: {e}")))?;
+        .await;
 
-        // Drain the forwarder before returning so all queued notifications
-        // are written to the transport. The blocking closure already dropped
-        // its progress_tx clone; the Forwarder still holds one — drop it now
-        // so recv() can return None and the forwarder can exit.
+        // Drain the forwarder unconditionally — even on join error or tool
+        // error — so the spawned task doesn't leak waiting on `rx.recv()`.
+        // The blocking closure already dropped its progress_tx clone; the
+        // Forwarder still holds one, so we drop it here to close the channel.
         if let Some(fwd) = forwarder {
             drop(fwd.tx);
             let _ = fwd.join.await;
         }
 
-        result
+        join.map_err(|e| mcp_err(format!("task join failed: {e}")))?
     }
 
     /// Show symbols and structure of a file without reading its content.
@@ -1038,7 +1037,7 @@ impl CartogServer {
             None => (None, None),
         };
 
-        let result = tokio::task::spawn_blocking(move || {
+        let join = tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "rag index");
 
@@ -1072,15 +1071,15 @@ impl CartogServer {
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             Ok(CallToolResult::success(vec![Content::text(json)]))
         })
-        .await
-        .map_err(|e| mcp_err(format!("task join failed: {e}")))?;
+        .await;
 
+        // Drain the forwarder unconditionally — see cartog_index for rationale.
         if let Some(fwd) = forwarder {
             drop(fwd.tx);
             let _ = fwd.join.await;
         }
 
-        result
+        join.map_err(|e| mcp_err(format!("task join failed: {e}")))?
     }
 
     /// Semantic search over code symbols using hybrid FTS5 + vector search.

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -233,7 +233,7 @@ fn index_with_optional_lsp(
         let db = db.lock().map_err(|_| {
             mcp_err("internal error: database lock poisoned (server restart required)")
         })?;
-        indexer::index_directory(&db, root, force, false)
+        indexer::index_directory(&db, root, force, false, None)
             .map_err(|e| mcp_err(format!("indexing failed: {e}")))?
     };
 
@@ -271,7 +271,7 @@ fn index_with_optional_lsp(
     let db = db
         .lock()
         .map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
-    indexer::index_directory(&db, root, force, false)
+    indexer::index_directory(&db, root, force, false, None)
         .map_err(|e| mcp_err(format!("indexing failed: {e}")))
 }
 
@@ -997,7 +997,7 @@ impl CartogServer {
             })?;
 
             // Ensure the code graph index is up to date first
-            let _ = indexer::index_directory(&db, &validated, false, false)
+            let _ = indexer::index_directory(&db, &validated, false, false, None)
                 .map_err(|e| mcp_err(format!("code graph indexing failed: {e}")))?;
 
             let mut provider = provider.lock().map_err(|_| {

--- a/crates/cartog-mcp/src/progress.rs
+++ b/crates/cartog-mcp/src/progress.rs
@@ -1,0 +1,248 @@
+//! Bridge between cartog's library-level progress callbacks and MCP
+//! `notifications/progress`.
+//!
+//! Long-running tools (`cartog_index`, `cartog_rag_index`) accept a
+//! synchronous callback and run inside `tokio::task::spawn_blocking`. The
+//! bridge converts those synchronous events into asynchronous
+//! `notifications/progress` calls on the MCP peer, gated on the request
+//! supplying a `progressToken` in `_meta`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use rmcp::model::{ProgressNotificationParam, ProgressToken};
+use tokio::sync::mpsc;
+
+/// Internal, transport-neutral phase event shipped from a blocking task to
+/// the async forwarder. Each variant maps to a `ProgressNotificationParam`
+/// via [`Phase::into_message_and_total`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum Phase {
+    Indexer(cartog_indexer::ProgressUpdate),
+    Rag(cartog_rag::indexer::ProgressUpdate),
+    /// Free-form phase added by the MCP layer (e.g. `Resolving` after the
+    /// LSP edge-resolution pass).
+    Custom(&'static str),
+}
+
+impl Phase {
+    /// Render `(message, total)` for [`ProgressNotificationParam`].
+    ///
+    /// The `progress` counter itself is owned by the forwarder so it can
+    /// stay monotonic across phases (the MCP spec requires this).
+    pub fn into_message_and_total(self) -> (String, Option<f64>) {
+        use cartog_indexer::ProgressUpdate as IxU;
+        use cartog_rag::indexer::ProgressUpdate as RgU;
+        match self {
+            Phase::Indexer(IxU::Walking) => ("walking".into(), None),
+            Phase::Indexer(IxU::Parsing { total }) => {
+                (format!("parsing {total} files"), Some(total as f64))
+            }
+            Phase::Indexer(IxU::Storing { total }) => {
+                (format!("storing {total} files"), Some(total as f64))
+            }
+            Phase::Rag(RgU::Preparing) => ("preparing".into(), None),
+            Phase::Rag(RgU::Embedding { processed, total }) => {
+                (format!("embedding {processed}/{total}"), Some(total as f64))
+            }
+            Phase::Rag(RgU::Storing) => ("storing".into(), None),
+            Phase::Custom(s) => (s.into(), None),
+        }
+    }
+}
+
+/// Async notification dispatcher. Real impl wraps an rmcp `Peer`; tests
+/// substitute a closure that pushes into a `Vec`.
+pub type Notifier = Arc<
+    dyn Fn(ProgressNotificationParam) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+>;
+
+/// Build a [`Notifier`] backed by an rmcp server peer. Errors from
+/// `notify_progress` are intentionally swallowed — progress is best-effort.
+pub fn peer_notifier(peer: rmcp::Peer<rmcp::RoleServer>) -> Notifier {
+    Arc::new(move |param| {
+        let peer = peer.clone();
+        Box::pin(async move {
+            if let Err(e) = peer.notify_progress(param).await {
+                tracing::debug!("notify_progress dropped: {e}");
+            }
+        })
+    })
+}
+
+/// Handle returned by [`spawn_forwarder`]. Drop the `tx` to signal "no more
+/// events"; the forwarder drains then exits. Then `await` the join handle
+/// so every queued notification is written before the tool result returns.
+pub struct Forwarder {
+    pub tx: mpsc::Sender<Phase>,
+    pub join: tokio::task::JoinHandle<()>,
+}
+
+/// Bounded channel capacity. Phase events from both tools are sparse (at
+/// most ~`N/512 + 3` for very large RAG runs), so 64 is comfortable. We
+/// use `try_send` on the producer side so a stalled client cannot block
+/// the indexer thread; dropped events are logged at debug level.
+const CHANNEL_CAPACITY: usize = 64;
+
+/// Spawn an async forwarder that consumes [`Phase`] events from `rx` and
+/// pushes them to `notifier` as `notifications/progress` with the given
+/// token.
+///
+/// `progress` is a monotonically-increasing counter incremented once per
+/// emitted event, per the MCP spec.
+pub fn spawn_forwarder(token: ProgressToken, notifier: Notifier) -> Forwarder {
+    let (tx, mut rx) = mpsc::channel::<Phase>(CHANNEL_CAPACITY);
+    let join = tokio::spawn(async move {
+        let mut counter: f64 = 0.0;
+        while let Some(phase) = rx.recv().await {
+            counter += 1.0;
+            let (message, total) = phase.into_message_and_total();
+            (notifier)(ProgressNotificationParam {
+                progress_token: token.clone(),
+                progress: counter,
+                total,
+                message: Some(message),
+            })
+            .await;
+        }
+    });
+    Forwarder { tx, join }
+}
+
+/// Build a library-side callback from an mpsc sender. The returned closure
+/// is `'static`, `Send`, `Sync`, suitable for handing to library code that
+/// will run inside `tokio::task::spawn_blocking`.
+///
+/// Events are sent best-effort via `try_send`. If the forwarder has been
+/// dropped or the channel is full, the event is silently discarded.
+pub fn indexer_callback(
+    tx: mpsc::Sender<Phase>,
+) -> impl Fn(cartog_indexer::ProgressUpdate) + Send + Sync + 'static {
+    move |u| {
+        if tx.try_send(Phase::Indexer(u)).is_err() {
+            tracing::debug!("progress channel full or closed; dropping event");
+        }
+    }
+}
+
+/// Same as [`indexer_callback`] for the RAG indexer.
+pub fn rag_callback(
+    tx: mpsc::Sender<Phase>,
+) -> impl Fn(cartog_rag::indexer::ProgressUpdate) + Send + Sync + 'static {
+    move |u| {
+        if tx.try_send(Phase::Rag(u)).is_err() {
+            tracing::debug!("progress channel full or closed; dropping event");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cartog_indexer::ProgressUpdate as IxU;
+    use cartog_rag::indexer::ProgressUpdate as RgU;
+    use rmcp::model::NumberOrString;
+    use std::sync::Mutex;
+
+    fn token() -> ProgressToken {
+        ProgressToken(NumberOrString::String("test-token".into()))
+    }
+
+    fn capturing_notifier() -> (Notifier, Arc<Mutex<Vec<ProgressNotificationParam>>>) {
+        let events: Arc<Mutex<Vec<ProgressNotificationParam>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let notifier: Notifier = Arc::new(move |param| {
+            let captured = Arc::clone(&captured);
+            Box::pin(async move {
+                captured.lock().unwrap().push(param);
+            })
+        });
+        (notifier, events)
+    }
+
+    #[tokio::test]
+    async fn forwarder_emits_one_notification_per_event_in_order() {
+        let (notifier, events) = capturing_notifier();
+        let fwd = spawn_forwarder(token(), notifier);
+
+        let cb = indexer_callback(fwd.tx.clone());
+        cb(IxU::Walking);
+        cb(IxU::Parsing { total: 7 });
+        cb(IxU::Storing { total: 5 });
+
+        drop(cb);
+        drop(fwd.tx);
+        fwd.join.await.unwrap();
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        assert!(events[0].progress < events[1].progress);
+        assert!(events[1].progress < events[2].progress);
+        assert_eq!(events[0].message.as_deref(), Some("walking"));
+        assert_eq!(events[1].message.as_deref(), Some("parsing 7 files"));
+        assert_eq!(events[2].message.as_deref(), Some("storing 5 files"));
+        assert_eq!(events[0].total, None);
+        assert_eq!(events[1].total, Some(7.0));
+        assert_eq!(events[2].total, Some(5.0));
+    }
+
+    #[tokio::test]
+    async fn rag_callback_round_trips_through_forwarder() {
+        let (notifier, events) = capturing_notifier();
+        let fwd = spawn_forwarder(token(), notifier);
+
+        let cb = rag_callback(fwd.tx.clone());
+        cb(RgU::Preparing);
+        cb(RgU::Embedding {
+            processed: 512,
+            total: 1024,
+        });
+        cb(RgU::Storing);
+
+        drop(cb);
+        drop(fwd.tx);
+        fwd.join.await.unwrap();
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].message.as_deref(), Some("preparing"));
+        assert_eq!(events[1].message.as_deref(), Some("embedding 512/1024"));
+        assert_eq!(events[1].total, Some(1024.0));
+        assert_eq!(events[2].message.as_deref(), Some("storing"));
+    }
+
+    #[tokio::test]
+    async fn custom_phase_is_forwarded() {
+        let (notifier, events) = capturing_notifier();
+        let fwd = spawn_forwarder(token(), notifier);
+
+        fwd.tx
+            .send(Phase::Custom("resolving with LSP"))
+            .await
+            .unwrap();
+        drop(fwd.tx);
+        fwd.join.await.unwrap();
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message.as_deref(), Some("resolving with LSP"));
+    }
+
+    #[tokio::test]
+    async fn dropped_sender_lets_forwarder_exit_cleanly() {
+        let (notifier, events) = capturing_notifier();
+        let fwd = spawn_forwarder(token(), notifier);
+        drop(fwd.tx);
+        fwd.join.await.unwrap();
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn full_channel_drops_event_silently_without_panic() {
+        let (tx, _rx) = mpsc::channel::<Phase>(1);
+        let cb = indexer_callback(tx);
+        cb(IxU::Walking);
+        cb(IxU::Parsing { total: 1 });
+    }
+}

--- a/crates/cartog-mcp/src/progress.rs
+++ b/crates/cartog-mcp/src/progress.rs
@@ -22,7 +22,10 @@ pub enum Phase {
     Indexer(cartog_indexer::ProgressUpdate),
     Rag(cartog_rag::indexer::ProgressUpdate),
     /// Free-form phase added by the MCP layer (e.g. `Resolving` after the
-    /// LSP edge-resolution pass).
+    /// LSP edge-resolution pass). Only constructed when the `lsp` feature
+    /// is enabled; `#[allow(dead_code)]` keeps `cargo check
+    /// --no-default-features` clean.
+    #[allow(dead_code)]
     Custom(&'static str),
 }
 

--- a/crates/cartog-rag/README.md
+++ b/crates/cartog-rag/README.md
@@ -61,7 +61,8 @@ Providers are created per-command invocation via `create_embedding_provider(conf
 | `provider::EmbeddingProvider` | Trait for embedding backends |
 | `provider::RerankerProvider` | Trait for reranker backends |
 | `search::hybrid_search()` | Run the full hybrid search pipeline |
-| `indexer::index_embeddings()` | Embed symbols and write vectors to DB |
+| `indexer::index_embeddings()` | Embed symbols and write vectors to DB. Optional `progress: Option<ProgressCallback>` fires per batch (`Preparing`, `Embedding{processed,total}`, `Storing`); pass `None` for no-op. |
+| `indexer::ProgressUpdate` / `indexer::ProgressCallback` | Plain-data callback types for in-flight phase reporting (transport-agnostic) |
 | `setup::download_model()` | Download the embedding model (local provider) |
 | `EMBEDDING_DIM` | Default vector dimension (384) |
 

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -290,13 +290,11 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
         }
     }
 
-    // Always emit Storing when there was work to do, even if the last
-    // flush_embedding_batch already drained db_batch via DB_BATCH_LIMIT.
-    // Clients use Storing as the final-phase marker; suppressing it on
-    // large runs would leave the progress UI stuck at "embedding N/N".
-    if !pairs.is_empty() {
-        emit(ProgressUpdate::Storing);
-    }
+    // Always emit Storing once Preparing has fired (i.e. symbol_ids was
+    // non-empty at line 233). Closes the progress sequence even when every
+    // symbol was filtered out (empty pairs, no Embedding events) so clients
+    // never get stuck on a lone "preparing" event with no terminal marker.
+    emit(ProgressUpdate::Storing);
     if !db_batch.is_empty() {
         db.insert_embeddings(&db_batch)?;
     }
@@ -602,6 +600,44 @@ mod tests {
         index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
 
         assert!(events.into_inner().unwrap().is_empty());
+    }
+
+    /// Regression: when symbol_ids is non-empty but every symbol is filtered
+    /// out (content too small for MIN_EMBED_TEXT_BYTES, or missing from the
+    /// content map), pairs ends up empty and no Embedding event fires. The
+    /// final Storing must still be emitted so the client sees a terminal
+    /// phase marker after Preparing and isn't left waiting forever.
+    #[test]
+    fn progress_callback_emits_storing_when_all_symbols_filtered() {
+        use std::sync::Mutex;
+
+        let db = Database::open_memory().unwrap();
+        // Seed two symbols whose content + header are below MIN_EMBED_TEXT_BYTES
+        // (40). Both will be filtered, leaving pairs empty.
+        for i in 0..2 {
+            let name = format!("tiny_{i}");
+            let sym = Symbol::new(&name, SymbolKind::Function, "a.py", 1, 2, 0, 10, None);
+            db.insert_symbol(&sym).unwrap();
+            db.upsert_symbol_content(&sym.id, &name, "x=1", "h")
+                .unwrap();
+        }
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        let result = index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+
+        assert_eq!(result.symbols_embedded, 0);
+        assert_eq!(result.symbols_skipped, 2);
+        let events = events.into_inner().unwrap();
+        assert_eq!(events.first(), Some(&ProgressUpdate::Preparing));
+        assert_eq!(events.last(), Some(&ProgressUpdate::Storing));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ProgressUpdate::Embedding { .. })),
+            "no Embedding events expected when pairs is empty"
+        );
     }
 
     /// B1 regression: when symbol count is a multiple of DB_BATCH_LIMIT (256),

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -266,6 +266,10 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
     }
     pairs.sort_by_key(|(text, _)| text.len());
 
+    // Progress total uses the post-filter pair count so `processed` can reach
+    // 100%. The original `total = symbol_ids.len()` stays in tracing logs as
+    // the user-facing "how many symbols did you ask me to embed?" figure.
+    let progress_total = pairs.len() as u32;
     let mut db_batch: Vec<(i64, Vec<u8>)> = Vec::with_capacity(DB_BATCH_LIMIT);
     let mut processed = 0usize;
 
@@ -278,7 +282,7 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
 
         emit(ProgressUpdate::Embedding {
             processed: processed as u32,
-            total: total as u32,
+            total: progress_total,
         });
 
         if processed % 1000 < CHUNK_SIZE {
@@ -286,9 +290,14 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
         }
     }
 
-    // Flush remaining DB writes
-    if !db_batch.is_empty() {
+    // Always emit Storing when there was work to do, even if the last
+    // flush_embedding_batch already drained db_batch via DB_BATCH_LIMIT.
+    // Clients use Storing as the final-phase marker; suppressing it on
+    // large runs would leave the progress UI stuck at "embedding N/N".
+    if !pairs.is_empty() {
         emit(ProgressUpdate::Storing);
+    }
+    if !db_batch.is_empty() {
         db.insert_embeddings(&db_batch)?;
     }
 
@@ -593,6 +602,65 @@ mod tests {
         index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
 
         assert!(events.into_inner().unwrap().is_empty());
+    }
+
+    /// B1 regression: when symbol count is a multiple of DB_BATCH_LIMIT (256),
+    /// the inner `flush_embedding_batch` drains `db_batch` mid-loop and the
+    /// outer `if !db_batch.is_empty()` check would skip Storing. The fix
+    /// emits Storing whenever `pairs` is non-empty.
+    #[test]
+    fn progress_callback_emits_storing_when_db_batch_drained_midloop() {
+        use std::sync::Mutex;
+
+        let db = setup_db_with_symbols(DB_BATCH_LIMIT);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+
+        let events = events.into_inner().unwrap();
+        assert_eq!(events.last(), Some(&ProgressUpdate::Storing));
+    }
+
+    /// B2 regression: when some symbols are skipped (content too small), the
+    /// `total` reported in Embedding events must reflect the post-filter
+    /// pair count so a client can render a progress bar that reaches 100%.
+    #[test]
+    fn progress_callback_embedding_total_uses_post_filter_count() {
+        use std::sync::Mutex;
+
+        let db = Database::open_memory().unwrap();
+        // 1 valid + 1 too-small symbol
+        let s1 = Symbol::new("big", SymbolKind::Function, "a.py", 1, 2, 0, 10, None);
+        db.insert_symbol(&s1).unwrap();
+        let big_content =
+            "def big_function():\n    return 'a value long enough for the embedding threshold'\n";
+        db.upsert_symbol_content(&s1.id, "big", big_content, "// File: a.py | function big")
+            .unwrap();
+        let s2 = Symbol::new("tiny", SymbolKind::Function, "a.py", 5, 6, 0, 10, None);
+        db.insert_symbol(&s2).unwrap();
+        db.upsert_symbol_content(&s2.id, "tiny", "x=1", "h")
+            .unwrap();
+
+        let mut provider = MockEmbeddingProvider::new(384);
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+
+        let events = events.into_inner().unwrap();
+        let emb = events
+            .iter()
+            .find_map(|e| match e {
+                ProgressUpdate::Embedding { processed, total } => Some((*processed, *total)),
+                _ => None,
+            })
+            .expect("expected an Embedding event");
+        assert_eq!(
+            emb,
+            (1, 1),
+            "total must reflect post-filter count, not symbol_ids.len()"
+        );
     }
 
     #[test]

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -159,16 +159,45 @@ fn is_insignificant_line(line: &str) -> bool {
     false
 }
 
+/// Coarse-grained progress events emitted by [`index_embeddings`].
+///
+/// Plain data — no transport or runtime types — so callers (CLI, watcher,
+/// MCP, tests) can adapt these to whatever channel they like.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgressUpdate {
+    /// Preparing: text collection + sort, before any embedding calls.
+    Preparing,
+    /// One batch of symbols just finished embedding. Fires once per
+    /// CHUNK_SIZE (≈512) symbols.
+    Embedding { processed: u32, total: u32 },
+    /// Final DB flush of any remaining batched writes.
+    Storing,
+}
+
+/// Optional progress callback type accepted by [`index_embeddings`].
+///
+/// Called synchronously from inside the indexer (never on an async runtime).
+/// Implementations must be cheap and non-blocking.
+pub type ProgressCallback<'a> = &'a (dyn Fn(ProgressUpdate) + Send + Sync);
+
 /// Embed all symbols that have content but no embedding yet.
 ///
 /// Requires the embedding model to be available (downloaded via `cartog rag setup`
 /// or auto-downloaded on first use by fastembed).
 /// When `force` is true, clears all existing embeddings and re-embeds everything.
+/// When `progress` is `Some`, the callback fires at each coarse phase boundary
+/// (see [`ProgressUpdate`]). Pass `None` for the no-op default.
 pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
     db: &Database,
     provider: &mut P,
     force: bool,
+    progress: Option<ProgressCallback<'_>>,
 ) -> Result<RagIndexResult> {
+    let emit = |u: ProgressUpdate| {
+        if let Some(cb) = progress {
+            cb(u);
+        }
+    };
     let total_content_symbols = db.symbol_content_count()?;
 
     // Auto-detect embedding format change and force re-embed
@@ -206,6 +235,7 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
         return Ok(result);
     }
 
+    emit(ProgressUpdate::Preparing);
     info!("Embedding {} symbols...", symbol_ids.len());
 
     let total = symbol_ids.len();
@@ -246,6 +276,11 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
         let count = flush_embedding_batch(provider, db, &texts, &sids, &mut db_batch, &mut result)?;
         processed += count;
 
+        emit(ProgressUpdate::Embedding {
+            processed: processed as u32,
+            total: total as u32,
+        });
+
         if processed % 1000 < CHUNK_SIZE {
             info!("  {processed}/{total} symbols embedded");
         }
@@ -253,6 +288,7 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
 
     // Flush remaining DB writes
     if !db_batch.is_empty() {
+        emit(ProgressUpdate::Storing);
         db.insert_embeddings(&db_batch)?;
     }
 
@@ -449,7 +485,7 @@ mod tests {
         let db = setup_db_with_symbols(5);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let result = index_embeddings(&db, &mut provider, false).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, None).unwrap();
         assert_eq!(result.symbols_embedded, 5);
         assert_eq!(result.symbols_skipped, 0);
         assert_eq!(result.total_content_symbols, 5);
@@ -461,10 +497,10 @@ mod tests {
         let db = setup_db_with_symbols(3);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let r1 = index_embeddings(&db, &mut provider, false).unwrap();
+        let r1 = index_embeddings(&db, &mut provider, false, None).unwrap();
         assert_eq!(r1.symbols_embedded, 3);
 
-        let r2 = index_embeddings(&db, &mut provider, false).unwrap();
+        let r2 = index_embeddings(&db, &mut provider, false, None).unwrap();
         assert_eq!(r2.symbols_embedded, 0, "second run should embed nothing");
     }
 
@@ -473,10 +509,10 @@ mod tests {
         let db = setup_db_with_symbols(3);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let r1 = index_embeddings(&db, &mut provider, false).unwrap();
+        let r1 = index_embeddings(&db, &mut provider, false, None).unwrap();
         assert_eq!(r1.symbols_embedded, 3);
 
-        let r2 = index_embeddings(&db, &mut provider, true).unwrap();
+        let r2 = index_embeddings(&db, &mut provider, true, None).unwrap();
         assert_eq!(r2.symbols_embedded, 3, "force should re-embed everything");
     }
 
@@ -485,7 +521,7 @@ mod tests {
         let db = setup_db_with_symbols(1);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        index_embeddings(&db, &mut provider, false).unwrap();
+        index_embeddings(&db, &mut provider, false, None).unwrap();
 
         let version: String = db
             .get_metadata("embedding_format_version")
@@ -499,7 +535,7 @@ mod tests {
         let db = Database::open_memory().unwrap();
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let result = index_embeddings(&db, &mut provider, false).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, None).unwrap();
         assert_eq!(result.symbols_embedded, 0);
         assert_eq!(result.total_content_symbols, 0);
         assert_eq!(provider.embed_count, 0);
@@ -515,8 +551,63 @@ mod tests {
             .unwrap();
 
         let mut provider = MockEmbeddingProvider::new(384);
-        let result = index_embeddings(&db, &mut provider, false).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, None).unwrap();
         assert_eq!(result.symbols_skipped, 1);
         assert_eq!(result.symbols_embedded, 0);
+    }
+
+    // ── progress callback ──
+
+    #[test]
+    fn progress_callback_fires_preparing_embedding_storing() {
+        use std::sync::Mutex;
+
+        let db = setup_db_with_symbols(3);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+
+        let events = events.into_inner().unwrap();
+        assert!(!events.is_empty(), "expected at least one event");
+        assert_eq!(events[0], ProgressUpdate::Preparing);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ProgressUpdate::Embedding { total, .. } if *total == 3)),
+            "expected at least one Embedding event with total=3, got {events:?}"
+        );
+        assert_eq!(events.last(), Some(&ProgressUpdate::Storing));
+    }
+
+    #[test]
+    fn progress_callback_silent_when_nothing_to_embed() {
+        use std::sync::Mutex;
+
+        let db = Database::open_memory().unwrap();
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+
+        assert!(events.into_inner().unwrap().is_empty());
+    }
+
+    #[test]
+    fn progress_callback_none_matches_some_for_result() {
+        let db1 = setup_db_with_symbols(3);
+        let mut p1 = MockEmbeddingProvider::new(384);
+        let r_none = index_embeddings(&db1, &mut p1, false, None).unwrap();
+
+        let db2 = setup_db_with_symbols(3);
+        let mut p2 = MockEmbeddingProvider::new(384);
+        let cb = |_: ProgressUpdate| {};
+        let r_some = index_embeddings(&db2, &mut p2, false, Some(&cb)).unwrap();
+
+        assert_eq!(r_none.symbols_embedded, r_some.symbols_embedded);
+        assert_eq!(r_none.symbols_skipped, r_some.symbols_skipped);
+        assert_eq!(r_none.total_content_symbols, r_some.total_content_symbols);
     }
 }

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -447,8 +447,12 @@ fn watch_loop(
                             }
                             if let Some(ref mut provider) = rag_provider {
                                 let embed_start = Instant::now();
-                                match rag::indexer::index_embeddings(&db, provider.as_mut(), false)
-                                {
+                                match rag::indexer::index_embeddings(
+                                    &db,
+                                    provider.as_mut(),
+                                    false,
+                                    None,
+                                ) {
                                     Ok(r) => {
                                         info!(
                                             embedded = r.symbols_embedded,
@@ -493,7 +497,7 @@ fn watch_loop(
         ensure_provider(&mut rag_provider);
         if let Some(ref mut provider) = rag_provider {
             let embed_start = Instant::now();
-            match rag::indexer::index_embeddings(&db, provider.as_mut(), false) {
+            match rag::indexer::index_embeddings(&db, provider.as_mut(), false, None) {
                 Ok(r) => {
                     info!(embedded = r.symbols_embedded, "final RAG flush complete");
                     if config.json_events {

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -276,7 +276,7 @@ fn watch_loop(
 
     // Initial incremental index to ensure DB is current
     let initial_start = Instant::now();
-    match indexer::index_directory(&db, root, false, false) {
+    match indexer::index_directory(&db, root, false, false, None) {
         Ok(r) => {
             info!(
                 files = r.files_indexed,
@@ -377,7 +377,7 @@ fn watch_loop(
                         "file change events received, re-indexing"
                     );
                     let reindex_start = Instant::now();
-                    match indexer::index_directory(&db, root, false, false) {
+                    match indexer::index_directory(&db, root, false, false, None) {
                         Ok(r) => {
                             if r.files_indexed > 0 || r.files_removed > 0 {
                                 info!(

--- a/crates/cartog/benches/queries.rs
+++ b/crates/cartog/benches/queries.rs
@@ -24,7 +24,7 @@ fn setup_db() -> Database {
         .join("webapp_py");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false).expect("index fixture");
+    index_directory(&db, &fixture_dir, true, false, None).expect("index fixture");
     db
 }
 
@@ -147,7 +147,7 @@ fn setup_java_db() -> Database {
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false).expect("index Java fixture");
+    index_directory(&db, &fixture_dir, true, false, None).expect("index Java fixture");
     db
 }
 
@@ -277,21 +277,21 @@ fn bench_indexing(c: &mut Criterion) {
     c.bench_function("index_full_force", |b| {
         b.iter(|| {
             let db = Database::open_memory().unwrap();
-            index_directory(&db, &fixture_dir, true, false).unwrap()
+            index_directory(&db, &fixture_dir, true, false, None).unwrap()
         })
     });
 
     // Incremental no-op: all files already indexed with matching hashes
     c.bench_function("index_incremental_noop", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture_dir, true, false).unwrap();
-        b.iter(|| index_directory(&db, &fixture_dir, false, false).unwrap())
+        index_directory(&db, &fixture_dir, true, false, None).unwrap();
+        b.iter(|| index_directory(&db, &fixture_dir, false, false, None).unwrap())
     });
 
     // Incremental one-file change: invalidate one file's hash to force re-parse + Merkle diff
     c.bench_function("index_incremental_one_file", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture_dir, true, false).unwrap();
+        index_directory(&db, &fixture_dir, true, false, None).unwrap();
         b.iter(|| {
             // Invalidate hash to simulate file change
             db.upsert_file(&FileInfo {
@@ -302,7 +302,7 @@ fn bench_indexing(c: &mut Criterion) {
                 num_symbols: 0,
             })
             .unwrap();
-            index_directory(&db, &fixture_dir, false, false).unwrap()
+            index_directory(&db, &fixture_dir, false, false, None).unwrap()
         })
     });
 }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -711,7 +711,7 @@ pub fn cmd_rag_index(
     } else {
         Spinner::start("Embedding symbols")
     };
-    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force);
+    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force, None);
     if let Some(s) = spinner {
         s.stop();
     }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -140,7 +140,7 @@ pub fn cmd_index(
     } else {
         Spinner::start("Indexing")
     };
-    let result = indexer::index_directory(&db, root, force, lsp);
+    let result = indexer::index_directory(&db, root, force, lsp, None);
     if let Some(s) = spinner {
         s.stop();
     }
@@ -700,7 +700,7 @@ pub fn cmd_rag_index(
     } else {
         Spinner::start("Indexing code graph")
     };
-    let index_res = indexer::index_directory(&db, root, false, false);
+    let index_res = indexer::index_directory(&db, root, false, false, None);
     if let Some(s) = spinner {
         s.stop();
     }

--- a/crates/cartog/tests/rag_relevancy.rs
+++ b/crates/cartog/tests/rag_relevancy.rs
@@ -115,7 +115,7 @@ fn setup_db() -> Database {
         .join("webapp_py");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false).expect("index fixture");
+    index_directory(&db, &fixture_dir, true, false, None).expect("index fixture");
     db
 }
 
@@ -285,7 +285,7 @@ fn setup_java_db() -> Database {
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false).expect("index Java fixture");
+    index_directory(&db, &fixture_dir, true, false, None).expect("index Java fixture");
     db
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -954,7 +954,7 @@ All tool responses are JSON.
 
 **Path restriction**: `cartog_index` and `cartog_rag_index` reject paths outside the project directory (CWD subtree). Agents cannot index arbitrary filesystem locations.
 
-**Progress notifications**: `cartog_index` and `cartog_rag_index` emit standard MCP `notifications/progress` when the client includes a `progressToken` in the request's `_meta`. Phases are coarse (3–4 events per call) and surface in the `message` field — treat that field as human-readable, not a contract. Clients that do not supply a `progressToken` see no notifications and behavior is unchanged. Cold-cache or `force=true` runs report larger `total` values than warm runs; `total` is per-request, not historical.
+**Progress notifications**: `cartog_index` and `cartog_rag_index` emit standard MCP `notifications/progress` when the client includes a `progressToken` in the request's `_meta`. `cartog_index` emits 3 phase events (`walking`, `parsing N files`, `storing N files`) plus an optional fourth (`resolving with LSP`) when the LSP pass runs. `cartog_rag_index` emits `preparing`, one `embedding processed/total` per ~512-symbol batch, then `storing` — so larger re-embed runs produce more events. The `message` field is human-readable, not a contract. Clients that do not supply a `progressToken` see no notifications and behavior is unchanged. Cold-cache or `force=true` runs report larger `total` values than warm runs; `total` is per-request, not historical.
 
 ### Built-in Workflow Guidance
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -954,6 +954,8 @@ All tool responses are JSON.
 
 **Path restriction**: `cartog_index` and `cartog_rag_index` reject paths outside the project directory (CWD subtree). Agents cannot index arbitrary filesystem locations.
 
+**Progress notifications**: `cartog_index` and `cartog_rag_index` emit standard MCP `notifications/progress` when the client includes a `progressToken` in the request's `_meta`. Phases are coarse (3–4 events per call) and surface in the `message` field — treat that field as human-readable, not a contract. Clients that do not supply a `progressToken` see no notifications and behavior is unchanged. Cold-cache or `force=true` runs report larger `total` values than warm runs; `total` is per-request, not historical.
+
 ### Built-in Workflow Guidance
 
 The MCP server sends workflow instructions to the client at initialization, covering tool chaining order (index → search → refs/callees/impact → re-index) and when to use semantic search. Clients that support the MCP `instructions` field will surface these automatically.

--- a/site/usage.html
+++ b/site/usage.html
@@ -464,6 +464,8 @@ cartog rag search "deployment architecture" --kind document</pre>
         </tbody>
       </table>
 
+      <p><strong>Progress notifications:</strong> <code>cartog_index</code> and <code>cartog_rag_index</code> emit standard MCP <code>notifications/progress</code> when the client includes a <code>progressToken</code> in the request's <code>_meta</code>. <code>cartog_index</code> emits 3 phase events (<code>walking</code>, <code>parsing N files</code>, <code>storing N files</code>) plus an optional fourth (<code>resolving with LSP</code>) when the LSP pass runs. <code>cartog_rag_index</code> emits <code>preparing</code>, one <code>embedding processed/total</code> per ~512-symbol batch, then <code>storing</code>. The <code>message</code> field is human-readable, not a contract. Clients that don't supply a <code>progressToken</code> see no notifications.</p>
+
       <h3 id="mcp-quickstart">Wiring cartog into editors: <code>cartog ide</code></h3>
       <p><code>cartog ide</code> is the only verb that writes MCP configs. Run it once per machine, plus any time you install a new editor.</p>
       <pre>cartog ide                          <span class="comment"># all installed clients, all scopes</span>


### PR DESCRIPTION
## Summary

Adds standard MCP `notifications/progress` to the two long-running tools (`cartog_index`, `cartog_rag_index`), opt-in per request via `_meta.progressToken`. Closes the silent-tool-call UX gap raised in [#56](https://github.com/jrollin/cartog/issues/56) — but via the standard MCP mechanism rather than the Claude-Code-specific `claude/channel` extension.

- `cartog_index`: `walking` → `parsing N files` → `storing N files` → `resolving with LSP` (4th only when LSP runs)
- `cartog_rag_index`: `preparing` → `embedding processed/total` per ~512-symbol batch → `storing`
- Cross-client: pure MCP spec, works with any client (Cursor, Continue, custom). Clients that don't subscribe see byte-identical behavior to today.

Originally [#56](https://github.com/jrollin/cartog/issues/56) proposed `claude/channel`. After reading the Anthropic docs that turned out to be the wrong primitive: channels push *external events* (Telegram, webhooks) into a session, not in-flight tool progress. The standard MCP `notifications/progress` mechanism is what the issue actually wants.

## Why `notifications/progress` is the right choice

- Pure MCP spec — supported by every conforming client.
- Opt-in per request: no behavior change for non-subscribing clients.
- Same mechanism upstream issue [anthropics/claude-code#4157](https://github.com/anthropics/claude-code/issues/4157) ("How to report progress with an MCP Server") asks server authors to implement.

## Architecture

A small `crates/cartog-mcp/src/progress.rs` module bridges the synchronous indexer (running inside `tokio::task::spawn_blocking`) to the async MCP peer:

1. The library crates (`cartog-indexer`, `cartog-rag`) gain transport-agnostic `ProgressUpdate` enums and an optional `ProgressCallback` parameter. Plain data — no rmcp/tokio leak.
2. The MCP handlers read `progressToken` from `ctx.meta`. If absent, pass `None` to the library — no bridge, no allocation, zero events emitted.
3. If present: spawn a bounded mpsc forwarder (capacity 64). The blocking indexer `try_send`s phase events; an async task drains the channel and calls `Peer::notify_progress` with a monotonic counter.
4. On every tool exit path (success / tool error / join error), the forwarder is drained and awaited before the response returns.

## Testing

- **Unit tests** (+10 new): 3 in `cartog-indexer`, 5 in `cartog-rag` (incl. 2 regression tests for B1/B2 below), 5 in the MCP bridge module (capturing-notifier sink, monotonic counter, drop-on-full).
- **End-to-end MCP smoke** against three repos using a Python stdio client driving `tools/call` with `_meta.progressToken`:
  - cartog (this repo): `cartog_index` 448 files / 4 events; `cartog_rag_index` 4065 symbols / 10 events
  - family-check sibling: `cartog_index` 855 files / 4 events; `cartog_rag_index` 12304 symbols / 27 events
  - All under default settings (no `CARTOG_SINGLE_WRITER=0`). All progress monotonic, all tokens correctly echoed, final embedding event reaches `N/N`, final phase is `storing` even on multi-thousand-symbol runs.

## Bugs fixed during review

Three issues caught during a deep self-review after the initial implementation and verified by the regression tests + the large-scale smoke runs:

- **B1**: `Storing` was suppressed in `cartog_rag_index` whenever the symbol count was an exact multiple of `DB_BATCH_LIMIT` (256), because the inner `flush_embedding_batch` drained `db_batch` mid-loop. Fix: emit `Storing` whenever there were any pairs to embed.
- **B2**: `Embedding{total}` reported `symbol_ids.len()` but `processed` could only reach `pairs.len()` after `MIN_EMBED_TEXT_BYTES` filtering. Progress bars would never reach 100% on any repo with small symbols. Fix: use post-filter `pairs.len()` as the progress total.
- **B3**: Forwarder leaked on tool-error paths (`?` propagated before draining). Fix: drain unconditionally.

## Caveats — Claude Code TUI

There's an open Claude Code regression ([anthropics/claude-code#51713](https://github.com/anthropics/claude-code/issues/51713)) suppressing MCP progress display in the TUI since v2.1.116. This server implementation is correct per the MCP spec and works with other clients today; Claude Code TUI surfaces will light up once that upstream bug is fixed.

## Out of scope (deferred)

- Honor `RequestContext.ct` (cancellation) — cooperative abort from the forwarder side.
- Progress for `cartog_map` / `cartog_impact` / `cartog_rag_search` (sub-second tools).
- Watcher-initiated server notifications when `cartog serve --watch` finishes a background re-index.
- Closing / repurposing issue #56 — will do that in a follow-up comment after PR merge.

## Verification

- ``cargo fmt --check`` ✓
- ``cargo clippy --all-targets -- -D warnings`` ✓
- ``cargo test --workspace`` ✓ (cartog-indexer 28/28, cartog-rag 77/77, cartog-mcp 44/44 with lsp, all others green)
- ``make check-rust`` ✓
- End-to-end MCP smoke against two real repos, both tools

## Test plan

- [ ] Reviewer runs ``make check`` locally
- [ ] Reviewer rebuilds and smoke-tests with a custom MCP client that subscribes to ``progressToken``
- [ ] Reviewer confirms behavior is identical to today for clients that do **not** subscribe (no progressToken in ``_meta``)
- [ ] Reviewer verifies the bridge code in ``crates/cartog-mcp/src/progress.rs`` and the new ``ProgressUpdate`` / ``ProgressCallback`` API in the two library crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added progress notifications for indexing operations. The MCP server now emits phase-boundary updates during code indexing and RAG embedding when clients request progress tracking, enabling real-time visibility into long-running index operations.

* **Documentation**
  * Updated API documentation and usage guides to describe progress notification behavior and available phase events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->