### PR TITLE
chore(tests): tighten PR #55 review follow-ups

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -4636,6 +4636,14 @@ mod tests {
             )
             .unwrap();
         assert_eq!(stored_dim, 1024);
+        // A successful wipe must also recreate symbol_vec at the new dim.
+        // Without this assertion, an early return between the DROP and the
+        // CREATE in reconcile_embedding_fingerprint would pass the count +
+        // metadata checks above while leaving the DB unusable for RAG.
+        assert!(
+            symbol_vec_exists(&db.conn).unwrap(),
+            "successful reconcile must recreate symbol_vec"
+        );
     }
 
     // ── Read-only attach tests (Phase 3) ──

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -250,6 +250,15 @@ pub const LEGACY_DB_FILE: &str = ".cartog.db";
 /// to every on-disk connection.
 pub const BUSY_TIMEOUT_MS: u32 = 5000;
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only fault injection: when set to true, `reconcile_embedding_fingerprint`
+    /// returns SQLITE_FULL between the model write and the dimension write.
+    /// Cleared (swapped to false) on read so each fire is one-shot.
+    static RECONCILE_FAIL_AFTER_MODEL: std::sync::atomic::AtomicBool =
+        const { std::sync::atomic::AtomicBool::new(false) };
+}
+
 /// Run `PRAGMA wal_checkpoint(TRUNCATE)` on the SQLite file at `path`.
 /// No-op for missing files. Used before moving the DB to flush the WAL.
 pub fn checkpoint_wal(path: &std::path::Path) -> anyhow::Result<()> {
@@ -333,6 +342,9 @@ pub struct Database {
     /// Captures the `metadata` snapshot at attach time so a later promotion
     /// (Phase 5) can detect drift before switching to read-write mode. `None`
     /// for read-write opens.
+    ///
+    /// Invariant: `pinned.is_some() == is_read_only()`. Both flow from the
+    /// same opening path, and the equivalence is what callers rely on.
     pinned: Option<PinnedAttach>,
 }
 
@@ -1045,6 +1057,15 @@ impl Database {
                 "INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)",
                 params![EMBED_MODEL_KEY, fp.model],
             )?;
+            #[cfg(test)]
+            if RECONCILE_FAIL_AFTER_MODEL
+                .with(|b| b.swap(false, std::sync::atomic::Ordering::SeqCst))
+            {
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL),
+                    Some("injected mid-sequence failure".into()),
+                ));
+            }
             tx.execute(
                 "INSERT OR REPLACE INTO metadata (key, value) VALUES ('embedding_dimension', ?1)",
                 params![fp.dimension.to_string()],
@@ -4990,63 +5011,6 @@ mod tests {
     }
 
     #[test]
-    fn test_reconcile_fingerprint_transaction_rolls_back_on_failure() {
-        // Lower-level regression: prove that a failing statement inside
-        // the reconcile transaction reverts everything. We do this by
-        // running the same DROP/CREATE/UPDATE sequence inside an explicit
-        // unchecked_transaction and rolling it back; verify the post-DB
-        // state is unchanged.
-        let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("test.db");
-        let db = Database::open(&db_path, 384).unwrap();
-        db.reconcile_embedding_fingerprint(&fp("local", "BGE-small-en-v1.5", 384))
-            .unwrap();
-        seed_embedding(&db, 384, "before");
-        let initial_count = db.embedding_count().unwrap();
-        assert_eq!(initial_count, 1);
-
-        // Simulate the reconcile sequence under a transaction, then
-        // abort. This is the contract: a rollback after partial writes
-        // leaves the on-disk state exactly as it was.
-        {
-            let tx = db.conn.unchecked_transaction().unwrap();
-            tx.execute("DROP TABLE IF EXISTS symbol_vec", []).unwrap();
-            tx.execute("DELETE FROM symbol_embedding_map", []).unwrap();
-            tx.execute(
-                "INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)",
-                params!["embedding_provider", "ollama"],
-            )
-            .unwrap();
-            // No commit: tx is dropped -> rollback.
-        }
-
-        // Post-rollback: everything must be back to the initial state.
-        let stored_provider = db.get_metadata("embedding_provider").unwrap();
-        assert_eq!(
-            stored_provider.as_deref(),
-            Some("local"),
-            "rollback must revert provider write"
-        );
-        assert_eq!(
-            db.embedding_count().unwrap(),
-            1,
-            "rollback must revert symbol_embedding_map DELETE"
-        );
-        // symbol_vec must be back too.
-        let has_vec = db
-            .conn
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='symbol_vec'",
-                [],
-                |row| row.get::<_, i64>(0),
-            )
-            .optional()
-            .unwrap()
-            .is_some();
-        assert!(has_vec, "rollback must revert DROP TABLE symbol_vec");
-    }
-
-    #[test]
     fn test_reconcile_fingerprint_rolls_back_on_midsequence_failure() {
         // Regression: pre-fix, each metadata write in
         // reconcile_embedding_fingerprint ran outside any transaction.
@@ -5073,24 +5037,20 @@ mod tests {
             seed_embedding(&db, 384, "seed");
         }
 
-        // 2. Force a SQLITE_FULL mid-reconcile by capping the page count.
-        //    The cap must be tight enough that the multi-row metadata
-        //    upserts can't all fit, but loose enough that the initial
-        //    DROP TABLE succeeds (we want to verify rollback, not just
-        //    "first write failed").
+        // 2. Force a deterministic mid-sequence failure via the
+        //    RECONCILE_FAIL_AFTER_MODEL fault-injection hook (gated by
+        //    #[cfg(test)]). Page-cap tricks don't reliably trigger
+        //    SQLITE_FULL: SQLite reuses freed pages after DROP TABLE.
         let new_fp = fp("ollama", "nomic-embed-text-v2", 384);
         let outcome = {
             let db = Database::open(&db_path, 384).unwrap();
-            // Tighten budget. Page count of 8 is enough for the
-            // transaction's own begin/commit overhead but not enough
-            // for the new CREATE VIRTUAL TABLE + 3 metadata rows.
-            db.set_max_page_count_for_tests(8).unwrap();
+            RECONCILE_FAIL_AFTER_MODEL.with(|b| b.store(true, std::sync::atomic::Ordering::SeqCst));
             db.reconcile_embedding_fingerprint(&new_fp)
         };
+        assert!(outcome.is_err(), "injected SQLITE_FULL must surface as Err");
 
-        // 3. The reconcile may succeed or fail. If it failed, the DB on
-        //    disk must still reflect the INITIAL fingerprint — not a
-        //    partial state.
+        // 3. Failure path: the DB on disk must still reflect the INITIAL
+        //    fingerprint, not a partial state.
         let post = Database::open(&db_path, 384).unwrap();
         let stored_provider = post.get_metadata("embedding_provider").unwrap();
         let stored_model = post.get_metadata("embedding_model").unwrap();
@@ -5105,45 +5065,30 @@ mod tests {
             .optional()
             .unwrap()
             .is_some();
-
-        match outcome {
-            Ok(()) => {
-                // Either it succeeded — then the new fingerprint is fully
-                // installed (provider/model/dim all swapped, symbol_vec
-                // recreated). Verify consistency.
-                assert_eq!(stored_provider.as_deref(), Some("ollama"));
-                assert_eq!(stored_model.as_deref(), Some("nomic-embed-text-v2"));
-                assert_eq!(stored_dim_str.as_deref(), Some("384"));
-                assert!(
-                    symbol_vec_exists,
-                    "successful reconcile must have symbol_vec"
-                );
-            }
-            Err(_) => {
-                // Or it failed — then the OLD fingerprint must be intact.
-                // This is the regression assertion: pre-fix, the DB could
-                // end up in a half-applied state.
-                assert_eq!(
-                    stored_provider.as_deref(),
-                    Some("local"),
-                    "failed reconcile must roll back provider"
-                );
-                assert_eq!(
-                    stored_model.as_deref(),
-                    Some("BGE-small-en-v1.5"),
-                    "failed reconcile must roll back model"
-                );
-                assert_eq!(
-                    stored_dim_str.as_deref(),
-                    Some("384"),
-                    "failed reconcile must roll back dimension"
-                );
-                assert!(
-                    symbol_vec_exists,
-                    "failed reconcile must roll back symbol_vec drop"
-                );
-            }
-        }
+        assert_eq!(
+            stored_provider.as_deref(),
+            Some("local"),
+            "failed reconcile must roll back provider"
+        );
+        assert_eq!(
+            stored_model.as_deref(),
+            Some("BGE-small-en-v1.5"),
+            "failed reconcile must roll back model"
+        );
+        assert_eq!(
+            stored_dim_str.as_deref(),
+            Some("384"),
+            "failed reconcile must roll back dimension"
+        );
+        assert!(
+            symbol_vec_exists,
+            "failed reconcile must roll back symbol_vec drop"
+        );
+        assert_eq!(
+            post.embedding_count().unwrap(),
+            1,
+            "failed reconcile must roll back the symbol_embedding_map DELETE"
+        );
     }
 
     #[test]

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -1627,6 +1627,10 @@ fn validate_pinned_state(
         Some(p) => p,
         None => return Ok(()),
     };
+    // Bump AFTER the None-pin early return so the test counter only
+    // tracks meaningful validations (a None pin is a trivial pass).
+    #[cfg(test)]
+    test_validate_call_counter::bump();
     let reader = Database::open_readonly(db_path)
         .map_err(|e| anyhow::anyhow!("re-attach read-only failed: {e}"))?;
     let now = reader
@@ -1638,6 +1642,37 @@ fn validate_pinned_state(
         );
     }
     Ok(())
+}
+
+/// Test-only call counter for `validate_pinned_state`. Lets the promoter
+/// suite assert that BOTH the pre-acquire and post-acquire validate
+/// branches fire — deleting either call site would surface as a count
+/// regression. Production builds compile this whole module away.
+///
+/// `COUNT` is the running tally; `SERIAL` is a separate `tokio` Mutex
+/// tests hold for their full duration to serialize against any sibling
+/// test that also reads/writes the counter (Cargo runs tests in parallel
+/// by default, and these statics are process-global). We use the async
+/// Mutex so the guard can be held across `.await` in `#[tokio::test]`
+/// bodies; sync tests use `blocking_lock()`.
+#[cfg(test)]
+mod test_validate_call_counter {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    pub(super) static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    pub(super) static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    pub(super) fn bump() {
+        COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(super) fn reset() {
+        COUNT.store(0, Ordering::SeqCst);
+    }
+
+    pub(super) fn snapshot() -> usize {
+        COUNT.load(Ordering::SeqCst)
+    }
 }
 
 /// Resolve to a future that completes when the process receives SIGTERM.
@@ -2059,6 +2094,7 @@ mod tests {
 
     #[test]
     fn promoter_validate_pinned_state_matches_when_unchanged() {
+        let _serial = test_validate_call_counter::SERIAL.blocking_lock();
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         {
@@ -2074,6 +2110,7 @@ mod tests {
 
     #[test]
     fn promoter_validate_pinned_state_detects_schema_bump() {
+        let _serial = test_validate_call_counter::SERIAL.blocking_lock();
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         let pinned = {
@@ -2260,6 +2297,7 @@ mod tests {
         // polling for up to one poll_interval after run_server returns
         // and even promote during that window. We assert that abort()
         // really terminates the task within a small bounded time.
+        let _serial = test_validate_call_counter::SERIAL.lock().await;
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         let state_dir = dir.path().join("state");
@@ -2295,6 +2333,7 @@ mod tests {
 
     #[test]
     fn validate_pinned_state_returns_ok_when_pin_is_none() {
+        let _serial = test_validate_call_counter::SERIAL.blocking_lock();
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         {
@@ -2304,17 +2343,16 @@ mod tests {
     }
 
     #[test]
-    fn validate_pinned_state_detects_drift() {
-        // Drift is exercised via the embedding fingerprint (not
-        // schema_version) because `open_readonly` rejects schema_version
-        // mismatch *before* this helper's comparison runs.
-        //
-        // A fresh `Database::open` writes only `embedding_dimension`
-        // (no provider/model), so the read-only attach captures
-        // `pinned.embedding = None`. After the test writes provider and
-        // model, the next `open_readonly` inside `validate_pinned_state`
-        // assembles `embedding = Some(...)`, and `None != Some(...)`
-        // surfaces as drift.
+    fn validate_pinned_state_detects_none_vs_some_drift() {
+        // A brand-new DB never reconciled has no provider/model in
+        // metadata, so a read-only attach captures `pinned.embedding =
+        // None`. If the primary subsequently runs `rag index` and stamps
+        // provider/model, the secondary must detect this as drift — pin
+        // was None, disk is now Some(...). This path is distinct from
+        // `validate_pinned_state_detects_drift`, which seeds provider+
+        // model BEFORE the attach so the pin is Some(...) and only the
+        // Some-vs-Some inequality is exercised.
+        let _serial = test_validate_call_counter::SERIAL.blocking_lock();
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         let pinned = {
@@ -2324,7 +2362,57 @@ mod tests {
                 .pinned_attach()
                 .cloned()
         };
-        // Another writer rewrites the embedding provider under us.
+        assert!(
+            pinned.as_ref().is_some_and(|p| p.embedding.is_none()),
+            "pin against an un-reconciled DB must capture embedding = None",
+        );
+        // Primary stamps provider+model.
+        {
+            let mutator = Database::open(&db_path, 384).unwrap();
+            mutator.set_metadata("embedding_provider", "local").unwrap();
+            mutator
+                .set_metadata("embedding_model", "BGE-small-en-v1.5")
+                .unwrap();
+        }
+        let err = validate_pinned_state(&db_path, pinned.as_ref())
+            .expect_err("None pin vs Some on disk must surface as drift");
+        assert!(
+            err.to_string().contains("DB metadata changed"),
+            "drift error should name the metadata change, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_pinned_state_detects_drift() {
+        // Drift is exercised via the embedding fingerprint (not
+        // schema_version) because `open_readonly` rejects schema_version
+        // mismatch *before* this helper's comparison runs.
+        //
+        // We seed provider+model BEFORE the read-only attach so the pin
+        // captures `embedding = Some(local, BGE-..., 384)`, then mutate
+        // to a different `Some(ollama, nomic, 384)`. This exercises the
+        // Some vs Some inequality directly — not the None vs Some accident
+        // that would silently stop firing if `Database::open` ever seeded
+        // default provider/model values.
+        let _serial = test_validate_call_counter::SERIAL.blocking_lock();
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pinned = {
+            let db = Database::open(&db_path, 384).unwrap();
+            db.set_metadata("embedding_provider", "local").unwrap();
+            db.set_metadata("embedding_model", "BGE-small-en-v1.5")
+                .unwrap();
+            drop(db);
+            Database::open_readonly(&db_path)
+                .unwrap()
+                .pinned_attach()
+                .cloned()
+        };
+        assert!(
+            pinned.as_ref().and_then(|p| p.embedding.as_ref()).is_some(),
+            "pin must capture Some(...) so the test exercises Some vs Some drift",
+        );
+        // Another writer rewrites provider + model under us.
         {
             let mutator = Database::open(&db_path, 384).unwrap();
             mutator
@@ -2349,6 +2437,7 @@ mod tests {
         // by `validate_pinned_state_detects_drift`; this test verifies
         // the promoter wires drift detection to a clean exit (role stays
         // ReadOnly, task finishes).
+        let _serial = test_validate_call_counter::SERIAL.lock().await;
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         let state_dir = dir.path().join("state");
@@ -2412,6 +2501,7 @@ mod tests {
         // open_existing_rw failure — we drop the lock and loop. We
         // assert that by checking the lock file does not persist after
         // a failed promotion attempt.
+        let _serial = test_validate_call_counter::SERIAL.lock().await;
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         let state_dir = dir.path().join("state");
@@ -2457,6 +2547,85 @@ mod tests {
         assert!(
             !lock_path.exists(),
             "promoter must release the lock on failure (not strand serve.pid)"
+        );
+    }
+
+    #[tokio::test]
+    async fn promoter_runs_validate_pinned_state_both_before_and_after_acquire() {
+        // Regression for the M-promoter (c) fix at the test layer: the
+        // promoter must call `validate_pinned_state` BOTH before and
+        // after `ProcessLock::acquire`. We need an assertion that catches
+        // deleting EITHER call site:
+        //
+        // - `calls >= 2` alone is insufficient: pre-acquire validate
+        //   bumps on every tick, so over multiple ticks the count climbs
+        //   past 2 even if the post-acquire site is gone.
+        // - `role == Primary` alone is insufficient: the role swap
+        //   succeeds even if pre-acquire validate is skipped entirely.
+        //
+        // Asserting BOTH catches either deletion: post-acquire validate
+        // gates the role swap (so Primary => post-acquire ran on at
+        // least one tick), and we additionally require `calls >= 2` to
+        // prove a second validate fired in the promote path.
+        let _serial = test_validate_call_counter::SERIAL.lock().await;
+        test_validate_call_counter::reset();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let state_dir = dir.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        {
+            let _ = Database::open(&db_path, 384).unwrap();
+        }
+        let reader = Database::open_readonly(&db_path).unwrap();
+        let pinned = reader.pinned_attach().cloned();
+        let db = Arc::new(Mutex::new(reader));
+        let role = Arc::new(AtomicRole::new(Role::ReadOnly));
+        // Pretend the primary is dead so the promoter exits the
+        // primary-alive `continue` branch and reaches the validate calls.
+        let primary = cartog_process_lock::ActiveLock {
+            slot: SERVE_LOCK_SLOT.to_string(),
+            pid: 4_194_304,
+            start_time: None,
+        };
+
+        let args = promoter_args_for_test(
+            Arc::clone(&db),
+            Arc::clone(&role),
+            db_path,
+            state_dir,
+            primary,
+            pinned,
+        );
+        let handle = tokio::task::spawn(promoter_task(args));
+
+        // Bounded poll instead of a fixed wall-clock sleep: keeps the
+        // test fast on a healthy box and tolerates a stalled CI runner
+        // up to the 2s deadline. We wait for BOTH conditions before
+        // asserting — reading them once after a fixed sleep was the
+        // source of the previous CI-flake risk.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if role.load() == Role::Primary && test_validate_call_counter::snapshot() >= 2 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        handle.abort();
+        let _ = handle.await;
+
+        let calls = test_validate_call_counter::snapshot();
+        assert_eq!(
+            role.load(),
+            Role::Primary,
+            "post-acquire validate gates the role swap; missing role flip implies the post-acquire site never ran"
+        );
+        assert!(
+            calls >= 2,
+            "validate_pinned_state must run twice per promotion tick (pre + post acquire), saw {calls}"
         );
     }
 }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -2293,18 +2293,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_pinned_state_returns_ok_when_pin_is_none() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        {
+            let _ = Database::open(&db_path, 384).unwrap();
+        }
+        validate_pinned_state(&db_path, None).expect("no pin must validate trivially");
+    }
+
+    #[test]
+    fn validate_pinned_state_detects_drift() {
+        // Drift is exercised via the embedding fingerprint (not
+        // schema_version) because `open_readonly` rejects schema_version
+        // mismatch *before* this helper's comparison runs.
+        //
+        // A fresh `Database::open` writes only `embedding_dimension`
+        // (no provider/model), so the read-only attach captures
+        // `pinned.embedding = None`. After the test writes provider and
+        // model, the next `open_readonly` inside `validate_pinned_state`
+        // assembles `embedding = Some(...)`, and `None != Some(...)`
+        // surfaces as drift.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pinned = {
+            let _ = Database::open(&db_path, 384).unwrap();
+            Database::open_readonly(&db_path)
+                .unwrap()
+                .pinned_attach()
+                .cloned()
+        };
+        // Another writer rewrites the embedding provider under us.
+        {
+            let mutator = Database::open(&db_path, 384).unwrap();
+            mutator
+                .set_metadata("embedding_provider", "ollama")
+                .unwrap();
+            mutator
+                .set_metadata("embedding_model", "nomic-embed-text")
+                .unwrap();
+        }
+        let err = validate_pinned_state(&db_path, pinned.as_ref())
+            .expect_err("divergent disk state must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("DB metadata changed"),
+            "error message should name the drift, got: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn promoter_aborts_when_state_diverges_after_acquire() {
-        // Regression for review fix M-promoter (c): the original code
-        // validated pinned state only BEFORE acquire. Between validate
-        // and acquire, a third writer could promote and upgrade the
-        // schema, then exit. We'd then take the lock and proceed with a
-        // stale pin. The fix re-validates AFTER acquire while we hold
-        // the lock.
-        //
-        // We test this by: attach pinned state, mutate on-disk
-        // schema_version under us, then run a single promoter iteration
-        // and assert it bails cleanly (does not flip role to Primary).
+        // Integration smoke. The post-acquire branch logic is covered
+        // by `validate_pinned_state_detects_drift`; this test verifies
+        // the promoter wires drift detection to a clean exit (role stays
+        // ReadOnly, task finishes).
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test.db");
         let state_dir = dir.path().join("state");

--- a/crates/cartog-process-lock/src/lib.rs
+++ b/crates/cartog-process-lock/src/lib.rs
@@ -901,11 +901,11 @@ mod tests {
     }
 
     #[test]
-    fn find_active_locks_does_not_unlink_a_freshly_rewritten_file() {
-        // Integration-level test: when the scanner reads (dead_pid, _)
-        // and decides not-alive but the file has been rewritten to a
-        // live entry by an external writer, the new content must survive
-        // the scan. Exercises find_active_locks's recheck pathway.
+    fn find_active_locks_keeps_live_entries() {
+        // Live PID payload must survive the scan. The prior name implied
+        // unlink coverage, but the alive branch never reaches
+        // unlink_if_unchanged: see the unlink_if_unchanged_* unit tests
+        // for that helper.
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("serve.pid");
         // We simulate the *current* state of the file (after an acquire

--- a/crates/cartog-process-lock/src/start_time.rs
+++ b/crates/cartog-process-lock/src/start_time.rs
@@ -7,6 +7,12 @@
 //! Returned values are OS-native and not portable across machines, but they
 //! are stable across multiple reads of the same live PID — which is all we
 //! need for our same-process check.
+//!
+//! Linux PID-namespace caveat: a container whose `/proc` is overlaid (e.g.
+//! the container sees its own PID 1 but the host PID is different) may get
+//! `None` back from `process_start_time` for its own PID. Callers fall back
+//! to `is_alive` semantics, so PID-reuse detection just degrades to plain
+//! liveness: safe, not exact.
 
 /// Look up the start time of a running process. Returns `None` if the
 /// process is gone, inaccessible, or the platform is unsupported.
@@ -74,6 +80,9 @@ pub fn process_start_time(pid: u32) -> Option<u64> {
     if pid == 0 || pid > i32::MAX as u32 {
         return None;
     }
+    // proc_pidinfo returns 0 (and we return None) when the caller's UID
+    // doesn't match the target. Treated identically to "process gone";
+    // callers fall back to is_alive() semantics.
     let mut info = std::mem::MaybeUninit::<ProcBsdInfo>::uninit();
     let size = std::mem::size_of::<ProcBsdInfo>() as c_int;
     // SAFETY: proc_pidinfo is a stable libproc entry point; we pass an
@@ -91,10 +100,13 @@ pub fn process_start_time(pid: u32) -> Option<u64> {
     if bytes_written != size {
         return None;
     }
-    // SAFETY: proc_pidinfo wrote `size` bytes into `info`, so it is now
-    // fully initialised.
-    let info = unsafe { info.assume_init() };
-    Some(info.pbi_start_tvsec)
+    // SAFETY: proc_pidinfo wrote `size` bytes into `info`. We read only
+    // `pbi_start_tvsec` via addr_of! rather than assume_init on the whole
+    // struct, so if Apple appends fields to proc_bsdinfo in a future SDK
+    // (changing total size) we still tolerate the change as long as the
+    // offset of pbi_start_tvsec stays stable.
+    let start = unsafe { std::ptr::addr_of!((*info.as_ptr()).pbi_start_tvsec).read_unaligned() };
+    Some(start)
 }
 
 #[cfg(windows)]

--- a/crates/cartog-rag/src/providers/ollama.rs
+++ b/crates/cartog-rag/src/providers/ollama.rs
@@ -124,6 +124,11 @@ impl EmbeddingProvider for OllamaEmbeddingProvider {
         "ollama"
     }
 
+    /// Returns the exact string the user configured, not the canonical
+    /// name Ollama resolves it to. A typo (`nomic-embed-tex` vs
+    /// `nomic-embed-text`) stays as written, so the next reconcile sees
+    /// fingerprint drift. Intentional: we'd rather re-embed than silently
+    /// keep stale vectors when the model identity is unclear.
     fn model_id(&self) -> &str {
         &self.model
     }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -150,6 +150,23 @@ The recursive CTE is fast, but SQLite may still need to populate the page
 cache. A second call should drop back to sub-ms. If it doesn't, please attach
 the output of `cartog stats` to your issue.
 
+## Logging and signals
+
+### Info-level lines appear as `[ERROR]` in my MCP client debug log
+
+The CLI uses `info` level when stderr is a TTY and `warn` otherwise. Under
+`tmux`, `docker run -t`, or other terminal-emulating launchers, `IsTerminal`
+may return true even though the MCP parent is consuming stderr, so info
+lines get surfaced as `[ERROR]` by the client. Set `RUST_LOG=warn` to opt
+out.
+
+### What happens if cartog cannot install a SIGINT handler
+
+`cartog serve` and `cartog watch` register a SIGINT handler at startup. If
+the install fails (rare, usually a sandboxed runtime), the handler future
+parks instead of resolving immediately. Other shutdown signals (SIGTERM,
+service shutdown) still work; only Ctrl-C is unavailable until restart.
+
 ## Reporting bugs
 
 A useful issue includes:

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -51,7 +51,7 @@ If MCP runs with `--watch`, the watcher will also re-index on file changes. A ma
 
 When two `cartog serve` instances run against the same DB (e.g. two Claude Code windows on the same project), single-writer election picks one as **primary** and the others attach **read-only**. Read-only secondaries refuse `cartog_index` / `cartog_rag_index` with a clear message but serve the other 11 MCP tools normally. The secondary auto-promotes to primary within ~10s if the primary process dies. See `docs/spec-mcp-sharing.md`.
 
-If `cartog_index` or `cartog_rag_index` fails with a read-only error, call `cartog_stats` and check `role` (`primary` vs `readonly`) and `watcher_active` (whether the primary is auto-reindexing). That tells you whether to wait for promotion (~10s) or whether the primary's watcher will pick up changes on its own.
+If `cartog_index` or `cartog_rag_index` fails with a read-only error, call `cartog_stats` and check `role` (`primary` vs `read-only`) and `watcher_active` (whether the primary is auto-reindexing). That tells you whether to wait for promotion (~10s) or whether the primary's watcher will pick up changes on its own.
 
 After the index is ready:
 

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -51,6 +51,8 @@ If MCP runs with `--watch`, the watcher will also re-index on file changes. A ma
 
 When two `cartog serve` instances run against the same DB (e.g. two Claude Code windows on the same project), single-writer election picks one as **primary** and the others attach **read-only**. Read-only secondaries refuse `cartog_index` / `cartog_rag_index` with a clear message but serve the other 11 MCP tools normally. The secondary auto-promotes to primary within ~10s if the primary process dies. See `docs/spec-mcp-sharing.md`.
 
+If `cartog_index` or `cartog_rag_index` fails with a read-only error, call `cartog_stats` and check `role` (`primary` vs `readonly`) and `watcher_active` (whether the primary is auto-reindexing). That tells you whether to wait for promotion (~10s) or whether the primary's watcher will pick up changes on its own.
+
 After the index is ready:
 
 1. **Explore an unfamiliar codebase** — `cartog map` gives a file tree + top symbols ranked by centrality. Start here when onboarding or orienting.


### PR DESCRIPTION
## Summary

Follow-ups deferred from PR #55 review rounds. No user-visible behavior change; all hygiene/tightening.

**Test quality:**
- Direct unit test `validate_pinned_state_detects_drift` covers the post-acquire revalidation branch via embedding-fingerprint drift (schema_version drift fails earlier in `open_readonly`, so the helper comparison is only reachable via the embedding path).
- Added `validate_pinned_state_returns_ok_when_pin_is_none`.
- Tightened the integration smoke `promoter_aborts_when_state_diverges_after_acquire` docstring to honestly describe what it covers.
- Deleted `test_reconcile_fingerprint_transaction_rolls_back_on_failure` (tested SQLite's rollback, not our code).
- Added `#[cfg(test)] thread_local!` fault-injection hook `RECONCILE_FAIL_AFTER_MODEL` in `reconcile_embedding_fingerprint` so the rollback test deterministically fires SQLITE_FULL mid-sequence. Replaces the prior Ok-branch tautology with `assert!(is_err())` and verifies `symbol_embedding_map` DELETEs roll back too.
- Renamed `find_active_locks_does_not_unlink_a_freshly_rewritten_file` -> `find_active_locks_keeps_live_entries` (prior name implied unlink coverage the test never reaches).

**Code hardening:**
- macOS `process_start_time` reads `pbi_start_tvsec` via `addr_of!(...).read_unaligned()` instead of `assume_init` on the whole struct, tolerating trailing-field drift in future SDKs.

**Docs:**
- `Database.pinned` <-> `is_read_only()` invariant.
- Ollama `model_id` exact-string contract.
- macOS UID-mismatch returns None.
- Linux PID-namespace fallback in `process_start_time` module doc.
- Troubleshooting entries: tmux/`IsTerminal` log levels + SIGINT handler install failure.
- SKILL.md hint to check `cartog_stats.role` and `watcher_active` when a write tool fails read-only.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `make check-skill` (33/33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for MCP logging and signal handling
  * Clarified model identifier behavior and preservation in configurations
  * Added guidance for agent workflow when encountering read-only DB mode
  * Documented PID-start-time edge cases across platforms

* **Tests**
  * Improved and simplified recovery/rollback tests with deterministic fault injection
  * Added unit tests for pinned-state validation and drift detection
  * Updated process-lock test descriptions to clarify liveness behavior

* **Bug Fixes**
  * Safer macOS process-start-time handling to avoid unsafe reads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->