### PR TITLE
feat(serve,watch): DB-scoped PID lock slots + stale-file sweep

### DIFF
--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -1261,7 +1261,19 @@ fn single_writer_election_enabled() -> bool {
 pub fn acquire_serve_lock(opts: &ServerOptions) -> anyhow::Result<ServeLockOutcome> {
     let dir = match opts.pid_lock_dir.as_deref() {
         Some(d) => d,
-        None => return Ok(ServeLockOutcome::Untracked),
+        None => {
+            // Inverse half-config: slot set but no dir. The slot is unused
+            // and the caller's intent is silently dropped, so we surface
+            // it as an error rather than running untracked.
+            if opts.pid_lock_slot.is_some() {
+                return Err(anyhow::anyhow!(
+                    "ServerOptions::pid_lock_slot is set but pid_lock_dir is None; \
+                     a slot without a directory is silently ignored — either set \
+                     both fields or clear both to run untracked"
+                ));
+            }
+            return Ok(ServeLockOutcome::Untracked);
+        }
     };
     // Reject the dangerous half-configured state: pid_lock_dir set but no
     // slot. Falling back to a global SERVE_LOCK_SLOT here would let an
@@ -2100,6 +2112,24 @@ mod tests {
         let err = acquire_serve_lock(&opts).unwrap_err();
         assert!(
             err.to_string().contains("pid_lock_slot is None"),
+            "error must explain the misconfiguration, got: {err}"
+        );
+    }
+
+    #[test]
+    fn acquire_serve_lock_rejects_slot_without_dir() {
+        // Inverse half-config: pid_lock_slot set but pid_lock_dir is
+        // None. Pre-fix the slot was silently ignored and the function
+        // returned Ok(Untracked), losing the caller's intent. Must
+        // surface as a hard error.
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        let opts = ServerOptions {
+            pid_lock_dir: None,
+            pid_lock_slot: Some("serve-deadbeef".to_string()),
+        };
+        let err = acquire_serve_lock(&opts).unwrap_err();
+        assert!(
+            err.to_string().contains("pid_lock_dir is None"),
             "error must explain the misconfiguration, got: {err}"
         );
     }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -1178,6 +1178,35 @@ impl ServerHandler for CartogServer {
 
 pub const SERVE_LOCK_SLOT: &str = "serve";
 
+/// Convert a serve-family slot (legacy `"serve"` or DB-scoped
+/// `"serve-<hash>"`) to the matching watch-family slot
+/// (`"watch"` / `"watch-<hash>"`). Used by [`run_server`] so both PID files
+/// for the same DB share their scope.
+///
+/// Anchored on the exact prefixes `"serve"` (literal, legacy) and
+/// `"serve-"` (DB-scoped, followed by the hex suffix). Inputs that
+/// happen to start with the four letters `serve` but are NOT a
+/// serve-family slot (`"server"`, `"serverless"`, `"servefoo"`, …) fall
+/// through to the global watch slot rather than silently producing a
+/// corrupted "watch{rest}" string.
+fn serve_to_watch_slot(serve_slot: &str) -> String {
+    if serve_slot == "serve" {
+        return watch::WATCH_LOCK_SLOT.to_string();
+    }
+    // strip_prefix + non-empty filter: `"serve-"` alone (trailing dash,
+    // empty hex) is treated as off-pattern, not as the legitimate
+    // serve-<hex> shape. Without the filter it would silently produce
+    // the slot "watch-" which validates but encodes no DB scope.
+    if let Some(rest) = serve_slot.strip_prefix("serve-").filter(|r| !r.is_empty()) {
+        return format!("watch-{rest}");
+    }
+    // Unknown prefix or off-pattern input: fall back to the global watch
+    // slot so we don't emit a fabricated slot that no other process can
+    // reproduce. Should not happen for slots produced by
+    // `state::slot_for_db("serve", _)` but guards against caller mistakes.
+    watch::WATCH_LOCK_SLOT.to_string()
+}
+
 /// Environment variable that, when set to `0`, disables single-writer
 /// election (every cartog process opens RW like pre-Phase-2 cartog). The
 /// migration-busy-retry from Phase 6a remains the only defense in that mode.
@@ -1189,6 +1218,18 @@ pub struct ServerOptions {
     /// graceful exit). `None` disables PID-file tracking. Consulted by
     /// `cartog self update` to detect a running peer.
     pub pid_lock_dir: Option<PathBuf>,
+    /// Slot name used when acquiring the serve PID file. Required when
+    /// `pid_lock_dir` is set — [`acquire_serve_lock`] hard-fails if a
+    /// directory is configured without a slot, to prevent a global-slot
+    /// peer from silently colliding with DB-scoped peers in
+    /// multi-project setups. `None` is only valid when `pid_lock_dir`
+    /// is also `None` (untracked mode used by tests).
+    ///
+    /// In the cartog binary the slot is derived via
+    /// `cartog::state::slot_for_db("serve", db_path)`. Library
+    /// embedders should follow the same shape: `<prefix>-<16 hex chars>`
+    /// where the hex is a SHA-256 prefix of the canonicalized DB path.
+    pub pid_lock_slot: Option<String>,
 }
 
 /// Outcome of trying to claim the `serve` lock at MCP startup.
@@ -1222,11 +1263,24 @@ pub fn acquire_serve_lock(opts: &ServerOptions) -> anyhow::Result<ServeLockOutco
         Some(d) => d,
         None => return Ok(ServeLockOutcome::Untracked),
     };
+    // Reject the dangerous half-configured state: pid_lock_dir set but no
+    // slot. Falling back to a global SERVE_LOCK_SLOT here would let an
+    // embedder claim `serve.pid` while a CLI peer on the same DB derives
+    // `serve-<hash>.pid`, producing two primaries on the same DB. Require
+    // the caller to opt into a slot explicitly (use
+    // `cartog::state::slot_for_db("serve", db_path)` from the bin crate).
+    let slot: &str = opts.pid_lock_slot.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "ServerOptions::pid_lock_dir is set but pid_lock_slot is None; \
+             refusing to claim the global serve slot — pass a DB-scoped slot \
+             (e.g. `cartog::state::slot_for_db(\"serve\", db_path)`)"
+        )
+    })?;
     if !single_writer_election_enabled() {
         // Kill switch: use the old overwrite-on-acquire behavior. We still
         // write our PID file so `cartog self update` and friends see us.
-        let lock = cartog_process_lock::ProcessLock::acquire_overwriting(dir, SERVE_LOCK_SLOT)
-            .map_err(|e| {
+        let lock =
+            cartog_process_lock::ProcessLock::acquire_overwriting(dir, slot).map_err(|e| {
                 anyhow::anyhow!(
                     "failed to acquire serve PID lock at {} (single-writer election disabled): {e}",
                     dir.display()
@@ -1234,7 +1288,7 @@ pub fn acquire_serve_lock(opts: &ServerOptions) -> anyhow::Result<ServeLockOutco
             })?;
         return Ok(ServeLockOutcome::Primary(lock));
     }
-    match cartog_process_lock::ProcessLock::acquire(dir, SERVE_LOCK_SLOT) {
+    match cartog_process_lock::ProcessLock::acquire(dir, slot) {
         Ok(lock) => Ok(ServeLockOutcome::Primary(lock)),
         Err(cartog_process_lock::AcquireError::Held(held)) => Ok(ServeLockOutcome::Held(held)),
         Err(cartog_process_lock::AcquireError::Io(e)) => Err(anyhow::anyhow!(
@@ -1280,11 +1334,20 @@ pub async fn run_server(
     // give us two indexers fighting over the DB. Read-only clients ride
     // along on the primary's index updates via WAL.
     let db_path_str = db_path.to_string_lossy().into_owned();
+    // Derive the watcher's slot from the serve slot so per-DB scoping is
+    // consistent across both PID files. When serve runs un-scoped (legacy /
+    // tests), the watcher also runs un-scoped via the WATCH_LOCK_SLOT
+    // fallback inside `cartog-watch`.
+    let watch_slot: Option<String> = opts.pid_lock_slot.as_deref().map(serve_to_watch_slot);
     let initial_watch_handle: Option<WatchHandle> = if watch && role == Role::Primary {
         let cwd = std::env::current_dir()?;
         let mut config = WatchConfig::new(cwd);
         config.rag = rag;
         config.rag_config = rag_config.clone();
+        // Claim the watcher's PID slot so a separately-running `cartog watch`
+        // from a terminal correctly refuses to start against the same DB.
+        config.pid_lock_dir = opts.pid_lock_dir.clone();
+        config.pid_lock_slot = watch_slot.clone();
         match watch::spawn_watch(config, &db_path_str) {
             Ok(handle) => {
                 info!(rag, "background file watcher started");
@@ -1341,6 +1404,18 @@ pub async fn run_server(
                     watcher_active: Arc::clone(&server.watcher_active),
                     db_path: db_path.to_path_buf(),
                     state_dir,
+                    // .expect documents the precondition: this branch
+                    // requires opts.pid_lock_dir.is_some() (see line above),
+                    // and acquire_serve_lock already hard-fails when dir is
+                    // Some but slot is None. A future refactor that loosens
+                    // either guard will trip this assertion loudly rather
+                    // than silently re-introducing global-slot peers.
+                    serve_slot: opts.pid_lock_slot.clone().expect(
+                        "precondition: acquire_serve_lock rejects pid_lock_dir without pid_lock_slot",
+                    ),
+                    watch_slot: watch_slot.clone().expect(
+                        "precondition: watch_slot is derived from opts.pid_lock_slot above",
+                    ),
                     cwd,
                     primary,
                     pinned,
@@ -1411,6 +1486,13 @@ struct PromoterArgs {
     watcher_active: Arc<std::sync::atomic::AtomicBool>,
     db_path: std::path::PathBuf,
     state_dir: std::path::PathBuf,
+    /// Slot to claim when the promoter wins election. Matches the slot the
+    /// originally-attached primary held — DB-scoped (`serve-<hash>`) in
+    /// production, the global `SERVE_LOCK_SLOT` in legacy / test paths.
+    serve_slot: String,
+    /// Slot the post-promotion watcher claims. Derived from `serve_slot`
+    /// (see `serve_to_watch_slot`) so both PID files share their scope.
+    watch_slot: String,
     /// CWD captured at server startup. Reused for the post-promotion
     /// watcher so the watch root doesn't follow a later `std::env::set_current_dir`.
     cwd: std::path::PathBuf,
@@ -1470,7 +1552,7 @@ async fn promoter_task(args: PromoterArgs) {
         // Atomic O_EXCL acquire. Other readers may race us; the loser stays
         // read-only and tries again on the next tick.
         let new_lock =
-            match cartog_process_lock::ProcessLock::acquire(&args.state_dir, SERVE_LOCK_SLOT) {
+            match cartog_process_lock::ProcessLock::acquire(&args.state_dir, &args.serve_slot) {
                 Ok(lock) => lock,
                 Err(cartog_process_lock::AcquireError::Held(held)) => {
                     info!(
@@ -1568,6 +1650,7 @@ async fn promoter_task(args: PromoterArgs) {
             config.rag = args.rag;
             config.rag_config = args.rag_config.clone();
             config.pid_lock_dir = Some(args.state_dir.clone());
+            config.pid_lock_slot = Some(args.watch_slot.clone());
             // Skip migrations because we validated the schema when we
             // attached read-only — re-running them would re-trigger the
             // embedding-dimension reconcile the election prevents.
@@ -1962,6 +2045,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let opts = ServerOptions {
             pid_lock_dir: Some(dir.path().to_path_buf()),
+            pid_lock_slot: Some(SERVE_LOCK_SLOT.to_string()),
         };
         let outcome = acquire_serve_lock(&opts).expect("acquire");
         let lock = match outcome {
@@ -2001,6 +2085,75 @@ mod tests {
     }
 
     #[test]
+    fn acquire_serve_lock_rejects_dir_without_slot() {
+        // Regression: a half-configured ServerOptions (pid_lock_dir set,
+        // pid_lock_slot None) used to silently fall back to the global
+        // SERVE_LOCK_SLOT, letting an embedder collide with — or be hidden
+        // from — a CLI peer that derives a DB-scoped slot. The mixed-scope
+        // hazard must surface as a hard error.
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::TempDir::new().unwrap();
+        let opts = ServerOptions {
+            pid_lock_dir: Some(dir.path().to_path_buf()),
+            pid_lock_slot: None,
+        };
+        let err = acquire_serve_lock(&opts).unwrap_err();
+        assert!(
+            err.to_string().contains("pid_lock_slot is None"),
+            "error must explain the misconfiguration, got: {err}"
+        );
+    }
+
+    #[test]
+    fn distinct_slots_for_different_dbs_do_not_collide() {
+        // Two cartog peers serving different DBs in the same per-user state
+        // dir must coexist. Pre-PR, both fought over a single `serve.pid`
+        // slot; with DB-scoped slots they each claim their own
+        // `serve-<hash>.pid`.
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::TempDir::new().unwrap();
+        let opts_a = ServerOptions {
+            pid_lock_dir: Some(dir.path().to_path_buf()),
+            pid_lock_slot: Some("serve-aaaa1111".to_string()),
+        };
+        let opts_b = ServerOptions {
+            pid_lock_dir: Some(dir.path().to_path_buf()),
+            pid_lock_slot: Some("serve-bbbb2222".to_string()),
+        };
+        let _a = match acquire_serve_lock(&opts_a).expect("acquire A") {
+            ServeLockOutcome::Primary(l) => l,
+            other => panic!("expected Primary for A, got {other:?}"),
+        };
+        let _b = match acquire_serve_lock(&opts_b).expect("acquire B") {
+            ServeLockOutcome::Primary(l) => l,
+            other => panic!("expected Primary for B, got {other:?}"),
+        };
+        // Both PID files present on disk, no Held collision.
+        assert!(dir.path().join("serve-aaaa1111.pid").exists());
+        assert!(dir.path().join("serve-bbbb2222.pid").exists());
+    }
+
+    #[test]
+    fn serve_to_watch_slot_preserves_db_scope() {
+        // The watcher slot is derived from the serve slot so both PID files
+        // for the same DB share their scope suffix.
+        assert_eq!(serve_to_watch_slot("serve"), "watch");
+        assert_eq!(serve_to_watch_slot("serve-abc123"), "watch-abc123");
+        // Unknown prefix falls back to the global watch slot.
+        assert_eq!(serve_to_watch_slot("unknown-prefix"), "watch");
+        // Off-pattern inputs that start with the bytes "serve" but are NOT
+        // a serve-family slot must fall back to the global slot rather than
+        // produce a silently-corrupted "watch{rest}" string.
+        assert_eq!(serve_to_watch_slot("server"), "watch");
+        assert_eq!(serve_to_watch_slot("serverless"), "watch");
+        assert_eq!(serve_to_watch_slot("servefoo"), "watch");
+        assert_eq!(serve_to_watch_slot("Serve"), "watch");
+        assert_eq!(serve_to_watch_slot(""), "watch");
+        // Trailing-dash with empty hex: must fall back, not emit "watch-".
+        assert_eq!(serve_to_watch_slot("serve-"), "watch");
+    }
+
+    #[test]
     fn second_acquire_for_same_dir_reports_held() {
         // Two acquire_serve_lock calls against the same dir: the first wins,
         // the second must surface Held(_) with the first's PID so the caller
@@ -2009,6 +2162,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let opts = ServerOptions {
             pid_lock_dir: Some(dir.path().to_path_buf()),
+            pid_lock_slot: Some(SERVE_LOCK_SLOT.to_string()),
         };
         let _first = match acquire_serve_lock(&opts).expect("first acquire") {
             ServeLockOutcome::Primary(l) => l,
@@ -2034,6 +2188,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let opts = ServerOptions {
             pid_lock_dir: Some(dir.path().to_path_buf()),
+            pid_lock_slot: Some(SERVE_LOCK_SLOT.to_string()),
         };
         let _first = match acquire_serve_lock(&opts).expect("first acquire") {
             ServeLockOutcome::Primary(l) => l,
@@ -2257,6 +2412,7 @@ mod tests {
         let blocker = tempfile::NamedTempFile::new().unwrap();
         let opts = ServerOptions {
             pid_lock_dir: Some(blocker.path().to_path_buf()),
+            pid_lock_slot: Some(SERVE_LOCK_SLOT.to_string()),
         };
         let err = acquire_serve_lock(&opts).unwrap_err();
         assert!(
@@ -2275,6 +2431,26 @@ mod tests {
         primary: cartog_process_lock::ActiveLock,
         pinned: Option<PinnedAttach>,
     ) -> PromoterArgs {
+        promoter_args_with_slot(
+            db,
+            role,
+            db_path,
+            state_dir,
+            primary,
+            pinned,
+            SERVE_LOCK_SLOT,
+        )
+    }
+
+    fn promoter_args_with_slot(
+        db: Arc<Mutex<Database>>,
+        role: Arc<AtomicRole>,
+        db_path: std::path::PathBuf,
+        state_dir: std::path::PathBuf,
+        primary: cartog_process_lock::ActiveLock,
+        pinned: Option<PinnedAttach>,
+        serve_slot: &str,
+    ) -> PromoterArgs {
         PromoterArgs {
             db,
             role,
@@ -2283,6 +2459,8 @@ mod tests {
             watcher_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             db_path: db_path.clone(),
             state_dir,
+            serve_slot: serve_slot.to_string(),
+            watch_slot: serve_to_watch_slot(serve_slot),
             cwd: std::env::current_dir().unwrap(),
             primary,
             pinned,
@@ -2434,6 +2612,164 @@ mod tests {
             msg.contains("DB metadata changed"),
             "error message should name the drift, got: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn promoter_acquires_db_scoped_slot_from_args() {
+        // Regression: promoter_task must acquire the slot carried in
+        // `args.serve_slot`, not a hardcoded `SERVE_LOCK_SLOT`. The
+        // previous test scaffolding hardcoded the global slot, so a
+        // refactor that reverts the acquire call to `SERVE_LOCK_SLOT`
+        // would have shipped green. This test passes a non-global serve
+        // slot and asserts the on-disk PID filename matches.
+        let _serial = test_validate_call_counter::SERIAL.lock().await;
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let state_dir = dir.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        {
+            let _ = Database::open(&db_path, 384).unwrap();
+        }
+        let reader_db = Database::open_readonly(&db_path).unwrap();
+        let pinned = reader_db.pinned_attach().cloned();
+        let db = Arc::new(Mutex::new(reader_db));
+        let role = Arc::new(AtomicRole::new(Role::ReadOnly));
+        // Dead primary holding the scoped slot we want the promoter to
+        // claim. Slot name must match exactly what the promoter acquires
+        // so the original `serve-fa11`.pid file (planted below) gets
+        // reclaimed.
+        let scoped_slot = "serve-fa11ed7e57c0fed5";
+        let primary_pid_path = state_dir.join(format!("{scoped_slot}.pid"));
+        std::fs::write(&primary_pid_path, "4194304\n0\n").unwrap();
+        let primary = cartog_process_lock::ActiveLock {
+            slot: scoped_slot.to_string(),
+            pid: 4_194_304,
+            start_time: None,
+        };
+
+        let args = promoter_args_with_slot(
+            Arc::clone(&db),
+            Arc::clone(&role),
+            db_path,
+            state_dir.clone(),
+            primary,
+            pinned,
+            scoped_slot,
+        );
+        // Keep the lock_cell Arc alive past the task so the acquired
+        // ProcessLock isn't dropped (and the PID file removed) before we
+        // assert on it. The production run_server lifecycle does the
+        // same: it holds lock_cell for the whole server lifetime.
+        let lock_cell = Arc::clone(&args.lock_cell);
+
+        let handle = tokio::task::spawn(promoter_task(args));
+        // Give the promoter time to notice primary-gone and acquire.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        assert_eq!(
+            role.load(),
+            Role::Primary,
+            "promoter must flip role after acquiring the scoped slot"
+        );
+        // The on-disk PID file must use the scoped slot, not the global.
+        assert!(
+            primary_pid_path.exists(),
+            "expected promoter to acquire {primary_pid_path:?}"
+        );
+        let global_path = state_dir.join(format!("{SERVE_LOCK_SLOT}.pid"));
+        assert!(
+            !global_path.exists(),
+            "promoter must NOT acquire the global slot ({global_path:?})"
+        );
+
+        // Drop the held lock explicitly so the temp dir teardown is clean.
+        {
+            let mut guard = lock_cell.lock().unwrap();
+            *guard = None;
+        }
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn promoter_spawns_watcher_with_db_scoped_watch_slot() {
+        // Regression for review finding #2: promoter_task must claim the
+        // watch slot carried in `args.watch_slot`, not a hardcoded
+        // `WATCH_LOCK_SLOT`. The previous regression test only verified
+        // the serve-slot acquire path; a refactor that reverts the
+        // post-promotion watcher's `config.pid_lock_slot = Some(args
+        // .watch_slot.clone())` to the global constant would have shipped
+        // green. This test sets `watch_requested = true`, lets the
+        // promoter spawn a watcher, and asserts the watcher claims the
+        // scoped slot on disk.
+        let _serial = test_validate_call_counter::SERIAL.lock().await;
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let state_dir = dir.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        {
+            let _ = Database::open(&db_path, 384).unwrap();
+        }
+        let reader_db = Database::open_readonly(&db_path).unwrap();
+        let pinned = reader_db.pinned_attach().cloned();
+        let db = Arc::new(Mutex::new(reader_db));
+        let role = Arc::new(AtomicRole::new(Role::ReadOnly));
+        let scoped_slot = "serve-fa11ed7e57c0fed5";
+        let primary_pid_path = state_dir.join(format!("{scoped_slot}.pid"));
+        std::fs::write(&primary_pid_path, "4194304\n0\n").unwrap();
+        let primary = cartog_process_lock::ActiveLock {
+            slot: scoped_slot.to_string(),
+            pid: 4_194_304,
+            start_time: None,
+        };
+
+        let mut args = promoter_args_with_slot(
+            Arc::clone(&db),
+            Arc::clone(&role),
+            db_path,
+            state_dir.clone(),
+            primary,
+            pinned,
+            scoped_slot,
+        );
+        // Enable the watcher-spawn path. RAG stays off and watch root
+        // (cwd, captured by the helper) is the cartog crate dir — fine
+        // for spawning the watcher; we tear it down immediately.
+        args.watch_requested = true;
+        let lock_cell = Arc::clone(&args.lock_cell);
+        let watch_cell = Arc::clone(&args.watch_cell);
+
+        let handle = tokio::task::spawn(promoter_task(args));
+        // Give the promoter time to promote + spawn the watcher thread.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // The expected watcher PID file uses the SCOPED watch slot derived
+        // via `serve_to_watch_slot(scoped_slot)`.
+        let expected_watch_slot = serve_to_watch_slot(scoped_slot);
+        let expected_watch_pid = state_dir.join(format!("{expected_watch_slot}.pid"));
+        let global_watch_pid = state_dir.join(format!("{}.pid", watch::WATCH_LOCK_SLOT));
+        assert!(
+            expected_watch_pid.exists(),
+            "watcher should have claimed the scoped slot at {expected_watch_pid:?}"
+        );
+        assert!(
+            !global_watch_pid.exists(),
+            "watcher must NOT claim the global slot ({global_watch_pid:?})"
+        );
+
+        // Clean shutdown so the temp dir teardown succeeds.
+        {
+            let mut wguard = watch_cell.lock().unwrap();
+            if let Some(handle) = wguard.take() {
+                handle.stop();
+            }
+        }
+        {
+            let mut guard = lock_cell.lock().unwrap();
+            *guard = None;
+        }
+        handle.abort();
+        let _ = handle.await;
     }
 
     #[tokio::test]

--- a/crates/cartog-process-lock/src/lib.rs
+++ b/crates/cartog-process-lock/src/lib.rs
@@ -57,7 +57,7 @@ impl std::fmt::Display for AcquireError {
         match self {
             AcquireError::Held(lock) => write!(
                 f,
-                "another cartog process holds slot {slot:?} (PID {pid})",
+                "another cartog process holds slot {slot} (PID {pid})",
                 slot = lock.slot,
                 pid = lock.pid,
             ),
@@ -99,6 +99,12 @@ impl ProcessLock {
     pub fn acquire(state_dir: &Path, slot: &str) -> Result<Self, AcquireError> {
         validate_slot(slot).map_err(AcquireError::Io)?;
         fs::create_dir_all(state_dir).map_err(AcquireError::Io)?;
+        // Reap any stale `*.pid` files left by crashed peers before we try
+        // to claim our own slot. Without this, DB-scoped slots accumulate
+        // (each crashed project leaves its own `serve-<hash>.pid`) until a
+        // `cartog self update` runs. Sweep uses `unlink_if_unchanged` so a
+        // live peer that lands fresh content during the scan is preserved.
+        sweep_stale_locks(state_dir);
         let path = state_dir.join(format!("{slot}.{PID_EXTENSION}"));
         let pid = std::process::id();
         let payload = match process_start_time(pid) {
@@ -250,6 +256,10 @@ impl ProcessLock {
     pub fn acquire_overwriting(state_dir: &Path, slot: &str) -> io::Result<Self> {
         validate_slot(slot)?;
         fs::create_dir_all(state_dir)?;
+        // Same sweep as the O_EXCL path: even with election disabled, we
+        // want crashed-peer leftovers from other DBs to disappear so a
+        // listing of the state dir doesn't grow without bound.
+        sweep_stale_locks(state_dir);
         let path = state_dir.join(format!("{slot}.{PID_EXTENSION}"));
         let pid = std::process::id();
         let tmp = state_dir.join(format!(".{slot}.{pid}.{PID_EXTENSION}.tmp"));
@@ -344,6 +354,28 @@ pub fn find_active_locks(state_dir: &Path) -> Vec<ActiveLock> {
         }
     }
     active
+}
+
+/// Reap stale PID files in `state_dir`. Side-effect equivalent of
+/// [`find_active_locks`] without the return value.
+///
+/// Each `*.pid` whose recorded PID is dead (or whose recorded start_time
+/// disagrees with the live PID, i.e. PID-reuse) is unlinked via
+/// [`unlink_if_unchanged`] so a concurrent writer landing fresh content in
+/// the TOCTOU window is preserved. Malformed files (unreadable on two
+/// consecutive reads) are removed unconditionally because there is no
+/// holder identity to protect.
+///
+/// Called from [`ProcessLock::acquire`] so every long-lived command launch
+/// (`cartog serve`, `cartog watch`, promoter handoff) reaps leftovers from
+/// crashed peers before claiming its own slot. Cost is one `read_dir` plus
+/// one `kill(pid, 0)` per file — sub-millisecond on a state dir with a
+/// handful of entries.
+///
+/// A missing or unreadable `state_dir` is a no-op (the caller will create
+/// it during their own acquire).
+pub fn sweep_stale_locks(state_dir: &Path) {
+    let _ = find_active_locks(state_dir);
 }
 
 /// Unlink the PID file at `path` only if its current contents still match
@@ -1020,6 +1052,91 @@ mod tests {
         let (recorded_pid, recorded_st) = read_lock_file(&path).expect("file parses");
         assert_eq!(recorded_pid, pid);
         assert_eq!(recorded_st, Some(real_st));
+    }
+
+    #[test]
+    fn sweep_stale_locks_removes_dead_entries_from_other_slots() {
+        // Regression for the DB-scoped-slot accumulation: pre-sweep, a
+        // crashed peer for project A left `serve-aaaa.pid` lying in the
+        // state dir forever; a fresh acquire for project B's slot
+        // `serve-bbbb` never touched it. Now every acquire scans first
+        // and reaps stale files belonging to ANY slot.
+        let dir = TempDir::new().unwrap();
+        let stale_a = dir.path().join("serve-aaaa1111.pid");
+        let stale_b = dir.path().join("watch-bbbb2222.pid");
+        // PIDs guaranteed dead (above Linux's pid_max).
+        fs::write(&stale_a, "4194304\n0\n").unwrap();
+        fs::write(&stale_b, "4194304\n0\n").unwrap();
+
+        // Acquire a fresh, unrelated slot. Sweep must run during acquire
+        // and clean both unrelated stale files even though we are not
+        // claiming either of them.
+        let _lock = ProcessLock::acquire(dir.path(), "serve-cccc3333").unwrap();
+        assert!(
+            !stale_a.exists(),
+            "stale serve-aaaa1111.pid should be swept by acquire"
+        );
+        assert!(
+            !stale_b.exists(),
+            "stale watch-bbbb2222.pid should be swept by acquire"
+        );
+    }
+
+    #[test]
+    fn sweep_stale_locks_preserves_live_entries() {
+        // The sweep must NOT touch a live peer's PID file. We plant our
+        // own PID under an unrelated slot, then acquire a fresh slot;
+        // the live file must survive.
+        let dir = TempDir::new().unwrap();
+        let live_slot = "serve-live9999";
+        let live_path = dir.path().join(format!("{live_slot}.pid"));
+        let pid = std::process::id();
+        let payload = match process_start_time(pid) {
+            Some(st) => format!("{pid}\n{st}\n"),
+            None => format!("{pid}\n"),
+        };
+        fs::write(&live_path, &payload).unwrap();
+
+        let _lock = ProcessLock::acquire(dir.path(), "serve-other1111").unwrap();
+        assert!(
+            live_path.exists(),
+            "live peer's PID file must survive a sweep from an unrelated acquire"
+        );
+    }
+
+    #[test]
+    fn sweep_stale_locks_is_callable_independently() {
+        // Public entry point should be usable from any cartog tool (e.g.
+        // a hypothetical `cartog doctor --clean-locks`).
+        let dir = TempDir::new().unwrap();
+        let stale = dir.path().join("watch-stale1234.pid");
+        fs::write(&stale, "4194304\n0\n").unwrap();
+        sweep_stale_locks(dir.path());
+        assert!(!stale.exists(), "sweep should remove the stale file");
+    }
+
+    #[test]
+    fn sweep_stale_locks_no_op_on_missing_dir() {
+        // Defensive: a missing state_dir must not panic or error.
+        let parent = TempDir::new().unwrap();
+        let missing = parent.path().join("does-not-exist");
+        sweep_stale_locks(&missing);
+        // No assertion needed — absence of panic is the test.
+    }
+
+    #[test]
+    fn acquire_overwriting_sweeps_stale_too() {
+        // The kill-switch path runs the same sweep; we test it
+        // explicitly so a future refactor that only touches `acquire`
+        // doesn't drop the cleanup on the other path.
+        let dir = TempDir::new().unwrap();
+        let stale = dir.path().join("watch-old5678.pid");
+        fs::write(&stale, "4194304\n0\n").unwrap();
+        let _lock = ProcessLock::acquire_overwriting(dir.path(), "serve-new").unwrap();
+        assert!(
+            !stale.exists(),
+            "stale entries should be swept by acquire_overwriting"
+        );
     }
 
     #[test]

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -40,6 +40,18 @@ pub struct WatchConfig {
     /// graceful exit). `None` disables PID-file tracking. Consulted by
     /// `cartog self update` to detect a running watcher.
     pub pid_lock_dir: Option<PathBuf>,
+    /// Slot name used when acquiring the watch PID file. Required when
+    /// `pid_lock_dir` is set — [`run_watch`]/[`spawn_watch`] hard-fail
+    /// if a directory is configured without a slot, to prevent a
+    /// global-slot watcher from silently colliding with DB-scoped peers
+    /// in multi-project setups. `None` is only valid when `pid_lock_dir`
+    /// is also `None` (untracked mode used by tests).
+    ///
+    /// In the cartog binary the slot is derived via
+    /// `cartog::state::slot_for_db("watch", db_path)`. Library
+    /// embedders should follow the same shape: `<prefix>-<16 hex chars>`
+    /// where the hex is a SHA-256 prefix of the canonicalized DB path.
+    pub pid_lock_slot: Option<String>,
     /// Open the on-disk DB via `Database::open_existing_rw` instead of
     /// `Database::open`. Used by the Phase 5 promoter to attach without
     /// re-running schema migrations (the promoter validated the schema
@@ -61,11 +73,17 @@ impl WatchConfig {
             rag_config: rag::EmbeddingProviderConfig::default(),
             json_events: false,
             pid_lock_dir: None,
+            pid_lock_slot: None,
             skip_migrations: false,
         }
     }
 }
 
+/// Legacy fallback slot used in untracked mode (`pid_lock_dir = None`,
+/// `pid_lock_slot = None`). When `pid_lock_dir` is set, callers must
+/// provide a DB-scoped slot via
+/// `cartog::state::slot_for_db("watch", db_path)` — see
+/// [`WatchConfig::pid_lock_slot`].
 pub const WATCH_LOCK_SLOT: &str = "watch";
 
 /// A single event emitted by the watch loop when `json_events` is enabled.
@@ -152,9 +170,34 @@ impl Drop for WatchHandle {
 /// Returns a `WatchHandle` that can be used to stop the watcher.
 /// The watcher opens its own `Database` connection (SQLite WAL allows concurrent readers).
 ///
-/// Errors from `watch_loop` (including PID-lock acquire failures) are
+/// Validate that the PID-lock configuration on a [`WatchConfig`] is
+/// internally consistent. The dangerous half-configured state is
+/// `pid_lock_dir = Some(_)` with `pid_lock_slot = None`: a global
+/// `watch.pid` claim coexists undetected with any DB-scoped peer for the
+/// same DB and two indexers race. Called synchronously by both
+/// [`spawn_watch`] and [`run_watch`] so a misconfigured embedder never
+/// gets an `Ok(WatchHandle)` for a watcher that died on the spot.
+fn validate_pid_lock_config(config: &WatchConfig) -> Result<()> {
+    if config.pid_lock_dir.is_some() && config.pid_lock_slot.is_none() {
+        anyhow::bail!(
+            "WatchConfig::pid_lock_dir is set but pid_lock_slot is None; \
+             refusing to claim the global watch slot — pass a DB-scoped slot \
+             (e.g. `cartog::state::slot_for_db(\"watch\", db_path)`)"
+        );
+    }
+    Ok(())
+}
+
+/// Errors from `watch_loop` after the synchronous validation pass
+/// (PID-lock contention with a live peer, filesystem I/O failures) are
 /// logged inside the thread; the caller still receives `Ok(WatchHandle)`.
-/// Use [`run_watch`] when lock failures must propagate synchronously.
+/// Static misconfiguration of [`WatchConfig`] (e.g. `pid_lock_dir` set
+/// without `pid_lock_slot`) is checked synchronously before the thread
+/// is spawned and surfaced as `Err`, so a misconfigured embedder never
+/// gets a `WatchHandle` whose thread is already dead.
+///
+/// Use [`run_watch`] when ALL failures (including post-spawn lock
+/// contention) must propagate synchronously.
 pub fn spawn_watch(config: WatchConfig, db_path: &str) -> Result<WatchHandle> {
     let root = config
         .root
@@ -164,6 +207,7 @@ pub fn spawn_watch(config: WatchConfig, db_path: &str) -> Result<WatchHandle> {
     if !root.is_dir() {
         anyhow::bail!("watch target is not a directory: {}", root.display());
     }
+    validate_pid_lock_config(&config)?;
 
     let db_path = db_path.to_string();
     let shutdown = Arc::new(AtomicBool::new(false));
@@ -188,6 +232,7 @@ pub fn spawn_watch(config: WatchConfig, db_path: &str) -> Result<WatchHandle> {
 ///
 /// Used by `cartog watch` CLI command.
 pub fn run_watch(config: WatchConfig, db_path: &str) -> Result<()> {
+    validate_pid_lock_config(&config)?;
     let root = config
         .root
         .canonicalize()
@@ -229,26 +274,34 @@ fn watch_loop(
     // `cartog watch` from a terminal correctly sees Held and aborts. Two
     // watchers writing to the same DB would re-index the same files in
     // parallel; the watch slot is the only thing preventing that.
-    let _lock: Option<cartog_process_lock::ProcessLock> = match config.pid_lock_dir.as_deref() {
-        Some(dir) => match cartog_process_lock::ProcessLock::acquire(dir, WATCH_LOCK_SLOT) {
-            Ok(lock) => Some(lock),
-            Err(cartog_process_lock::AcquireError::Held(held)) => {
-                anyhow::bail!(
-                    "another cartog process holds the watch lock at {} (slot {:?}, PID {}); \
-                     stop it before running `cartog watch`",
-                    dir.display(),
-                    held.slot,
-                    held.pid,
-                );
-            }
-            Err(cartog_process_lock::AcquireError::Io(e)) => {
-                return Err(e).with_context(|| {
-                    format!("failed to acquire watch PID lock at {}", dir.display())
-                });
-            }
-        },
-        None => None,
-    };
+    //
+    // The (Some(dir), None) hard-fail is enforced synchronously by
+    // `validate_pid_lock_config` in spawn_watch/run_watch BEFORE this
+    // function runs; reaching this point with a misconfigured pair
+    // means a caller bypassed those entry points.
+    validate_pid_lock_config(&config)?;
+    let watch_slot: Option<&str> = config.pid_lock_slot.as_deref();
+    let _lock: Option<cartog_process_lock::ProcessLock> =
+        match (config.pid_lock_dir.as_deref(), watch_slot) {
+            (Some(dir), Some(slot)) => match cartog_process_lock::ProcessLock::acquire(dir, slot) {
+                Ok(lock) => Some(lock),
+                Err(cartog_process_lock::AcquireError::Held(held)) => {
+                    anyhow::bail!(
+                        "another cartog process holds the watch lock at {} (slot {}, PID {}); \
+                         stop it before running `cartog watch`",
+                        dir.display(),
+                        held.slot,
+                        held.pid,
+                    );
+                }
+                Err(cartog_process_lock::AcquireError::Io(e)) => {
+                    return Err(e).with_context(|| {
+                        format!("failed to acquire watch PID lock at {}", dir.display())
+                    });
+                }
+            },
+            _ => None,
+        };
 
     let db = if config.skip_migrations {
         Database::open_existing_rw(db_path)

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -61,6 +61,12 @@ pub struct WatchConfig {
 }
 
 impl WatchConfig {
+    /// Build a [`WatchConfig`] rooted at `root` with these defaults:
+    /// `debounce = 5s`, `rag = false`, `rag_delay = 30s`,
+    /// `json_events = false`, both `pid_lock_*` = `None` (untracked
+    /// mode), `skip_migrations = false`. Callers wanting PID-lock
+    /// tracking must set BOTH `pid_lock_dir` and `pid_lock_slot` after
+    /// construction — see [`WatchConfig::pid_lock_slot`].
     pub fn new(root: PathBuf) -> Self {
         Self {
             root,
@@ -165,39 +171,46 @@ impl Drop for WatchHandle {
     }
 }
 
-/// Spawn the watch loop on a background thread.
-///
-/// Returns a `WatchHandle` that can be used to stop the watcher.
-/// The watcher opens its own `Database` connection (SQLite WAL allows concurrent readers).
-///
 /// Validate that the PID-lock configuration on a [`WatchConfig`] is
-/// internally consistent. The dangerous half-configured state is
-/// `pid_lock_dir = Some(_)` with `pid_lock_slot = None`: a global
-/// `watch.pid` claim coexists undetected with any DB-scoped peer for the
-/// same DB and two indexers race. Called synchronously by both
+/// internally consistent. The two dangerous half-configured states are
+/// `(Some(dir), None)` — a global slot would collide with DB-scoped
+/// peers — and `(None, Some(slot))` — the slot is silently ignored and
+/// the caller's intent is dropped. Called synchronously by both
 /// [`spawn_watch`] and [`run_watch`] so a misconfigured embedder never
 /// gets an `Ok(WatchHandle)` for a watcher that died on the spot.
 fn validate_pid_lock_config(config: &WatchConfig) -> Result<()> {
-    if config.pid_lock_dir.is_some() && config.pid_lock_slot.is_none() {
-        anyhow::bail!(
+    match (
+        config.pid_lock_dir.is_some(),
+        config.pid_lock_slot.is_some(),
+    ) {
+        (true, false) => anyhow::bail!(
             "WatchConfig::pid_lock_dir is set but pid_lock_slot is None; \
              refusing to claim the global watch slot — pass a DB-scoped slot \
              (e.g. `cartog::state::slot_for_db(\"watch\", db_path)`)"
-        );
+        ),
+        (false, true) => anyhow::bail!(
+            "WatchConfig::pid_lock_slot is set but pid_lock_dir is None; \
+             a slot without a directory is silently ignored — either set \
+             both fields or clear both to run in untracked mode"
+        ),
+        _ => Ok(()),
     }
-    Ok(())
 }
 
-/// Errors from `watch_loop` after the synchronous validation pass
-/// (PID-lock contention with a live peer, filesystem I/O failures) are
-/// logged inside the thread; the caller still receives `Ok(WatchHandle)`.
-/// Static misconfiguration of [`WatchConfig`] (e.g. `pid_lock_dir` set
-/// without `pid_lock_slot`) is checked synchronously before the thread
-/// is spawned and surfaced as `Err`, so a misconfigured embedder never
-/// gets a `WatchHandle` whose thread is already dead.
+/// Spawn the watch loop on a background thread.
 ///
-/// Use [`run_watch`] when ALL failures (including post-spawn lock
-/// contention) must propagate synchronously.
+/// Returns a `WatchHandle` that can be used to stop the watcher. The
+/// watcher opens its own `Database` connection (SQLite WAL allows
+/// concurrent readers).
+///
+/// Static misconfiguration of [`WatchConfig`] (e.g. `pid_lock_dir` set
+/// without `pid_lock_slot`, or vice versa) is checked synchronously
+/// before the thread is spawned and surfaced as `Err`, so a
+/// misconfigured embedder never gets a `WatchHandle` whose thread is
+/// already dead. Errors that emerge later (PID-lock contention with a
+/// live peer, filesystem I/O failures) are logged inside the thread;
+/// the caller still receives `Ok(WatchHandle)`. Use [`run_watch`] when
+/// ALL failures must propagate synchronously.
 pub fn spawn_watch(config: WatchConfig, db_path: &str) -> Result<WatchHandle> {
     let root = config
         .root

--- a/crates/cartog-watch/tests/pid_file_test.rs
+++ b/crates/cartog-watch/tests/pid_file_test.rs
@@ -110,3 +110,22 @@ fn pid_file_dir_without_slot_is_rejected() {
         "error should explain the misconfiguration, got: {msg}"
     );
 }
+
+#[test]
+fn pid_file_slot_without_dir_is_rejected() {
+    // Inverse half-config: pid_lock_slot set but pid_lock_dir is None.
+    // Pre-fix this was silently ignored — the slot did nothing and the
+    // caller's intent was dropped. Must surface as a hard error.
+    let workspace = tempfile::TempDir::new().unwrap();
+    let mut config = WatchConfig::new(workspace.path().to_path_buf());
+    config.pid_lock_dir = None;
+    config.pid_lock_slot = Some("watch-deadbeef".to_string());
+
+    let err =
+        run_watch(config, ":memory:").expect_err("run_watch must reject slot without lock_dir");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("pid_lock_dir is None"),
+        "error should explain the misconfiguration, got: {msg}"
+    );
+}

--- a/crates/cartog-watch/tests/pid_file_test.rs
+++ b/crates/cartog-watch/tests/pid_file_test.rs
@@ -22,6 +22,7 @@ fn pid_file_written_on_start_and_removed_on_stop() {
 
     let mut config = WatchConfig::new(workspace.path().to_path_buf());
     config.pid_lock_dir = Some(lock_dir.path().to_path_buf());
+    config.pid_lock_slot = Some(WATCH_LOCK_SLOT.to_string());
 
     let handle = spawn_watch(config, ":memory:").expect("spawn watch");
 
@@ -54,6 +55,7 @@ fn pid_file_run_watch_propagates_acquire_failure() {
     let blocker = tempfile::NamedTempFile::new().unwrap();
     let mut config = WatchConfig::new(workspace.path().to_path_buf());
     config.pid_lock_dir = Some(blocker.path().to_path_buf());
+    config.pid_lock_slot = Some(WATCH_LOCK_SLOT.to_string());
 
     let err =
         run_watch(config, ":memory:").expect_err("run_watch should fail when lock dir is unusable");
@@ -61,5 +63,50 @@ fn pid_file_run_watch_propagates_acquire_failure() {
     assert!(
         msg.contains("watch PID lock"),
         "error should mention the lock context, got: {msg}"
+    );
+}
+
+#[test]
+fn spawn_watch_rejects_dir_without_slot_synchronously() {
+    // Regression: pre-fix, spawn_watch returned Ok(WatchHandle) even when
+    // watch_loop bailed inside the thread on the (Some(dir), None) misconfig
+    // — the caller got a handle for an already-dead watcher with only a
+    // tracing::warn! to indicate the failure. The synchronous validation
+    // pass in spawn_watch must surface the error to the caller.
+    let workspace = tempfile::TempDir::new().unwrap();
+    let lock_dir = tempfile::TempDir::new().unwrap();
+    let mut config = WatchConfig::new(workspace.path().to_path_buf());
+    config.pid_lock_dir = Some(lock_dir.path().to_path_buf());
+    config.pid_lock_slot = None;
+
+    let err = match spawn_watch(config, ":memory:") {
+        Ok(_) => panic!("spawn_watch must reject misconfig pre-thread"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("pid_lock_slot is None"),
+        "error should explain the misconfiguration, got: {msg}"
+    );
+}
+
+#[test]
+fn pid_file_dir_without_slot_is_rejected() {
+    // Regression: the half-configured state (lock_dir set, slot None) used
+    // to silently fall back to the global WATCH_LOCK_SLOT, letting an
+    // embedder collide with — or be hidden from — a CLI peer that derives a
+    // DB-scoped slot. Must surface as a hard error.
+    let workspace = tempfile::TempDir::new().unwrap();
+    let lock_dir = tempfile::TempDir::new().unwrap();
+    let mut config = WatchConfig::new(workspace.path().to_path_buf());
+    config.pid_lock_dir = Some(lock_dir.path().to_path_buf());
+    config.pid_lock_slot = None;
+
+    let err =
+        run_watch(config, ":memory:").expect_err("run_watch must reject lock_dir without slot");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("pid_lock_slot is None"),
+        "error should explain the misconfiguration, got: {msg}"
     );
 }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1446,6 +1446,7 @@ pub fn cmd_watch(
     config.rag_config = provider_config;
     config.json_events = json;
     config.pid_lock_dir = crate::state::default_state_dir();
+    config.pid_lock_slot = Some(crate::state::slot_for_db("watch", db_path));
 
     let db_path_str = db_path.to_string_lossy();
     watch::run_watch(config, &db_path_str)

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -213,6 +213,7 @@ fn main() -> Result<()> {
             let runtime = tokio::runtime::Runtime::new()?;
             let opts = mcp::ServerOptions {
                 pid_lock_dir: state::default_state_dir(),
+                pid_lock_slot: Some(state::slot_for_db("serve", &db_path)),
             };
             runtime.block_on(mcp::run_server(&db_path, watch, rag, provider_config, opts))
         }

--- a/crates/cartog/src/state.rs
+++ b/crates/cartog/src/state.rs
@@ -14,6 +14,7 @@
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 const FILE_NAME: &str = "state.toml";
@@ -66,6 +67,89 @@ pub fn default_state_dir() -> Option<PathBuf> {
 /// [`default_state_dir`]).
 pub fn default_state_file() -> Option<PathBuf> {
     Some(default_state_dir()?.join(FILE_NAME))
+}
+
+/// Derive a stable, project-scoped slot name for a long-lived command.
+///
+/// `prefix` is the command family (`"serve"`, `"watch"`); the returned
+/// slot looks like `serve-<16 hex chars>`. The hash covers the most
+/// fully-resolved form of `db_path` we can obtain at call time:
+///
+/// 1. `db_path.canonicalize()` if the file already exists — resolves
+///    every symlink including the leaf, so two peers reaching the same
+///    physical DB via different symlink paths agree on the slot.
+/// 2. Otherwise, walk up ancestors and canonicalize the closest one
+///    that exists, then re-append the missing suffix lexically. The DB
+///    parent directory is created by the indexer well before any
+///    long-lived command runs against it, so step 2 normally
+///    canonicalizes the parent and re-appends just the filename.
+/// 3. Only when no ancestor exists at all (the entire path is missing)
+///    do we hash the raw `db_path` verbatim. That branch is best-effort
+///    and may produce different slots for logically-equivalent paths,
+///    but it requires an unusual setup (running cartog against a path
+///    whose project root does not exist).
+///
+/// Two peers on logically-equivalent paths (relative vs absolute,
+/// symlinked components, symlinked leaf, macOS `/tmp` → `/private/tmp`,
+/// Windows verbatim `\\?\` prefix) collide on the same slot under steps
+/// 1 and 2, which is the correct outcome.
+pub fn slot_for_db(prefix: &str, db_path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+
+    let normalized = resolve_db_path_for_slot(db_path);
+
+    let mut hasher = Sha256::new();
+    // Hash the OS-native bytes so two paths that differ only in non-UTF-8
+    // byte sequences don't collide via lossy U+FFFD replacement.
+    hasher.update(normalized.as_os_str().as_encoded_bytes());
+    let digest = hasher.finalize();
+    // 8 bytes = 16 hex chars: enough collision resistance for a per-user
+    // state dir (~2^64 entropy) while keeping filenames short.
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{prefix}-{hex}")
+}
+
+/// Pick the most fully-resolved form of `db_path` for hashing. See
+/// [`slot_for_db`] for the three-step strategy.
+fn resolve_db_path_for_slot(db_path: &Path) -> PathBuf {
+    // Step 1: full canonicalize succeeds when the DB file (including any
+    // symlinks along the path) exists. Resolves a symlinked leaf too.
+    if let Ok(canon) = db_path.canonicalize() {
+        return canon;
+    }
+    // Step 2: walk up ancestors until one canonicalizes, then re-append
+    // the missing suffix. ancestors() yields self first, then each parent,
+    // ending with "/" (or "" for a relative path with no separators).
+    let mut suffix: Vec<&OsStr> = Vec::new();
+    for ancestor in db_path.ancestors() {
+        // Skip empty ancestor (relative paths end with "" or "."):
+        // canonicalize("") errors; canonicalize(".") would silently
+        // succeed but couple the slot to the cwd. We only want to
+        // canonicalize real ancestor directories.
+        if ancestor.as_os_str().is_empty() {
+            break;
+        }
+        if let Ok(canon_ancestor) = ancestor.canonicalize() {
+            let mut result = canon_ancestor;
+            // suffix was pushed parent-first as we walked up, so reverse
+            // to get child-first ordering.
+            for component in suffix.iter().rev() {
+                result.push(component);
+            }
+            return result;
+        }
+        // This ancestor didn't exist. Remember its file_name so we can
+        // re-attach it to the eventual canonical root.
+        if let Some(name) = ancestor.file_name() {
+            suffix.push(name);
+        } else {
+            // Reached "/" without an existing ancestor: bail.
+            break;
+        }
+    }
+    // Step 3: no ancestor canonicalized (path entirely missing). Hash
+    // the raw path verbatim. This branch is best-effort.
+    db_path.to_path_buf()
 }
 
 impl State {
@@ -145,6 +229,7 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     #[test]
@@ -268,5 +353,181 @@ mod tests {
         // Either is acceptable — the test just asserts no panic.
         let _ = default_state_file();
         let _ = default_state_dir();
+    }
+
+    #[test]
+    fn slot_for_db_is_deterministic() {
+        let p = Path::new("/tmp/some-cartog.db");
+        let a = slot_for_db("serve", p);
+        let b = slot_for_db("serve", p);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn slot_for_db_differs_per_prefix() {
+        let p = Path::new("/tmp/cartog.db");
+        assert_ne!(slot_for_db("serve", p), slot_for_db("watch", p));
+    }
+
+    #[test]
+    fn slot_for_db_differs_per_path() {
+        assert_ne!(
+            slot_for_db("serve", Path::new("/a/cartog.db")),
+            slot_for_db("serve", Path::new("/b/cartog.db"))
+        );
+    }
+
+    #[test]
+    fn slot_for_db_is_filesystem_safe() {
+        let slot = slot_for_db("serve", Path::new("/path/with spaces & specials/cartog.db"));
+        assert!(slot.starts_with("serve-"));
+        // 16 hex chars after the prefix-dash.
+        let hex = &slot["serve-".len()..];
+        assert_eq!(hex.len(), 16);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn slot_for_db_stable_across_db_creation() {
+        // Regression: canonicalize() on the WHOLE db_path used to flip
+        // between Err (file missing) and Ok (file present), changing the
+        // hash input. We now canonicalize only the parent, which exists
+        // both before and after the DB file is created. Two peers
+        // spanning the DB-creation moment must compute the same slot.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("cartog.db");
+        let before = slot_for_db("serve", &db_path);
+        std::fs::write(&db_path, b"").unwrap();
+        let after = slot_for_db("serve", &db_path);
+        assert_eq!(
+            before, after,
+            "slot must be stable across DB creation (parent canonicalize path)"
+        );
+    }
+
+    #[test]
+    fn slot_for_db_normalizes_symlinked_parents() {
+        // Two equivalent paths (one going through a symlinked parent,
+        // one through the canonical parent) must hash to the same slot.
+        // This is the macOS /tmp → /private/tmp scenario in microcosm.
+        let dir = tempfile::TempDir::new().unwrap();
+        let real = dir.path().join("data");
+        std::fs::create_dir(&real).unwrap();
+        let link = dir.path().join("link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        #[cfg(not(unix))]
+        {
+            // Skip on non-Unix: symlink creation needs admin on Windows.
+            let _ = link;
+            return;
+        }
+
+        let via_real = slot_for_db("serve", &real.join("cartog.db"));
+        let via_link = slot_for_db("serve", &link.join("cartog.db"));
+        assert_eq!(
+            via_real, via_link,
+            "logically-equivalent paths must share the slot"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn slot_for_db_normalizes_relative_when_parent_exists() {
+        // A relative path whose parent canonicalizes from cwd should
+        // hash the same as the equivalent absolute path. Verifies the
+        // canonicalize-parent strategy normalizes "." and trailing
+        // separators.
+        //
+        // `#[serial]`: this test mutates the process-global cwd via
+        // `set_current_dir`. Other tests in this binary (config.rs,
+        // commands/mod.rs doctor tests) also use #[serial] for cwd
+        // mutation — they must all share the same serial slot.
+        let dir = tempfile::TempDir::new().unwrap();
+        let abs = dir.path().join("cartog.db");
+        let prev = std::env::current_dir().ok();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let via_rel = slot_for_db("serve", Path::new("./cartog.db"));
+        let via_abs = slot_for_db("serve", &abs);
+        if let Some(p) = prev {
+            let _ = std::env::set_current_dir(p);
+        }
+        assert_eq!(
+            via_rel, via_abs,
+            "relative and absolute paths to the same DB must share the slot"
+        );
+    }
+
+    #[test]
+    fn slot_for_db_resolves_symlinked_db_leaf() {
+        // Regression: pre-fix slot_for_db only canonicalized the parent
+        // directory and rejoined the raw leaf name. A DB file that's a
+        // symlink to a different physical path produced a different slot
+        // than the target, so two cartog peers reaching the same DB via
+        // the symlink vs the real path both became primary on the same
+        // file. The full-path canonicalize-when-leaf-exists strategy
+        // resolves this.
+        let dir = tempfile::TempDir::new().unwrap();
+        let real_dir = dir.path().join("storage");
+        std::fs::create_dir(&real_dir).unwrap();
+        let real_db = real_dir.join("real.db");
+        std::fs::write(&real_db, b"").unwrap();
+        let link_dir = dir.path().join("proj");
+        std::fs::create_dir(&link_dir).unwrap();
+        let link_db = link_dir.join("db.sqlite");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_db, &link_db).unwrap();
+        #[cfg(not(unix))]
+        {
+            let _ = link_db;
+            return;
+        }
+
+        let via_real = slot_for_db("serve", &real_db);
+        let via_link = slot_for_db("serve", &link_db);
+        assert_eq!(
+            via_real, via_link,
+            "symlinked DB leaf must produce the same slot as the real target"
+        );
+    }
+
+    #[test]
+    fn slot_for_db_walks_up_when_parent_missing() {
+        // Regression: when neither the DB file nor its immediate parent
+        // exists yet, the old code hashed the raw path verbatim — so
+        // equivalent forms (with/without trailing slash, relative vs
+        // absolute) produced different slots, breaking single-writer.
+        // The new code walks up ancestors until one canonicalizes and
+        // appends the missing suffix lexically.
+        let dir = tempfile::TempDir::new().unwrap();
+        // dir.path() exists; .cartog/db.sqlite does not (no parent created).
+        let a = dir.path().join(".cartog").join("db.sqlite");
+        // Equivalent form via a redundant "./" (parent walked the same way).
+        let b = dir.path().join(".").join(".cartog").join("db.sqlite");
+
+        let slot_a = slot_for_db("serve", &a);
+        let slot_b = slot_for_db("serve", &b);
+        assert_eq!(
+            slot_a, slot_b,
+            "equivalent paths with missing parent must produce the same slot"
+        );
+    }
+
+    #[test]
+    fn slot_for_db_stable_across_parent_creation() {
+        // Stronger form of slot_for_db_stable_across_db_creation: the
+        // PARENT directory is also missing initially. Walking ancestors
+        // should anchor on dir.path() both before and after the parent
+        // is created, yielding the same slot.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join(".cartog").join("db.sqlite");
+        let before = slot_for_db("serve", &db_path);
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        std::fs::write(&db_path, b"").unwrap();
+        let after = slot_for_db("serve", &db_path);
+        assert_eq!(
+            before, after,
+            "slot must be stable across parent-dir + DB-file creation"
+        );
     }
 }

--- a/crates/cartog/src/state.rs
+++ b/crates/cartog/src/state.rs
@@ -122,11 +122,27 @@ fn resolve_db_path_for_slot(db_path: &Path) -> PathBuf {
     // ending with "/" (or "" for a relative path with no separators).
     let mut suffix: Vec<&OsStr> = Vec::new();
     for ancestor in db_path.ancestors() {
-        // Skip empty ancestor (relative paths end with "" or "."):
-        // canonicalize("") errors; canonicalize(".") would silently
-        // succeed but couple the slot to the cwd. We only want to
-        // canonicalize real ancestor directories.
-        if ancestor.as_os_str().is_empty() {
+        // Empty ("") or current-dir (".") ancestor: a bare relative path
+        // (e.g. `db.sqlite`, `subdir/db.sqlite`) exhausts its ancestors
+        // before finding one that canonicalizes. Anchor on the canonical
+        // CWD so two equivalent forms (`db.sqlite` and `./db.sqlite` from
+        // the same cwd) produce the same slot. Note: this couples the
+        // slot to the cwd, which is the correct behaviour — the same
+        // bare relative path from a different cwd refers to a different
+        // physical DB.
+        let is_implicit_cwd =
+            ancestor.as_os_str().is_empty() || ancestor.as_os_str() == std::ffi::OsStr::new(".");
+        if is_implicit_cwd {
+            if let Ok(cwd) = std::env::current_dir() {
+                // Best-effort canonicalize so symlinked cwds normalize.
+                let base = cwd.canonicalize().unwrap_or(cwd);
+                let mut result = base;
+                for component in suffix.iter().rev() {
+                    result.push(component);
+                }
+                return result;
+            }
+            // No cwd available (extremely unusual): fall through to step 3.
             break;
         }
         if let Ok(canon_ancestor) = ancestor.canonicalize() {
@@ -488,6 +504,36 @@ mod tests {
         assert_eq!(
             via_real, via_link,
             "symlinked DB leaf must produce the same slot as the real target"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn slot_for_db_bare_relative_anchors_on_cwd() {
+        // Regression: a bare relative path like `db.sqlite` exhausted
+        // its ancestors (`db.sqlite`, ``) before finding one that
+        // canonicalized, falling through to the raw-path branch and
+        // hashing just "db.sqlite". A peer running from a DIFFERENT cwd
+        // with the same `--db db.sqlite` arg would compute the SAME
+        // hash for a DIFFERENT physical file. Anchoring on the
+        // canonical cwd fixes this — and also makes `db.sqlite` and
+        // `./db.sqlite` from the same cwd produce the same slot.
+        let dir = tempfile::TempDir::new().unwrap();
+        let prev = std::env::current_dir().ok();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let bare = slot_for_db("serve", Path::new("db.sqlite"));
+        let dotted = slot_for_db("serve", Path::new("./db.sqlite"));
+        let absolute = slot_for_db("serve", &dir.path().join("db.sqlite"));
+        if let Some(p) = prev {
+            let _ = std::env::set_current_dir(p);
+        }
+        assert_eq!(
+            bare, dotted,
+            "bare relative and './' relative must produce the same slot"
+        );
+        assert_eq!(
+            bare, absolute,
+            "bare relative must anchor on cwd and match the absolute equivalent"
         );
     }
 

--- a/docs/spec-mcp-sharing.md
+++ b/docs/spec-mcp-sharing.md
@@ -22,7 +22,7 @@ background promoter on the secondary takes over.
 
 ```text
                           ┌─────────────────────────────────────────────┐
-cartog serve   →   acquire_serve_lock(O_EXCL on .cartog/state/serve.pid)
+cartog serve   →   acquire_serve_lock(O_EXCL on <state_dir>/serve-<db_hash>.pid)
                           │
               ┌───────────┴───────────┐
               │                       │
@@ -57,7 +57,7 @@ cartog serve   →   acquire_serve_lock(O_EXCL on .cartog/state/serve.pid)
 
 4. **Tool gating, not transport split.** Same MCP stdio transport for both roles. The two write tools (`cartog_index`, `cartog_rag_index`) early-return a clear error when role is `ReadOnly`. The other 11 (search, outline, refs, callees, impact, hierarchy, deps, stats, map, changes, rag_search) work unchanged. `cartog_stats` JSON includes `"role": "primary" | "read-only"` for introspection.
 
-5. **Promotion under the existing `Mutex<Database>`.** When the secondary's promoter detects the primary died, validates pinned state, and wins an O_EXCL acquire, it swaps the inner `Database` value under the mutex. No reader can be mid-query through the same guard (it must release before the promoter can claim it), so SQLITE_MISUSE from a connection-mid-use is impossible. The promoter then spawns the watcher (acquiring `watch.pid` alongside the `serve.pid` it already holds — they're different slots gating different consumers; `serve.pid` blocks other MCP servers, `watch.pid` blocks a separately-running `cartog watch` from a terminal) via `Database::open_existing_rw` (`skip_migrations=true` so we don't re-trigger the migration race the election prevents), and flips `Arc<AtomicRole>` to `Primary`. `cartog_stats` exposes `"watcher_active"` so users can see whether the watcher actually started post-promotion (it may fail if a live terminal `cartog watch` holds the slot).
+5. **Promotion under the existing `Mutex<Database>`.** When the secondary's promoter detects the primary died, validates pinned state, and wins an O_EXCL acquire, it swaps the inner `Database` value under the mutex. No reader can be mid-query through the same guard (it must release before the promoter can claim it), so SQLITE_MISUSE from a connection-mid-use is impossible. The promoter then spawns the watcher (acquiring the DB-scoped watch slot `watch-<db_hash>` alongside the `serve-<db_hash>` it already holds — they're different slots gating different consumers; serve blocks other MCP servers for the same DB, watch blocks a separately-running `cartog watch` from a terminal) via `Database::open_existing_rw` (`skip_migrations=true` so we don't re-trigger the migration race the election prevents), and flips `Arc<AtomicRole>` to `Primary`. `cartog_stats` exposes `"watcher_active"` so users can see whether the watcher actually started post-promotion (it may fail if a live terminal `cartog watch` holds the slot).
 
 6. **Migration-race safety net.** `handle_embedding_dimension` writes wrap in `retry_busy` on `SQLITE_BUSY` / `SQLITE_LOCKED` with 50/100/250/500/1000ms backoff. A true early-return on already-matching dimension means same-dim reopens never take a write lock at all. Layered defense for any case where two writers reach migration despite election (TOCTOU window, kill switch enabled).
 
@@ -72,7 +72,7 @@ cartog serve   →   acquire_serve_lock(O_EXCL on .cartog/state/serve.pid)
 ## Functional Requirements
 
 ### FR-001: Election
-When `cartog serve` starts, the system shall attempt `ProcessLock::acquire` against `<state_dir>/serve.pid` with O_EXCL semantics, returning `Primary` on success, `Held(ActiveLock)` when a live peer (same PID + start_time) owns the slot, and `Io(error)` for filesystem failures.
+When `cartog serve` starts, the system shall attempt `ProcessLock::acquire` against `<state_dir>/serve-<db_hash>.pid` with O_EXCL semantics, returning `Primary` on success, `Held(ActiveLock)` when a live peer (same PID + start_time) owns the slot, and `Io(error)` for filesystem failures. The `<db_hash>` is a 16-char SHA-256 prefix of the canonical DB path (`cartog::state::slot_for_db`), so two peers on different DBs claim different slots and coexist; two peers on the same DB collide on the same slot.
 
 ### FR-002: Stale-lock cleanup
 While `ProcessLock::acquire` sees `AlreadyExists` and the recorded holder is no longer alive (PID gone, or start_time mismatch from PID reuse), the system shall unlink the stale file and retry the acquire once.
@@ -96,7 +96,7 @@ While role is `ReadOnly` and the primary's `ActiveLock` is known, the system sha
 When the promoter detects the primary is gone AND `validate_pinned_state` confirms the on-disk schema and fingerprint match the attach-time `PinnedAttach`, the system shall:
 - attempt an atomic O_EXCL acquire of the serve slot;
 - on success, open `Database::open_existing_rw` and swap it into the existing `Arc<Mutex<Database>>` under the held guard;
-- spawn a watcher (with `skip_migrations=true` via `Database::open_existing_rw`, and acquiring `watch.pid` alongside the already-held `serve.pid`) if the user invoked `serve --watch`. If `watch.pid` is held by another live cartog process, the watcher fails to start and `cartog_stats` reports `"watcher_active": false`;
+- spawn a watcher (with `skip_migrations=true` via `Database::open_existing_rw`, and acquiring `watch-<db_hash>.pid` alongside the already-held `serve-<db_hash>.pid`) if the user invoked `serve --watch`. If the watch slot is held by another live cartog process, the watcher fails to start and `cartog_stats` reports `"watcher_active": false`;
 - store `Role::Primary` in `AtomicRole`;
 - exit the promoter loop.
 
@@ -148,7 +148,7 @@ While `cartog watch` starts and another live cartog process holds the watch slot
    - All 13 tools then work on what was the secondary.
 3. Two readers race for promotion: exactly one wins, the loser stays read-only, no `SQLITE_BUSY` on the new primary's `open_existing_rw`.
 4. Promoter aborts cleanly when a third writer upgraded the schema or swapped the embedding stack between the secondary's attach and the primary's death.
-5. `kill -INT` or `kill -TERM` on a primary serve unlinks `serve.pid` before exit; the PID file is gone when the process is gone.
+5. `kill -INT` or `kill -TERM` on a primary serve unlinks its `serve-<db_hash>.pid` before exit; the PID file is gone when the process is gone. A hard kill (`kill -9`, power loss) leaves the file behind; the next `cartog serve` / `cartog watch` startup runs a `sweep_stale_locks` pass that reaps every dead `.pid` entry in the state dir (not just the slot being claimed), so leftovers from crashed peers of any project disappear automatically.
 6. `cartog serve` stderr in MCP-child mode no longer emits `info!` lines as `[ERROR]` in `~/.claude/debug/*.txt`. `cartog serve` in a foreground terminal still shows `info!` progress.
 7. `CARTOG_SINGLE_WRITER=0 cartog serve` reproduces the pre-Phase-2 overwrite-on-acquire behavior; two such processes both report `Primary` and the migration busy-retry catches any race.
 
@@ -215,7 +215,7 @@ All items completed across the initial 8 implementation commits
 
 ### Phase 5: promotion
 - [x] `Database::open_existing_rw(path)` (full RW + PRAGMAs + schema-drift check, no migrations)
-- [x] `WatchConfig::skip_migrations` flag (originally included `skip_pid_lock`, removed in a later review fix — both promoter-spawned and CLI-spawned watchers now claim `watch.pid` uniformly so two `cartog watch` processes can't run concurrently against the same DB)
+- [x] `WatchConfig::skip_migrations` flag (originally included `skip_pid_lock`, removed in a later review fix — both promoter-spawned and CLI-spawned watchers now claim the same DB-scoped watch slot (`watch-<db_hash>`) uniformly so two `cartog watch` processes can't run concurrently against the same DB)
 - [x] `cartog-watch` watch loop honors `skip_migrations`
 - [x] `AtomicRole` wrapping `AtomicU8`; `CartogServer.role: Arc<AtomicRole>`
 - [x] `PromoterArgs` struct + `promoter_task` async function
@@ -250,6 +250,31 @@ regression test.
   - (e) Watcher post-promotion reuses the server's captured `cwd` (was: `std::env::current_dir()`).
   - `poll_interval` becomes a `PromoterArgs` field so tests can shrink it from 10s to milliseconds.
 - [x] `4d876b1 docs`: removed unsafe "manually delete `watch.pid`" advice; clarified log-level autodetect; documented per-OS `<state_dir>` paths.
+
+### DB-scoped lock slots + stale-file sweep (issue #53)
+
+Slot names became DB-scoped — `serve-<hash>.pid` / `watch-<hash>.pid`
+where `<hash>` is a 16-char SHA-256 prefix of the canonicalized DB
+path — so two cartog peers on different DBs in the same per-user state
+dir coexist without colliding on a single global `serve.pid` /
+`watch.pid`. Slot derivation lives in
+`cartog::state::slot_for_db(prefix, db_path)` in the binary crate.
+
+Additional safeguards landed alongside:
+
+- `ProcessLock::acquire` (and `acquire_overwriting`) call
+  `sweep_stale_locks(state_dir)` at the top, reaping every dead `.pid`
+  entry — not just the slot being claimed — via
+  `unlink_if_unchanged`. Hard-killed peers from any project disappear
+  on the next long-lived command launch.
+- `acquire_serve_lock` and the watch path hard-fail when
+  `pid_lock_dir` is set but `pid_lock_slot` is None, preventing an
+  embedder from silently claiming the global slot while a CLI peer
+  uses a DB-scoped slot.
+- `slot_for_db` canonicalizes the full DB path when the file exists
+  (resolving symlinked leaves), and walks up ancestors when it
+  doesn't, so equivalent-but-different path forms hash to the same
+  slot whether or not the DB has been created yet.
 
 ## Out of Scope
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,19 +95,26 @@ Exactly one `cartog watch` may run per project at a time. The watcher
 refuses to start (rather than attaching read-only — unlike `cartog serve`)
 because a second watcher would re-index the same files redundantly.
 
-Find the holder via `cat <state_dir>/watch.pid` (first line is the PID,
-second is the OS start time) and stop it. **Do not manually delete the
-lock file** — cartog auto-cleans it on the next acquire once the
-recorded PID + start_time no longer matches a live process, and deleting
-it under a live writer would let a second watcher start and corrupt the
-index.
+Find the holder by listing `<state_dir>/watch-*.pid` (one file per
+project). Each file's first line is the PID, second is the OS start
+time. Stop the holder process. **Do not manually delete the lock file**
+— cartog auto-cleans it on the next acquire once the recorded PID +
+start_time no longer matches a live process, and deleting it under a
+live writer would let a second watcher start and corrupt the index.
+
+PID file names are DB-scoped: `<state_dir>/serve-<hash>.pid` and
+`watch-<hash>.pid` where `<hash>` is a 16-char SHA-256 prefix of the
+canonical DB path. Run `cartog config` to see your DB path, then list
+the state dir to find the matching file.
 
 ### My cartog process exited but the PID file is still there
 
 cartog unlinks its PID file via the `ProcessLock` Drop impl on clean exit
 (rmcp shutdown, SIGINT, SIGTERM). A hard kill (`kill -9`, power loss)
-leaves the file behind. The next acquire detects the stale entry via
-`is_same_process(pid, start_time)` and removes it; no manual action needed.
+leaves the file behind. The next `cartog serve` / `cartog watch`
+startup runs a `sweep_stale_locks` pass that reaps every dead `.pid`
+file in the state dir (not just the slot being claimed), so leftovers
+from crashed peers disappear automatically — no manual action needed.
 
 ### MCP stderr is full of `[ERROR]` lines that look like info-level messages
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -105,17 +105,17 @@ cartog persists `last_update_check`, `last_known_latest`, and `last_known_outdat
 
 The file is best-effort: if it is missing, malformed, or unwritable, cartog falls back to defaults and continues. Safe to delete; it will be recreated on the next check.
 
-PID files for `cartog serve` and `cartog watch` (`serve.pid`, `watch.pid`) live in the same directory.
+PID files for `cartog serve` and `cartog watch` live in the same directory. Slot names are DB-scoped — `serve-<hash>.pid` / `watch-<hash>.pid` — where `<hash>` is a 16-char SHA-256 prefix of the canonical DB path. Two cartog peers on different projects therefore claim different files and coexist; `cartog self update` still detects any running peer regardless of scope.
 
 ## Troubleshooting
 
 ### "another cartog process is running"
 
-The upgrade refused because a peer `cartog serve` or `cartog watch` is holding the binary open. Stop the named process and re-run `cartog self update`. The error message includes the slot (`serve`/`watch`) and PID.
+The upgrade refused because a peer `cartog serve` or `cartog watch` is holding the binary open. Stop the named process and re-run `cartog self update`. The error message includes the slot (`serve-<hash>` / `watch-<hash>`, where `<hash>` is a SHA-256 prefix of the peer's DB path) and PID.
 
 ### Stale PID files
 
-If a `cartog serve`/`watch` was killed with `SIGKILL` (or the machine crashed), the PID file may remain after the process is gone. cartog detects and removes stale entries automatically — the next `cartog self update` clears them. To clear manually: `rm $XDG_STATE_HOME/cartog/{serve,watch}.pid`.
+If a `cartog serve`/`watch` was killed with `SIGKILL` (or the machine crashed), the PID file may remain after the process is gone. Cartog reaps stale entries automatically: every `cartog serve` / `cartog watch` startup runs a sweep that unlinks every `.pid` file whose recorded process has exited (not just the slot being claimed), and `cartog self update` also clears them. Manual cleanup is rarely needed; to clear by hand: `rm $XDG_STATE_HOME/cartog/{serve,watch}-*.pid` (Linux paths; substitute the platform-specific state dir).
 
 ### "checksum mismatch"
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -419,7 +419,7 @@ When `--watch` is passed, a background file watcher keeps the code graph up to d
 
 Opening two Claude Code windows on the same project (or running `cartog serve` in a terminal while a Claude Code window has its own MCP child) is supported via **single-writer election**:
 
-- The first instance acquires `<state_dir>/serve.pid` atomically (O_EXCL) and runs as **primary** — owns the file watcher, exposes all 13 MCP tools.
+- The first instance acquires `<state_dir>/serve-<hash>.pid` atomically (O_EXCL) and runs as **primary** — owns the file watcher, exposes all 13 MCP tools. The `<hash>` is a 16-char SHA-256 prefix of the canonical DB path, so two cartog peers on different projects coexist without colliding on the same slot.
 - Subsequent instances see the held lock, attach **read-only** (no migrations), and expose 11 of 13 tools. The two indexing tools (`cartog_index`, `cartog_rag_index`) return a clear error pointing at the primary; queries (`cartog_search`, `cartog_rag_search`, etc.) work normally. `cartog_stats` includes `"role": "read-only"` so you can tell which is which.
 - If the primary process dies (Cmd-Q, `kill`, crash), the secondary's background promoter detects this within ~10s, validates the on-disk schema hasn't drifted, atomically acquires the lock, and takes over without restart. All 13 tools become available on what was the secondary.
 
@@ -438,7 +438,12 @@ Escape hatches:
 | macOS | `~/Library/Application Support/io.cartog.cartog/` |
 | Windows | `%LOCALAPPDATA%\cartog\cartog\data\` |
 
-The directory holds `state.toml` (used by `cartog self update`) and PID lock files (`serve.pid`, `watch.pid`) for live long-lived commands.
+The directory holds `state.toml` (used by `cartog self update`) and PID lock files for live long-lived commands. Slots are scoped per DB so peers in different projects coexist:
+
+- `serve-<hash>.pid` — `cartog serve` (the MCP server)
+- `watch-<hash>.pid` — `cartog watch` or the `serve --watch` background watcher
+
+`<hash>` is a 16-char SHA-256 prefix of the canonical DB path. On every `cartog serve` / `cartog watch` startup, stale PID files (whose recorded process has exited) are reaped automatically — no manual cleanup needed.
 
 See [`spec-mcp-sharing.md`](spec-mcp-sharing.md) for the full design.
 


### PR DESCRIPTION
## Summary

- Lock slots become DB-scoped (`serve-<hash>.pid` / `watch-<hash>.pid`, where `<hash>` is a 16-char SHA-256 prefix of the canonical DB path) so two cartog peers on different projects coexist in the same per-user state dir.
- `ProcessLock::acquire` now reaps every dead `.pid` entry via `sweep_stale_locks` on every launch — crashed peers from any project disappear automatically.
- Hard-fail when `ServerOptions::pid_lock_dir` / `WatchConfig::pid_lock_dir` is set without a matching `pid_lock_slot`, preventing a global-slot peer from silently colliding with DB-scoped peers.

Closes #53.

## Why

`cartog serve` / `cartog watch` used a single global slot (`serve.pid`, `watch.pid`) per state dir, so running cartog on a second project while another instance was alive collided on the same lock. Empirically validated: two `cartog watch` peers on different DBs now run concurrently with distinct slot files (`watch-a902bb89f9a6b484.pid` + `watch-31d02780520150ec.pid`).

## What changed

### Code

- `crates/cartog/src/state.rs` — `slot_for_db(prefix, db_path)` derives a stable slot. Tries full `canonicalize()` first (resolves symlinked leaves), walks up ancestors when the leaf or parent doesn't exist, hashes raw path as last resort. Uses `OsStr::as_encoded_bytes` to avoid non-UTF-8 lossy collisions.
- `crates/cartog-process-lock/src/lib.rs` — `sweep_stale_locks(state_dir)` invoked at the top of both `acquire` and `acquire_overwriting`. Reuses the existing TOCTOU-safe `unlink_if_unchanged`. `AcquireError::Held` `Display` switched from `{:?}` to `{}` (no quote noise for long hex slots).
- `crates/cartog-watch/src/lib.rs` — new `pid_lock_slot` field on `WatchConfig`. `validate_pid_lock_config` runs synchronously in `spawn_watch` before `thread::spawn` so a misconfigured embedder gets `Err`, not `Ok(WatchHandle)` for a dead watcher. Removed dead `WATCH_LOCK_PREFIX`.
- `crates/cartog-mcp/src/lib.rs` — `pid_lock_slot` field on `ServerOptions`, `serve_to_watch_slot` anchored on `strip_prefix("serve-")` with non-empty filter (off-pattern inputs fall back to the global watch slot rather than producing a fabricated `watchr` / `watch-`). `PromoterArgs` gains `serve_slot` and `watch_slot`. Dead `unwrap_or_else` fallbacks replaced with `.expect(...)` so a future refactor that loosens guards trips loudly.
- `crates/cartog/src/main.rs`, `crates/cartog/src/commands/mod.rs` — wire scoped slots into serve + watch command paths.

### Tests (+17)

- `slot_for_db` edge cases: symlinked leaf, walks up when parent missing, stable across parent + DB creation, relative vs absolute (with `#[serial]` because it mutates cwd).
- 5 `sweep_stale_locks` cases (dead entries removed, live entry preserved, no-op on missing dir, both acquire paths sweep).
- 2 promoter scoped-slot regression tests (`serve_slot` + `watch_slot` — both verified to catch a regression that reverts to the global constant).
- `acquire_serve_lock`, `run_watch`, `spawn_watch` hard-fail tests for the `(dir set, slot None)` misconfig.
- `serve_to_watch_slot` off-pattern cases including the trailing-dash case (`serve-` → `watch`, not `watch-`).

### Docs

- `docs/usage.md` — multi-instance section + state-dir filenames.
- `docs/troubleshooting.md` — wildcard listing for slots, sweep behavior note, removed unsafe manual-delete advice for specific filenames.
- `docs/spec-mcp-sharing.md` — architecture diagram, FR-001, FR-008, acceptance criteria, plus new "DB-scoped lock slots + sweep" subsection summarising the change.
- `docs/updates.md` — peer-running diagnostic, stale-file cleanup behaviour.

## Empirical validation

| Scenario | Pre-PR | This PR |
|---|---|---|
| Two `cartog watch` peers on different DBs | Second hits `Held`, refuses to start | Both run concurrently with distinct PID files |
| Stale `.pid` from SIGKILLed peer | Lingers until `cartog self update` | Reaped on next `cartog serve` / `cartog watch` launch |
| Embedder with `pid_lock_dir = Some(_)`, `pid_lock_slot = None` | Silently uses global slot, races CLI peers | Hard-fail with explanation |
| Cold/dirty index wall-clock | unchanged | unchanged (this PR doesn't touch the hot path) |

## Risks accepted

- Hard-fail on the `(dir, None)` config is a **breaking change** for external embedders of `cartog-mcp` / `cartog-watch` who relied on the legacy single-project semantics. The CHANGELOG entry calls it out. The crates surface is small and the fix at the call site is one line (`pid_lock_slot: Some(slot_for_db(...))`).
- Slot strings in user-facing error messages are now long hex (16 chars after the prefix). Minor UX impact; documented in troubleshooting.
- This PR does **not** make the watcher LSP-aware. That follow-up scope from issue #53 is gated on #43 (sustained CPU on large repos) — separate PR.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` (~600 tests, all green)
- [x] `make check-rust`
- [x] Manual: two concurrent `cartog watch` peers on different DBs in the same state dir → both run.
- [x] Manual: SIGKILL a watcher, restart same DB → stale file reaped.
- [x] Manual: `cartog self update` peer detection still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cartog now uses database-scoped process locks, enabling multiple instances to safely operate on different databases simultaneously without conflicts.
  * Automatic stale lock file cleanup on startup removes leftover files from crashed or force-killed processes.

* **Documentation**
  * Updated guidance for managing multiple databases and troubleshooting process lock issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->