### PR TITLE
feat(mcp): honor notifications/cancelled in cartog_index and cartog_rag_index

### DIFF
--- a/crates/cartog-indexer/benches/indexing.rs
+++ b/crates/cartog-indexer/benches/indexing.rs
@@ -40,7 +40,7 @@ fn bench_indexing(c: &mut Criterion) {
     c.bench_function("index_full_force", |b| {
         b.iter(|| {
             let db = Database::open_memory().unwrap();
-            index_directory(&db, &fixture, true, false, None).unwrap();
+            index_directory(&db, &fixture, true, false, None, None).unwrap();
         });
     });
 
@@ -48,9 +48,9 @@ fn bench_indexing(c: &mut Criterion) {
     // before parsing.
     c.bench_function("index_incremental_noop", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture, true, false, None).unwrap();
+        index_directory(&db, &fixture, true, false, None, None).unwrap();
         b.iter(|| {
-            index_directory(&db, &fixture, false, false, None).unwrap();
+            index_directory(&db, &fixture, false, false, None, None).unwrap();
         });
     });
 
@@ -58,7 +58,7 @@ fn bench_indexing(c: &mut Criterion) {
     // and exercises the Merkle-diff path inside Phase 3.
     c.bench_function("index_incremental_one_file", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture, true, false, None).unwrap();
+        index_directory(&db, &fixture, true, false, None, None).unwrap();
         b.iter(|| {
             db.upsert_file(&FileInfo {
                 path: "auth/service.py".to_string(),
@@ -68,7 +68,7 @@ fn bench_indexing(c: &mut Criterion) {
                 num_symbols: 0,
             })
             .unwrap();
-            index_directory(&db, &fixture, false, false, None).unwrap();
+            index_directory(&db, &fixture, false, false, None, None).unwrap();
         });
     });
 }

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -157,6 +157,15 @@ pub enum ProgressUpdate {
 /// Implementations must be cheap and non-blocking.
 pub type ProgressCallback<'a> = &'a (dyn Fn(ProgressUpdate) + Send + Sync);
 
+/// Optional cooperative-cancellation probe accepted by [`index_directory`].
+///
+/// Returns `true` when the caller wants the indexer to stop. Polled at phase
+/// boundaries and once per file in the storing loop, so worst-case latency is
+/// one file's write. When the probe trips, `index_directory` returns
+/// `Err` whose root cause string is `"cancelled"` — the MCP layer matches on
+/// this to surface a cancelled response. Behavior with `None` is unchanged.
+pub type CancelProbe<'a> = &'a (dyn Fn() -> bool + Send + Sync);
+
 /// Index a directory, updating the database incrementally.
 ///
 /// Change detection strategy (in order):
@@ -173,11 +182,18 @@ pub fn index_directory(
     force: bool,
     lsp: bool,
     progress: Option<ProgressCallback<'_>>,
+    cancel: Option<CancelProbe<'_>>,
 ) -> Result<IndexResult> {
     let emit = |u: ProgressUpdate| {
         if let Some(cb) = progress {
             cb(u);
         }
+    };
+    let check_cancel = || -> Result<()> {
+        if cancel.is_some_and(|c| c()) {
+            anyhow::bail!("cancelled");
+        }
+        Ok(())
     };
 
     let mut result = IndexResult::default();
@@ -211,6 +227,7 @@ pub fn index_directory(
     };
 
     // ── Phase 1: walk + filter candidates (cheap, single-threaded) ──
+    check_cancel()?;
     emit(ProgressUpdate::Walking);
     let mut candidates: Vec<(PathBuf, String, &'static str)> = Vec::new();
     for entry in WalkDir::new(&root)
@@ -254,6 +271,7 @@ pub fn index_directory(
     }
 
     // ── Phase 2: parallel parse + extract (CPU-bound, rayon-worker pool) ──
+    check_cancel()?;
     emit(ProgressUpdate::Parsing {
         total: candidates.len() as u32,
     });
@@ -295,11 +313,13 @@ pub fn index_directory(
         .iter()
         .filter(|p| matches!(p, ParseOutput::Parsed { .. }))
         .count() as u32;
+    check_cancel()?;
     emit(ProgressUpdate::Storing {
         total: storing_total,
     });
     let tx = db.begin_indexing_tx()?;
     for item in parsed {
+        check_cancel()?;
         let (rel_path, lang, source, hash, modified, symbols, edges) = match item {
             ParseOutput::Skipped => {
                 result.files_skipped += 1;
@@ -1077,12 +1097,12 @@ mod tests {
 
         if fixtures.exists() {
             // First index
-            let r1 = index_directory(&db, &fixtures, false, false, None).unwrap();
+            let r1 = index_directory(&db, &fixtures, false, false, None, None).unwrap();
             assert!(r1.files_indexed > 0);
             assert!(r1.dirty_files > 0);
 
             // Second index without force — should skip all files (no-op)
-            let r2 = index_directory(&db, &fixtures, false, false, None).unwrap();
+            let r2 = index_directory(&db, &fixtures, false, false, None, None).unwrap();
             assert_eq!(r2.files_indexed, 0);
             assert!(r2.files_skipped > 0);
             assert_eq!(
@@ -1095,7 +1115,7 @@ mod tests {
             );
 
             // Force re-index — dirty_files matches files_indexed
-            let r3 = index_directory(&db, &fixtures, true, false, None).unwrap();
+            let r3 = index_directory(&db, &fixtures, true, false, None, None).unwrap();
             assert_eq!(r3.files_indexed, r1.files_indexed);
             assert_eq!(r3.files_skipped, 0);
             assert_eq!(r3.dirty_files, r3.files_indexed);
@@ -1116,9 +1136,9 @@ mod tests {
 
         // Prime, then re-run. Don't assert LSP found anything (depends on
         // whether pyright is on PATH in CI) — only that the second pass skips it.
-        let _ = index_directory(&db, &fixtures, false, true, None).unwrap();
+        let _ = index_directory(&db, &fixtures, false, true, None, None).unwrap();
 
-        let r2 = index_directory(&db, &fixtures, false, true, None).unwrap();
+        let r2 = index_directory(&db, &fixtures, false, true, None, None).unwrap();
         assert_eq!(r2.dirty_files, 0);
         assert_eq!(r2.edges_lsp_resolved, 0);
     }
@@ -1137,7 +1157,7 @@ mod tests {
         std::fs::write(root.join("a.py"), "def caller():\n    find_user('x')\n").unwrap();
 
         let db = Database::open_memory().unwrap();
-        let r1 = index_directory(&db, &root, false, false, None).unwrap();
+        let r1 = index_directory(&db, &root, false, false, None, None).unwrap();
         assert!(
             r1.files_indexed >= 1,
             "expected a.py to index, got {:?}",
@@ -1155,7 +1175,7 @@ mod tests {
 
         // Adding b.py with find_user definition should reopen the marker.
         std::fs::write(root.join("b.py"), "def find_user(name):\n    return None\n").unwrap();
-        index_directory(&db, &root, false, false, None).unwrap();
+        index_directory(&db, &root, false, false, None, None).unwrap();
 
         assert!(
             !db.is_edge_unresolvable(edge_id).unwrap(),
@@ -1181,7 +1201,7 @@ mod tests {
         std::fs::write(root.join("a.py"), "def caller():\n    find_x()\n").unwrap();
 
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &root, false, false, None).unwrap();
+        index_directory(&db, &root, false, false, None, None).unwrap();
 
         let pre = db.unresolved_edges().unwrap();
         let find_x_id = pre
@@ -1192,7 +1212,7 @@ mod tests {
         db.mark_edge_unresolvable(find_x_id).unwrap();
 
         // --force = true: rebuilds edges with fresh IDs, must NOT inherit state=2.
-        index_directory(&db, &root, true, false, None).unwrap();
+        index_directory(&db, &root, true, false, None, None).unwrap();
         let post = db.unresolved_edges().unwrap();
         let has_find_x_unresolved = post.iter().any(|e| e.target_name == "find_x");
         assert!(
@@ -1217,7 +1237,7 @@ mod tests {
         .unwrap();
 
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &root, false, false, None).unwrap();
+        index_directory(&db, &root, false, false, None, None).unwrap();
 
         let unresolved = db.unresolved_edges().unwrap();
         let target = unresolved
@@ -1227,7 +1247,7 @@ mod tests {
         db.mark_edge_unresolvable(target.edge_id).unwrap();
 
         // No file changes → reindex is a no-op → marker survives.
-        let r = index_directory(&db, &root, false, false, None).unwrap();
+        let r = index_directory(&db, &root, false, false, None, None).unwrap();
         assert_eq!(r.dirty_files, 0);
 
         assert!(
@@ -1561,7 +1581,7 @@ def main():
         let db = Database::open_memory().unwrap();
 
         // ── Index 1: initial full index ──
-        let r1 = index_directory(&db, &dir, true, false, None).unwrap();
+        let r1 = index_directory(&db, &dir, true, false, None, None).unwrap();
         assert_eq!(r1.files_indexed, 2);
         assert!(r1.symbols_added > 0, "should have symbols");
 
@@ -1610,7 +1630,7 @@ def standalone():
         )
         .unwrap();
 
-        let r2 = index_directory(&db, &dir, false, false, None).unwrap();
+        let r2 = index_directory(&db, &dir, false, false, None, None).unwrap();
         assert_eq!(r2.files_indexed, 1, "only a.py changed");
         assert!(r2.files_skipped > 0, "b.py should be skipped");
         assert_eq!(r2.symbols_added, 1, "standalone is new");
@@ -1657,7 +1677,7 @@ def standalone():
         )
         .unwrap();
 
-        let r3 = index_directory(&db, &dir, false, false, None).unwrap();
+        let r3 = index_directory(&db, &dir, false, false, None, None).unwrap();
         assert_eq!(r3.files_indexed, 1);
         assert!(r3.symbols_removed >= 1, "goodbye should be removed");
 
@@ -1711,7 +1731,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         .unwrap();
 
         let db = Database::open_memory().unwrap();
-        let result = index_directory(&db, &dir, false, false, None).unwrap();
+        let result = index_directory(&db, &dir, false, false, None, None).unwrap();
 
         assert_eq!(result.files_indexed, 1);
         assert!(result.symbols_added >= 3, "should have at least 3 sections");
@@ -1789,7 +1809,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         std::fs::write(dir.join("seed.py"), "def keep_me():\n    return 1\n").unwrap();
 
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &dir, true, false, None).expect("seed index should succeed");
+        index_directory(&db, &dir, true, false, None, None).expect("seed index should succeed");
 
         // Snapshot the seed state so we can assert it is preserved across the
         // failed run.
@@ -1820,7 +1840,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         // new functions through Phase 3.
         db.set_max_page_count_for_tests(30).unwrap();
 
-        let result = index_directory(&db, &dir, false, false, None);
+        let result = index_directory(&db, &dir, false, false, None, None);
         assert!(
             result.is_err(),
             "Phase 3 must fail when SQLite runs out of pages; got Ok({result:?})"
@@ -1881,7 +1901,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
 
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        let result = index_directory(&db, &root, true, false, Some(&cb)).unwrap();
+        let result = index_directory(&db, &root, true, false, Some(&cb), None).unwrap();
 
         assert!(result.files_indexed >= 2);
         let events = events.into_inner().unwrap();
@@ -1897,12 +1917,12 @@ We use PostgreSQL with connection pooling via pgbouncer.
 
         let (_t1, root1) = tiny_python_project();
         let db1 = Database::open_memory().unwrap();
-        let r_none = index_directory(&db1, &root1, true, false, None).unwrap();
+        let r_none = index_directory(&db1, &root1, true, false, None, None).unwrap();
 
         let (_t2, root2) = tiny_python_project();
         let db2 = Database::open_memory().unwrap();
         let cb = |_: ProgressUpdate| {};
-        let r_some = index_directory(&db2, &root2, true, false, Some(&cb)).unwrap();
+        let r_some = index_directory(&db2, &root2, true, false, Some(&cb), None).unwrap();
 
         // Different temp dirs → different file modified-times can shift, but the
         // count-based fields of IndexResult are deterministic on a fresh DB.
@@ -1933,7 +1953,7 @@ We use PostgreSQL with connection pooling via pgbouncer.
         let db = Database::open_memory().unwrap();
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        index_directory(&db, &root, true, false, Some(&cb)).unwrap();
+        index_directory(&db, &root, true, false, Some(&cb), None).unwrap();
 
         let events = events.into_inner().unwrap();
         assert!(matches!(events.first(), Some(ProgressUpdate::Walking)));
@@ -1943,5 +1963,54 @@ We use PostgreSQL with connection pooling via pgbouncer.
         assert!(events
             .iter()
             .any(|e| matches!(e, ProgressUpdate::Storing { total } if *total > 0)));
+    }
+
+    #[test]
+    fn cancel_probe_returning_true_aborts_with_cancelled_error() {
+        use cartog_db::Database;
+
+        let (_tmp, root) = tiny_python_project();
+        let db = Database::open_memory().unwrap();
+
+        let probe = || true;
+        let err = index_directory(&db, &root, true, false, None, Some(&probe))
+            .expect_err("index must abort when probe trips at first phase boundary");
+        assert!(
+            err.to_string().contains("cancelled"),
+            "error must mention cancellation, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cancel_probe_returning_false_runs_to_completion() {
+        use cartog_db::Database;
+
+        let (_tmp, root) = tiny_python_project();
+        let db = Database::open_memory().unwrap();
+
+        let probe = || false;
+        let result = index_directory(&db, &root, true, false, None, Some(&probe))
+            .expect("non-cancelling probe must not affect normal indexing");
+        assert!(result.files_indexed >= 2);
+    }
+
+    #[test]
+    fn rerun_after_cancellation_completes_normally() {
+        use cartog_db::Database;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (_tmp, root) = tiny_python_project();
+        let db = Database::open_memory().unwrap();
+
+        let flag = AtomicBool::new(true);
+        let probe = || flag.load(Ordering::SeqCst);
+        let _ = index_directory(&db, &root, true, false, None, Some(&probe))
+            .expect_err("first run cancels");
+
+        // Flip the probe off — second run must complete and produce a real result.
+        flag.store(false, Ordering::SeqCst);
+        let result = index_directory(&db, &root, true, false, None, Some(&probe))
+            .expect("re-run after cancellation must succeed");
+        assert!(result.files_indexed >= 2);
     }
 }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -232,6 +232,7 @@ fn index_with_optional_lsp(
     root: &Path,
     force: bool,
     progress_tx: Option<tokio::sync::mpsc::Sender<progress::Phase>>,
+    cancel: Option<indexer::CancelProbe<'_>>,
 ) -> Result<indexer::IndexResult, McpError> {
     let indexer_cb = progress_tx
         .as_ref()
@@ -242,7 +243,7 @@ fn index_with_optional_lsp(
         })?;
         let cb_ref: Option<&(dyn Fn(indexer::ProgressUpdate) + Send + Sync)> =
             indexer_cb.as_ref().map(|f| f as _);
-        indexer::index_directory(&db, root, force, false, cb_ref)
+        indexer::index_directory(&db, root, force, false, cb_ref, cancel)
             .map_err(|e| mcp_err(format!("indexing failed: {e}")))?
     };
 
@@ -280,6 +281,7 @@ fn index_with_optional_lsp(
     root: &Path,
     force: bool,
     progress_tx: Option<tokio::sync::mpsc::Sender<progress::Phase>>,
+    cancel: Option<indexer::CancelProbe<'_>>,
 ) -> Result<indexer::IndexResult, McpError> {
     let indexer_cb = progress_tx
         .as_ref()
@@ -289,7 +291,7 @@ fn index_with_optional_lsp(
         .map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
     let cb_ref: Option<&(dyn Fn(indexer::ProgressUpdate) + Send + Sync)> =
         indexer_cb.as_ref().map(|f| f as _);
-    indexer::index_directory(&db, root, force, false, cb_ref)
+    indexer::index_directory(&db, root, force, false, cb_ref, cancel)
         .map_err(|e| mcp_err(format!("indexing failed: {e}")))
 }
 
@@ -595,11 +597,20 @@ impl CartogServer {
             None => (None, None),
         };
 
+        let cancel = ctx.ct.clone();
         let join = tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "indexing directory");
-            let result =
-                index_with_optional_lsp(&db, &lsp_manager, &validated, force, progress_tx)?;
+            let probe = || cancel.is_cancelled();
+            let probe_ref: Option<&(dyn Fn() -> bool + Send + Sync)> = Some(&probe);
+            let result = index_with_optional_lsp(
+                &db,
+                &lsp_manager,
+                &validated,
+                force,
+                progress_tx,
+                probe_ref,
+            )?;
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -1037,6 +1048,7 @@ impl CartogServer {
             None => (None, None),
         };
 
+        let cancel = ctx.ct.clone();
         let join = tokio::task::spawn_blocking(move || {
             let validated = validate_path_within_cwd_canonical(&path, &cwd).map_err(mcp_err)?;
             debug!(path = %validated.display(), force, "rag index");
@@ -1045,11 +1057,14 @@ impl CartogServer {
                 mcp_err("internal error: database lock poisoned (server restart required)")
             })?;
 
+            let probe = || cancel.is_cancelled();
+            let probe_ref: Option<&(dyn Fn() -> bool + Send + Sync)> = Some(&probe);
+
             // Ensure the code graph index is up to date first. Inner phases are
             // intentionally suppressed: the RAG tool exposes only rag-specific
             // phases (preparing/embedding/storing) so the client-facing
             // vocabulary stays stable.
-            let _ = indexer::index_directory(&db, &validated, false, false, None)
+            let _ = indexer::index_directory(&db, &validated, false, false, None, probe_ref)
                 .map_err(|e| mcp_err(format!("code graph indexing failed: {e}")))?;
 
             let mut provider = provider.lock().map_err(|_| {
@@ -1064,8 +1079,9 @@ impl CartogServer {
             let cb_ref: Option<&(dyn Fn(rag::indexer::ProgressUpdate) + Send + Sync)> =
                 rag_cb.as_ref().map(|f| f as _);
 
-            let result = rag::indexer::index_embeddings(&db, provider.as_mut(), force, cb_ref)
-                .map_err(|e| mcp_err(format!("embedding indexing failed: {e}")))?;
+            let result =
+                rag::indexer::index_embeddings(&db, provider.as_mut(), force, cb_ref, probe_ref)
+                    .map_err(|e| mcp_err(format!("embedding indexing failed: {e}")))?;
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -2174,7 +2190,7 @@ mod tests {
 
         // First call primes the index. dirty_files > 0 → LSP is allowed (it may
         // resolve nothing if pyright isn't on PATH, but the gate must let it run).
-        let r1 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false, None).unwrap();
+        let r1 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false, None, None).unwrap();
         assert!(
             r1.dirty_files > 0,
             "first index must report dirty files (got {})",
@@ -2182,7 +2198,7 @@ mod tests {
         );
 
         // Second call without changes must be a no-op AND must skip LSP.
-        let r2 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false, None).unwrap();
+        let r2 = index_with_optional_lsp(&db, &lsp_mgr, &fixtures, false, None, None).unwrap();
         assert_eq!(r2.dirty_files, 0);
         assert_eq!(
             r2.edges_lsp_resolved, 0,

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -180,6 +180,14 @@ pub enum ProgressUpdate {
 /// Implementations must be cheap and non-blocking.
 pub type ProgressCallback<'a> = &'a (dyn Fn(ProgressUpdate) + Send + Sync);
 
+/// Optional cooperative-cancellation probe accepted by [`index_embeddings`].
+///
+/// Returns `true` when the caller wants the indexer to stop. Polled at phase
+/// boundaries and once per embedding batch, so worst-case latency is one
+/// CHUNK_SIZE worth of inference. When the probe trips, the function returns
+/// `Err` whose root cause string is `"cancelled"`.
+pub type CancelProbe<'a> = &'a (dyn Fn() -> bool + Send + Sync);
+
 /// Embed all symbols that have content but no embedding yet.
 ///
 /// Requires the embedding model to be available (downloaded via `cartog rag setup`
@@ -192,11 +200,18 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
     provider: &mut P,
     force: bool,
     progress: Option<ProgressCallback<'_>>,
+    cancel: Option<CancelProbe<'_>>,
 ) -> Result<RagIndexResult> {
     let emit = |u: ProgressUpdate| {
         if let Some(cb) = progress {
             cb(u);
         }
+    };
+    let check_cancel = || -> Result<()> {
+        if cancel.is_some_and(|c| c()) {
+            anyhow::bail!("cancelled");
+        }
+        Ok(())
     };
     let total_content_symbols = db.symbol_content_count()?;
 
@@ -235,6 +250,7 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
         return Ok(result);
     }
 
+    check_cancel()?;
     emit(ProgressUpdate::Preparing);
     info!("Embedding {} symbols...", symbol_ids.len());
 
@@ -274,6 +290,7 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
     let mut processed = 0usize;
 
     for batch in pairs.chunks(CHUNK_SIZE) {
+        check_cancel()?;
         let texts: Vec<String> = batch.iter().map(|(t, _)| t.clone()).collect();
         let sids: Vec<String> = batch.iter().map(|(_, s)| s.clone()).collect();
 
@@ -492,7 +509,7 @@ mod tests {
         let db = setup_db_with_symbols(5);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let result = index_embeddings(&db, &mut provider, false, None).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, None, None).unwrap();
         assert_eq!(result.symbols_embedded, 5);
         assert_eq!(result.symbols_skipped, 0);
         assert_eq!(result.total_content_symbols, 5);
@@ -504,10 +521,10 @@ mod tests {
         let db = setup_db_with_symbols(3);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let r1 = index_embeddings(&db, &mut provider, false, None).unwrap();
+        let r1 = index_embeddings(&db, &mut provider, false, None, None).unwrap();
         assert_eq!(r1.symbols_embedded, 3);
 
-        let r2 = index_embeddings(&db, &mut provider, false, None).unwrap();
+        let r2 = index_embeddings(&db, &mut provider, false, None, None).unwrap();
         assert_eq!(r2.symbols_embedded, 0, "second run should embed nothing");
     }
 
@@ -516,10 +533,10 @@ mod tests {
         let db = setup_db_with_symbols(3);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let r1 = index_embeddings(&db, &mut provider, false, None).unwrap();
+        let r1 = index_embeddings(&db, &mut provider, false, None, None).unwrap();
         assert_eq!(r1.symbols_embedded, 3);
 
-        let r2 = index_embeddings(&db, &mut provider, true, None).unwrap();
+        let r2 = index_embeddings(&db, &mut provider, true, None, None).unwrap();
         assert_eq!(r2.symbols_embedded, 3, "force should re-embed everything");
     }
 
@@ -528,7 +545,7 @@ mod tests {
         let db = setup_db_with_symbols(1);
         let mut provider = MockEmbeddingProvider::new(384);
 
-        index_embeddings(&db, &mut provider, false, None).unwrap();
+        index_embeddings(&db, &mut provider, false, None, None).unwrap();
 
         let version: String = db
             .get_metadata("embedding_format_version")
@@ -542,7 +559,7 @@ mod tests {
         let db = Database::open_memory().unwrap();
         let mut provider = MockEmbeddingProvider::new(384);
 
-        let result = index_embeddings(&db, &mut provider, false, None).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, None, None).unwrap();
         assert_eq!(result.symbols_embedded, 0);
         assert_eq!(result.total_content_symbols, 0);
         assert_eq!(provider.embed_count, 0);
@@ -558,7 +575,7 @@ mod tests {
             .unwrap();
 
         let mut provider = MockEmbeddingProvider::new(384);
-        let result = index_embeddings(&db, &mut provider, false, None).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, None, None).unwrap();
         assert_eq!(result.symbols_skipped, 1);
         assert_eq!(result.symbols_embedded, 0);
     }
@@ -574,7 +591,7 @@ mod tests {
 
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+        index_embeddings(&db, &mut provider, false, Some(&cb), None).unwrap();
 
         let events = events.into_inner().unwrap();
         assert!(!events.is_empty(), "expected at least one event");
@@ -597,7 +614,7 @@ mod tests {
 
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+        index_embeddings(&db, &mut provider, false, Some(&cb), None).unwrap();
 
         assert!(events.into_inner().unwrap().is_empty());
     }
@@ -625,7 +642,7 @@ mod tests {
 
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        let result = index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+        let result = index_embeddings(&db, &mut provider, false, Some(&cb), None).unwrap();
 
         assert_eq!(result.symbols_embedded, 0);
         assert_eq!(result.symbols_skipped, 2);
@@ -653,7 +670,7 @@ mod tests {
 
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+        index_embeddings(&db, &mut provider, false, Some(&cb), None).unwrap();
 
         let events = events.into_inner().unwrap();
         assert_eq!(events.last(), Some(&ProgressUpdate::Storing));
@@ -682,7 +699,7 @@ mod tests {
         let mut provider = MockEmbeddingProvider::new(384);
         let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
         let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
-        index_embeddings(&db, &mut provider, false, Some(&cb)).unwrap();
+        index_embeddings(&db, &mut provider, false, Some(&cb), None).unwrap();
 
         let events = events.into_inner().unwrap();
         let emb = events
@@ -703,15 +720,40 @@ mod tests {
     fn progress_callback_none_matches_some_for_result() {
         let db1 = setup_db_with_symbols(3);
         let mut p1 = MockEmbeddingProvider::new(384);
-        let r_none = index_embeddings(&db1, &mut p1, false, None).unwrap();
+        let r_none = index_embeddings(&db1, &mut p1, false, None, None).unwrap();
 
         let db2 = setup_db_with_symbols(3);
         let mut p2 = MockEmbeddingProvider::new(384);
         let cb = |_: ProgressUpdate| {};
-        let r_some = index_embeddings(&db2, &mut p2, false, Some(&cb)).unwrap();
+        let r_some = index_embeddings(&db2, &mut p2, false, Some(&cb), None).unwrap();
 
         assert_eq!(r_none.symbols_embedded, r_some.symbols_embedded);
         assert_eq!(r_none.symbols_skipped, r_some.symbols_skipped);
         assert_eq!(r_none.total_content_symbols, r_some.total_content_symbols);
+    }
+
+    #[test]
+    fn cancel_probe_returning_true_aborts_with_cancelled_error() {
+        let db = setup_db_with_symbols(3);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let probe = || true;
+        let err = index_embeddings(&db, &mut provider, false, None, Some(&probe))
+            .expect_err("embedding must abort when probe trips at first checkpoint");
+        assert!(
+            err.to_string().contains("cancelled"),
+            "error must mention cancellation, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cancel_probe_returning_false_runs_to_completion() {
+        let db = setup_db_with_symbols(3);
+        let mut provider = MockEmbeddingProvider::new(384);
+
+        let probe = || false;
+        let result = index_embeddings(&db, &mut provider, false, None, Some(&probe))
+            .expect("non-cancelling probe must not affect normal embedding");
+        assert_eq!(result.symbols_embedded, 3);
     }
 }

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -276,7 +276,7 @@ fn watch_loop(
 
     // Initial incremental index to ensure DB is current
     let initial_start = Instant::now();
-    match indexer::index_directory(&db, root, false, false, None) {
+    match indexer::index_directory(&db, root, false, false, None, None) {
         Ok(r) => {
             info!(
                 files = r.files_indexed,
@@ -377,7 +377,7 @@ fn watch_loop(
                         "file change events received, re-indexing"
                     );
                     let reindex_start = Instant::now();
-                    match indexer::index_directory(&db, root, false, false, None) {
+                    match indexer::index_directory(&db, root, false, false, None, None) {
                         Ok(r) => {
                             if r.files_indexed > 0 || r.files_removed > 0 {
                                 info!(
@@ -452,6 +452,7 @@ fn watch_loop(
                                     provider.as_mut(),
                                     false,
                                     None,
+                                    None,
                                 ) {
                                     Ok(r) => {
                                         info!(
@@ -497,7 +498,7 @@ fn watch_loop(
         ensure_provider(&mut rag_provider);
         if let Some(ref mut provider) = rag_provider {
             let embed_start = Instant::now();
-            match rag::indexer::index_embeddings(&db, provider.as_mut(), false, None) {
+            match rag::indexer::index_embeddings(&db, provider.as_mut(), false, None, None) {
                 Ok(r) => {
                     info!(embedded = r.symbols_embedded, "final RAG flush complete");
                     if config.json_events {

--- a/crates/cartog/benches/queries.rs
+++ b/crates/cartog/benches/queries.rs
@@ -24,7 +24,7 @@ fn setup_db() -> Database {
         .join("webapp_py");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false, None).expect("index fixture");
+    index_directory(&db, &fixture_dir, true, false, None, None).expect("index fixture");
     db
 }
 
@@ -147,7 +147,7 @@ fn setup_java_db() -> Database {
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false, None).expect("index Java fixture");
+    index_directory(&db, &fixture_dir, true, false, None, None).expect("index Java fixture");
     db
 }
 
@@ -277,21 +277,21 @@ fn bench_indexing(c: &mut Criterion) {
     c.bench_function("index_full_force", |b| {
         b.iter(|| {
             let db = Database::open_memory().unwrap();
-            index_directory(&db, &fixture_dir, true, false, None).unwrap()
+            index_directory(&db, &fixture_dir, true, false, None, None).unwrap()
         })
     });
 
     // Incremental no-op: all files already indexed with matching hashes
     c.bench_function("index_incremental_noop", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture_dir, true, false, None).unwrap();
-        b.iter(|| index_directory(&db, &fixture_dir, false, false, None).unwrap())
+        index_directory(&db, &fixture_dir, true, false, None, None).unwrap();
+        b.iter(|| index_directory(&db, &fixture_dir, false, false, None, None).unwrap())
     });
 
     // Incremental one-file change: invalidate one file's hash to force re-parse + Merkle diff
     c.bench_function("index_incremental_one_file", |b| {
         let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture_dir, true, false, None).unwrap();
+        index_directory(&db, &fixture_dir, true, false, None, None).unwrap();
         b.iter(|| {
             // Invalidate hash to simulate file change
             db.upsert_file(&FileInfo {
@@ -302,7 +302,7 @@ fn bench_indexing(c: &mut Criterion) {
                 num_symbols: 0,
             })
             .unwrap();
-            index_directory(&db, &fixture_dir, false, false, None).unwrap()
+            index_directory(&db, &fixture_dir, false, false, None, None).unwrap()
         })
     });
 }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -140,7 +140,7 @@ pub fn cmd_index(
     } else {
         Spinner::start("Indexing")
     };
-    let result = indexer::index_directory(&db, root, force, lsp, None);
+    let result = indexer::index_directory(&db, root, force, lsp, None, None);
     if let Some(s) = spinner {
         s.stop();
     }
@@ -700,7 +700,7 @@ pub fn cmd_rag_index(
     } else {
         Spinner::start("Indexing code graph")
     };
-    let index_res = indexer::index_directory(&db, root, false, false, None);
+    let index_res = indexer::index_directory(&db, root, false, false, None, None);
     if let Some(s) = spinner {
         s.stop();
     }
@@ -711,7 +711,7 @@ pub fn cmd_rag_index(
     } else {
         Spinner::start("Embedding symbols")
     };
-    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force, None);
+    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force, None, None);
     if let Some(s) = spinner {
         s.stop();
     }

--- a/crates/cartog/tests/rag_relevancy.rs
+++ b/crates/cartog/tests/rag_relevancy.rs
@@ -115,7 +115,7 @@ fn setup_db() -> Database {
         .join("webapp_py");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false, None).expect("index fixture");
+    index_directory(&db, &fixture_dir, true, false, None, None).expect("index fixture");
     db
 }
 
@@ -285,7 +285,7 @@ fn setup_java_db() -> Database {
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false, None).expect("index Java fixture");
+    index_directory(&db, &fixture_dir, true, false, None, None).expect("index Java fixture");
     db
 }
 

--- a/docs/spec-cancellation.md
+++ b/docs/spec-cancellation.md
@@ -1,0 +1,118 @@
+# Cooperative Cancellation for MCP Indexing Tools
+
+## Overview
+
+Cooperative cancellation for the long-running MCP tools `cartog_index` and
+`cartog_rag_index`. When an MCP client cancels the request (sends
+`notifications/cancelled`), the indexer aborts at the next checkpoint
+instead of running to completion. For `index_directory` the active
+rusqlite transaction rolls back on `Err`, so the run leaves no code-graph
+changes. For `index_embeddings`, batches flushed before the cancel point
+persist; the in-flight batch is dropped. Either way the DB stays
+consistent and the next index run picks up where the cancelled one left
+off.
+
+## Motivation
+
+- A `cartog_index` on a large repo can run for minutes. Without cancellation,
+  the MCP client is stuck until completion or transport drop.
+- `RequestContext.ct` (a `CancellationToken` from rmcp) already flips when the
+  client cancels. We were not consuming it.
+- The progress callback added in PR #57 fires at coarse phase boundaries — a
+  natural place to also poll cancellation.
+
+## Non-goals
+
+- Mid-file cancellation (interrupting a single tree-sitter parse).
+- Bespoke transaction handling on cancel. We rely on rusqlite's default
+  `Transaction::Drop` rollback for `index_directory`; `index_embeddings`
+  inherits whatever was flushed before the cancel point.
+- CLI cancellation beyond the existing Ctrl-C behavior.
+- Watcher cancellation. `cartog serve --watch` runs outside any request
+  lifecycle; nothing to wire `ctx.ct` to. Interaction with a watcher: none.
+  A cancelled MCP-driven index leaves the DB consistent (see FR-4); the
+  watcher's normal debounced re-index covers anything still missing on the
+  next file change.
+- Cancellation on the sub-second tools (`cartog_search`, `cartog_rag_search`,
+  etc.). Not worth the churn.
+
+## Architecture
+
+```
+MCP client ──cancel──▶ RequestContext.ct.cancel()
+                                │
+                                ▼
+                       cartog-mcp tool handler
+                                │  (clone CancellationToken into spawn_blocking)
+                                ▼
+                       indexer / rag-indexer
+                                │  (poll at each checkpoint)
+                                ▼
+                       Err("cancelled") ──▶ McpError surfaces to client
+```
+
+Indexer crates stay transport-agnostic: they accept
+`pub type CancelProbe<'a> = &'a (dyn Fn() -> bool + Send + Sync)` alongside the
+existing `ProgressCallback`. The MCP layer wraps `ctx.ct.is_cancelled()` into
+that closure. CLI passes `None`.
+
+## Functional requirements
+
+- **FR-1**: `index_directory` checks cancellation at each phase boundary
+  (Walking, Parsing, Storing) and between files in the storing loop.
+- **FR-2**: `index_embeddings` checks cancellation at Preparing and between
+  embedding batches.
+- **FR-3**: On cancellation, the indexer returns
+  `Err(anyhow!("cancelled"))` so the MCP error message contains the literal
+  `cancelled`, which clients (and tests) can match on.
+- **FR-4**: On cancellation, the indexer returns `Err` before reaching
+  `tx.commit()`. The `rusqlite::Transaction` drops in its default mode and
+  rolls back — `index_directory`'s code-graph writes for the cancelled run
+  are discarded. `index_embeddings` does not run inside a single transaction:
+  any embedding batches already flushed to SQLite stay, the in-flight batch
+  is dropped. The DB stays consistent either way; the next run redoes the
+  missing work.
+- **FR-5**: CLI behavior unchanged — CLI passes `None` for the probe.
+- **FR-6**: With `cancel = None`, behavior is byte-identical to today (one
+  closure-call per checkpoint, returns `false`).
+
+## Non-functional requirements
+
+- **NFR-1**: Probe overhead is one closure call per file (Phase 3) or per
+  embedding batch (Phase 2 of RAG). Must not regress `make bench`.
+- **NFR-2**: No new crate dependency. `CancellationToken` reaches us via the
+  existing `rmcp` dep; the indexer crates use a plain `dyn Fn()`.
+
+## Acceptance criteria
+
+- **AC-1**: Unit tests cover the three cases:
+  probe-trips → `Err("cancelled")`,
+  probe-never-trips → identical to `None`,
+  re-run after cancellation completes normally.
+  ✓ See `cartog-indexer::cancel_probe_*` and `cartog-rag::cancel_probe_*` tests.
+- **AC-2**: `cargo test --workspace` passes; `cargo clippy --all-targets -- -D
+  warnings` clean.
+
+## Implementation checklist
+
+- [x] Add `pub type CancelProbe` to `cartog-indexer` and `cartog-rag`.
+- [x] Add `cancel: Option<CancelProbe<'_>>` to `index_directory` and
+      `index_embeddings`.
+- [x] Sprinkle `check_cancel()?` at phase boundaries and per-file/per-batch.
+- [x] In `cartog-mcp`: clone `ctx.ct` into `spawn_blocking`, build a probe,
+      thread through `index_with_optional_lsp` and `index_embeddings` calls.
+- [x] CLI / watcher / tests / benches pass `None`.
+- [x] Unit tests for cancellation behavior.
+- [x] Update `docs/usage.md` MCP section with a one-line note.
+
+## Resolved questions
+
+1. **Cancellation contract for in-flight transactions** — for
+   `index_directory`, rusqlite's default `Transaction::Drop` rolls back the
+   indexing tx, so the run leaves no code-graph changes. For
+   `index_embeddings`, batches flushed before the cancel point persist; the
+   in-flight batch is dropped. Either way the DB stays consistent.
+2. **rmcp error mapping** — start with a recognisable `McpError` message
+   containing `cancelled`. A first-class `request_cancelled` variant in rmcp
+   would be a future polish.
+3. **Two-pass edge resolution partial state** — fine. Next run re-resolves.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -956,6 +956,8 @@ All tool responses are JSON.
 
 **Progress notifications**: `cartog_index` and `cartog_rag_index` emit standard MCP `notifications/progress` when the client includes a `progressToken` in the request's `_meta`. `cartog_index` emits 3 phase events (`walking`, `parsing N files`, `storing N files`) plus an optional fourth (`resolving with LSP`) when the LSP pass runs. `cartog_rag_index` emits `preparing`, one `embedding processed/total` per ~512-symbol batch, then `storing` — so larger re-embed runs produce more events. The `message` field is human-readable, not a contract. Clients that do not supply a `progressToken` see no notifications and behavior is unchanged. Cold-cache or `force=true` runs report larger `total` values than warm runs; `total` is per-request, not historical.
 
+**Cancellation**: `cartog_index` and `cartog_rag_index` honor MCP `notifications/cancelled`. The indexer aborts at the next phase boundary or per-file checkpoint (sub-second latency in typical cases), and the tool returns an error whose message contains `cancelled`. `cartog_index` runs inside a single rusqlite transaction that rolls back on the error path, so a cancelled run leaves no code-graph changes. `cartog_rag_index` keeps any embedding batches that were already flushed to SQLite; the in-flight batch is dropped. In both cases the next index run redoes the missing work.
+
 ### Built-in Workflow Guidance
 
 The MCP server sends workflow instructions to the client at initialization, covering tool chaining order (index → search → refs/callees/impact → re-index) and when to use semantic search. Clients that support the MCP `instructions` field will surface these automatically.


### PR DESCRIPTION
## Summary
- Wire `RequestContext.ct` into `cartog_index` and `cartog_rag_index` so clients can cancel long-running indexing
- Add a transport-agnostic `CancelProbe` (`&dyn Fn() -> bool + Send + Sync`) to `index_directory` and `index_embeddings`; probe is polled at phase boundaries, per-file in the storing loop, and per-batch in embedding
- On cancel: the indexer returns `Err("cancelled")`. For `cartog_index`, rusqlite's default `Transaction::Drop` rolls back the indexing tx, so the run leaves no code-graph changes. For `cartog_rag_index`, batches already flushed to SQLite persist; the in-flight batch is dropped. Either way the DB stays consistent.
- CLI / watcher / tests / benches pass `None`; behavior with `cancel = None` is byte-identical to today.

Full spec in `docs/spec-cancellation.md`. User-facing note added to `docs/usage.md`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` (5 new cancellation tests: 3 in cartog-indexer, 2 in cartog-rag)
- [ ] `make bench` to confirm no regression from the probe-call overhead (not run locally; cheap closure-call per file/batch should be sub-noise)