### PR TITLE
fix(tests): close ETXTBSY race in self_update_test binary copy

### DIFF
--- a/crates/cartog/tests/self_update_test.rs
+++ b/crates/cartog/tests/self_update_test.rs
@@ -515,9 +515,25 @@ fn self_update_full_already_up_to_date_exits_zero() {
 
 #[cfg(unix)]
 fn copy_cartog_into(dir: &std::path::Path) -> PathBuf {
+    use std::fs::OpenOptions;
     use std::os::unix::fs::PermissionsExt;
     let bin = dir.join("cartog");
-    std::fs::copy(cartog_bin(), &bin).expect("copy cartog");
+    // Linux returns ETXTBSY from execve() if any process still holds a write
+    // fd on the binary. `std::fs::copy` returns when bytes hit the page cache,
+    // not when the write fd is closed: racing parallel tests can then fail
+    // to spawn the freshly copied binary. Open/write/fsync/drop the dest fd
+    // in its own scope to close the race window before chmod+exec.
+    {
+        let mut src = std::fs::File::open(cartog_bin()).expect("open cartog");
+        let mut dst = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&bin)
+            .expect("create dest cartog");
+        std::io::copy(&mut src, &mut dst).expect("copy cartog");
+        dst.sync_all().expect("fsync dest cartog");
+    }
     let mut perms = std::fs::metadata(&bin).unwrap().permissions();
     perms.set_mode(0o755);
     std::fs::set_permissions(&bin, perms).unwrap();


### PR DESCRIPTION
## Summary
- Fixes the flaky `self_update_test` failures with `Os { code: 26, kind: ExecutableFileBusy }` on Linux CI parallel runs
- Replaces `std::fs::copy` in the test helper with explicit open/write/fsync/drop-fd, then chmod+exec
- ETXTBSY is closed before `execve()` — no more race between page-cache return and exec

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --test self_update_test` — 20/20 pass
- [x] `cargo test --test self_update_test -- --test-threads=8` — 20/20 pass
- [ ] CI Linux run stays green across reruns

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of the self-update test helper by enhancing file operation handling and synchronization. This prevents race conditions that could lead to inconsistent test behavior and ensures more reliable test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->