### PR TITLE
fix: code-review followups for PRs #63 + #64

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2560,8 +2560,10 @@ impl Database {
     /// excluded so a dirty reindex doesn't re-query the language server for
     /// edges it already classified. Both are sticky and re-enter the
     /// unresolved set only via [`Self::reset_unresolvable_for_names`] when a
-    /// matching symbol is added, [`Self::reset_all_unresolvable`] on `--force`,
-    /// or [`Self::invalidate_edges_targeting`] when a resolved target is removed.
+    /// matching symbol is added, or [`Self::reset_all_unresolvable`] on
+    /// `--force`. ([`Self::invalidate_edges_targeting`] only touches state=1
+    /// rows because it filters on `target_id IS NOT NULL`, and state {2, 3}
+    /// rows always have `target_id NULL`.)
     ///
     /// tx-safe: read-only single statement — see note above the section header.
     pub fn unresolved_edges(&self) -> Result<Vec<UnresolvedEdge>> {
@@ -2656,13 +2658,20 @@ impl Database {
     /// Callers MUST only invoke this after a definitive negative answer from
     /// the language server. Never call from a transient-error branch (server
     /// crash, didOpen failure, half-loaded warmup) — the marker is sticky
-    /// across runs until [`Self::reset_unresolvable_for_names`] or
-    /// [`Self::invalidate_edges_targeting`] reopens it.
+    /// across runs until [`Self::reset_unresolvable_for_names`] reopens it
+    /// (on a matching new symbol) or [`Self::reset_all_unresolvable`] runs
+    /// (`--force`).
+    ///
+    /// The `WHERE resolution_state = 0` guard preserves the invariant that
+    /// state {2, 3} rows have `target_id IS NULL` — without it an accidental
+    /// call on a state=1 (resolved) edge would silently flip the state while
+    /// keeping the stale target, hiding a corrupted edge from
+    /// [`Self::unresolved_edges`].
     ///
     /// tx-safe: single statement — see the LSP-section header note.
     pub fn mark_edge_unresolvable(&self, edge_id: i64) -> Result<()> {
         self.conn.execute(
-            "UPDATE edges SET resolution_state = 2 WHERE id = ?1",
+            "UPDATE edges SET resolution_state = 2 WHERE id = ?1 AND resolution_state = 0",
             params![edge_id],
         )?;
         Ok(())
@@ -2672,13 +2681,15 @@ impl Database {
     /// outside the indexed root — stdlib, third-party deps, node_modules).
     ///
     /// Same stickiness contract as [`Self::mark_edge_unresolvable`]: only call
-    /// after a definitive negative answer; reopened by the same name-keyed and
-    /// force-reset paths.
+    /// after a definitive positive answer naming an out-of-root URI;
+    /// reopened by the same name-keyed and force-reset paths. The
+    /// `WHERE resolution_state = 0` guard preserves the `target_id IS NULL`
+    /// invariant for state=3 rows.
     ///
     /// tx-safe: single statement — see the LSP-section header note.
     pub fn mark_edge_external(&self, edge_id: i64) -> Result<()> {
         self.conn.execute(
-            "UPDATE edges SET resolution_state = 3 WHERE id = ?1",
+            "UPDATE edges SET resolution_state = 3 WHERE id = ?1 AND resolution_state = 0",
             params![edge_id],
         )?;
         Ok(())

--- a/crates/cartog-lsp/src/manager.rs
+++ b/crates/cartog-lsp/src/manager.rs
@@ -654,8 +654,9 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let root = dir.path(); // exists and canonicalizes
         let not_yet_on_disk = root.join("generated.rs");
-        // Build a file:// URI for the not-yet-existing path.
-        let uri = format!("file://{}", not_yet_on_disk.display());
+        // Use the same path_to_uri helper the rest of the codebase uses so
+        // the test stays correct on Windows (drive-letter / verbatim paths).
+        let uri = path_to_uri(&not_yet_on_disk);
         let result = serde_json::json!({
             "uri": uri,
             "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },

--- a/crates/cartog-lsp/src/manager.rs
+++ b/crates/cartog-lsp/src/manager.rs
@@ -462,12 +462,22 @@ fn parse_definition_response(result: &Value, root: &Path) -> Result<Option<Defin
     // emit non-canonical URIs (e.g. `/var/folders/...` on macOS where root
     // canonical is `/private/var/...`), AND the caller may have passed a
     // symlinked root (e.g. `/tmp/proj` → `/private/tmp/proj`). A lexical
-    // strip_prefix on either asymmetric pair would wrongly tag in-root edges
-    // as External and burn a sticky state=3 marker. Fall back to the raw
-    // path on either side when canonicalize fails (file may not exist on
-    // disk yet — generated code, race against an unsaved buffer).
-    let abs_path = std::fs::canonicalize(&raw_path).unwrap_or(raw_path);
-    let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    // strip_prefix on an asymmetric pair (one canonicalized, one not) would
+    // wrongly tag in-root edges as External and burn a sticky state=3
+    // marker — the exact regression the canonicalize was meant to close.
+    //
+    // Either side can fail to canonicalize: root may be missing in tests, or
+    // raw_path can point to a file not yet on disk (generated code, race
+    // against an unsaved buffer). To keep the strip_prefix symmetric, we
+    // fall back to comparing both RAW paths together — never mix canonical
+    // root with raw target (or vice versa).
+    let (canonical_root, abs_path) = match (
+        std::fs::canonicalize(root),
+        std::fs::canonicalize(&raw_path),
+    ) {
+        (Ok(r), Ok(p)) => (r, p),
+        _ => (root.to_path_buf(), raw_path),
+    };
 
     // Out-of-root targets (stdlib, deps, node_modules) become External.
     let rel_path = match abs_path.strip_prefix(&canonical_root) {
@@ -631,5 +641,37 @@ mod tests {
         });
 
         assert!(parse_definition_response(&result, root).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_parse_definition_symmetric_fallback_on_missing_target() {
+        // Regression: when root canonicalizes (`/tmp/proj` → `/private/tmp/proj`
+        // on macOS) but raw_path does NOT (file not yet on disk: generated
+        // code, race against an unsaved buffer), the asymmetric pair made
+        // strip_prefix fail and burned an in-root edge as sticky External.
+        // The fix uses RAW paths on both sides whenever either canonicalize
+        // fails, so the lexical strip_prefix matches symmetrically.
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path(); // exists and canonicalizes
+        let not_yet_on_disk = root.join("generated.rs");
+        // Build a file:// URI for the not-yet-existing path.
+        let uri = format!("file://{}", not_yet_on_disk.display());
+        let result = serde_json::json!({
+            "uri": uri,
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+        });
+        let outcome = parse_definition_response(&result, root)
+            .unwrap()
+            .expect("expected Some outcome for in-root not-yet-existent target");
+        // Symmetric raw-vs-raw strip_prefix must classify this as InRoot, not
+        // External, so the resolver leaves it at state=0 for the next reindex.
+        match outcome {
+            DefinitionOutcome::InRoot(loc) => {
+                assert_eq!(loc.file_path, "generated.rs");
+            }
+            DefinitionOutcome::External => {
+                panic!("missing in-root target must not be marked External (sticky state=3)");
+            }
+        }
     }
 }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -1186,25 +1186,27 @@ pub const SERVE_LOCK_SLOT: &str = "serve";
 /// Anchored on the exact prefixes `"serve"` (literal, legacy) and
 /// `"serve-"` (DB-scoped, followed by the hex suffix). Inputs that
 /// happen to start with the four letters `serve` but are NOT a
-/// serve-family slot (`"server"`, `"serverless"`, `"servefoo"`, …) fall
-/// through to the global watch slot rather than silently producing a
-/// corrupted "watch{rest}" string.
-fn serve_to_watch_slot(serve_slot: &str) -> String {
+/// serve-family slot (`"server"`, `"serverless"`, `"servefoo"`, …) are
+/// rejected: silently folding them to the global watch slot would let
+/// distinct embedders collide on `watch.pid` while their serve slots
+/// stay distinct (same hazard as the pid_lock_dir/slot half-config).
+fn serve_to_watch_slot(serve_slot: &str) -> anyhow::Result<String> {
     if serve_slot == "serve" {
-        return watch::WATCH_LOCK_SLOT.to_string();
+        return Ok(watch::WATCH_LOCK_SLOT.to_string());
     }
     // strip_prefix + non-empty filter: `"serve-"` alone (trailing dash,
     // empty hex) is treated as off-pattern, not as the legitimate
     // serve-<hex> shape. Without the filter it would silently produce
     // the slot "watch-" which validates but encodes no DB scope.
     if let Some(rest) = serve_slot.strip_prefix("serve-").filter(|r| !r.is_empty()) {
-        return format!("watch-{rest}");
+        return Ok(format!("watch-{rest}"));
     }
-    // Unknown prefix or off-pattern input: fall back to the global watch
-    // slot so we don't emit a fabricated slot that no other process can
-    // reproduce. Should not happen for slots produced by
-    // `state::slot_for_db("serve", _)` but guards against caller mistakes.
-    watch::WATCH_LOCK_SLOT.to_string()
+    Err(anyhow::anyhow!(
+        "ServerOptions::pid_lock_slot {serve_slot:?} is not a serve-family slot; \
+         expected `serve` or `serve-<hex>`. Library embedders should derive the slot \
+         via `cartog::state::slot_for_db(\"serve\", db_path)` so the watcher's slot \
+         can be scoped to the same DB."
+    ))
 }
 
 /// Environment variable that, when set to `0`, disables single-writer
@@ -1349,8 +1351,13 @@ pub async fn run_server(
     // Derive the watcher's slot from the serve slot so per-DB scoping is
     // consistent across both PID files. When serve runs un-scoped (legacy /
     // tests), the watcher also runs un-scoped via the WATCH_LOCK_SLOT
-    // fallback inside `cartog-watch`.
-    let watch_slot: Option<String> = opts.pid_lock_slot.as_deref().map(serve_to_watch_slot);
+    // fallback inside `cartog-watch`. An off-pattern serve slot is a hard
+    // error here — silently using the global slot would let distinct
+    // embedders collide on `watch.pid`.
+    let watch_slot: Option<String> = match opts.pid_lock_slot.as_deref() {
+        Some(s) => Some(serve_to_watch_slot(s)?),
+        None => None,
+    };
     let initial_watch_handle: Option<WatchHandle> = if watch && role == Role::Primary {
         let cwd = std::env::current_dir()?;
         let mut config = WatchConfig::new(cwd);
@@ -1399,9 +1406,20 @@ pub async fn run_server(
     let lock_cell = Arc::new(Mutex::new(initial_lock));
     let watch_cell = Arc::new(Mutex::new(initial_watch_handle));
 
+    // The promoter requires all four of (held primary, state dir, serve
+    // slot, watch slot) to be present. The all-Some case is the production
+    // CLI path; partial-Some shapes occur only when a library embedder has
+    // an off-pattern config — we silently run without a promoter rather
+    // than panicking inside the spawned task, and `cartog_stats` keeps
+    // surfacing the ReadOnly role so the operator can debug.
     let promoter_handle: Option<tokio::task::JoinHandle<()>> = if role == Role::ReadOnly {
-        match (primary_to_watch, opts.pid_lock_dir.clone()) {
-            (Some(primary), Some(state_dir)) => {
+        match (
+            primary_to_watch,
+            opts.pid_lock_dir.clone(),
+            opts.pid_lock_slot.clone(),
+            watch_slot.clone(),
+        ) {
+            (Some(primary), Some(state_dir), Some(serve_slot), Some(watch_slot)) => {
                 let pinned = server
                     .db
                     .lock()
@@ -1414,20 +1432,11 @@ pub async fn run_server(
                     lock_cell: Arc::clone(&lock_cell),
                     watch_cell: Arc::clone(&watch_cell),
                     watcher_active: Arc::clone(&server.watcher_active),
+                    embedding_provider: Arc::clone(&server.embedding_provider),
                     db_path: db_path.to_path_buf(),
                     state_dir,
-                    // .expect documents the precondition: this branch
-                    // requires opts.pid_lock_dir.is_some() (see line above),
-                    // and acquire_serve_lock already hard-fails when dir is
-                    // Some but slot is None. A future refactor that loosens
-                    // either guard will trip this assertion loudly rather
-                    // than silently re-introducing global-slot peers.
-                    serve_slot: opts.pid_lock_slot.clone().expect(
-                        "precondition: acquire_serve_lock rejects pid_lock_dir without pid_lock_slot",
-                    ),
-                    watch_slot: watch_slot.clone().expect(
-                        "precondition: watch_slot is derived from opts.pid_lock_slot above",
-                    ),
+                    serve_slot,
+                    watch_slot,
                     cwd,
                     primary,
                     pinned,
@@ -1496,6 +1505,11 @@ struct PromoterArgs {
     /// on a successful post-promotion spawn, left false if the watcher
     /// failed to start (degraded Primary: surfaced in `cartog_stats`).
     watcher_active: Arc<std::sync::atomic::AtomicBool>,
+    /// Secondary's embedding provider. Used to reconcile the on-disk
+    /// embedding fingerprint against the secondary's actual provider when
+    /// we promote — CartogServer::new does this on first start, but
+    /// open_existing_ro deliberately skips it.
+    embedding_provider: Arc<Mutex<Box<dyn rag::provider::EmbeddingProvider>>>,
     db_path: std::path::PathBuf,
     state_dir: std::path::PathBuf,
     /// Slot to claim when the promoter wins election. Matches the slot the
@@ -1594,12 +1608,11 @@ async fn promoter_task(args: PromoterArgs) {
             return;
         }
 
-        // Swap the DB connection to read-write. We hold the Mutex for the
-        // entire swap, so no tool handler can be mid-query against the
-        // about-to-close read-only connection. On open_existing_rw
-        // failure (transient I/O, disk pressure), drop the lock and loop
-        // — a subsequent poll may succeed. Only a poisoned mutex is
-        // permanently fatal.
+        // Open a fresh RW Database. We DON'T install it into args.db yet —
+        // we first reconcile the embedding fingerprint and try to spawn
+        // the watcher (if requested), so a failure at either step rolls
+        // back cleanly (drop rw + lock, loop and retry next tick) without
+        // leaving the secondary with a half-promoted state.
         let rw = match Database::open_existing_rw(&args.db_path) {
             Ok(rw) => rw,
             Err(e) => {
@@ -1611,49 +1624,43 @@ async fn promoter_task(args: PromoterArgs) {
                 continue;
             }
         };
-        match args.db.lock() {
-            Ok(mut guard) => {
-                *guard = rw;
-            }
-            Err(_) => {
-                tracing::error!("db mutex poisoned; cannot promote, exiting promoter task");
-                drop(new_lock);
-                return;
-            }
-        }
 
-        // Install the lock so it lives until shutdown (Drop unlinks the
-        // PID file). Flip role to Primary BEFORE spawning the watcher so
-        // tool handlers that re-check `role.load()` immediately see the
-        // new state — and the write tools start accepting requests at
-        // the same moment the DB is RW (no window where role lags the
-        // swap).
-        //
-        // A poisoned lock_cell mutex is fatal in the same way args.db
-        // poison is (treated symmetrically above): if we let `new_lock`
-        // fall off the end of an `if let Ok(_)` arm, Drop unlinks the
-        // PID file, and then storing Role::Primary creates a "primary
-        // with no lock" state — a fresh `cartog serve` would win the
-        // next O_EXCL acquire and we'd have two Primaries. Instead, bail
-        // out cleanly: drop the lock, leave role as ReadOnly, exit the
-        // promoter task. The next-attempt path is now closed (caller
-        // would need to restart the process), but a poisoned mutex
-        // means the whole server is degraded anyway.
-        match args.lock_cell.lock() {
-            Ok(mut guard) => {
-                *guard = Some(new_lock);
-            }
+        // Reconcile the embedding fingerprint against the freshly-opened
+        // RW connection. CartogServer::new does this on first start, but
+        // a ReadOnly secondary skips it (open_existing_ro is a verbatim
+        // attach). Without this step, vectors written via cartog_rag_index
+        // after promotion would silently mismatch the fingerprint persisted
+        // by the previous primary.
+        let provider_fp = match args.embedding_provider.lock() {
+            Ok(guard) => rag::fingerprint_of(guard.as_ref()),
             Err(_) => {
                 tracing::error!(
-                    "lock_cell mutex poisoned; cannot install serve lock, exiting promoter task without flipping role"
+                    "embedding_provider mutex poisoned; cannot reconcile fingerprint, exiting promoter without promoting"
                 );
+                drop(rw);
                 drop(new_lock);
                 return;
             }
+        };
+        if let Err(e) = rw.reconcile_embedding_fingerprint(&provider_fp) {
+            tracing::warn!(
+                error = %e,
+                "embedding fingerprint reconcile failed during promotion; dropping lock and retrying"
+            );
+            drop(rw);
+            drop(new_lock);
+            continue;
         }
-        args.role.store(Role::Primary);
 
-        if args.watch_requested {
+        // Try to spawn the watcher BEFORE flipping role / installing the
+        // lock. If spawn fails (e.g. a separately-running `cartog watch`
+        // grabbed the watch slot in the gap between our serve-slot acquire
+        // and here), we drop both the rw handle and the new lock and loop
+        // — the next poll re-checks primary liveness and re-attempts. This
+        // keeps the invariant "Primary always owns its watcher when
+        // watch_requested" intact rather than leaving a degraded Primary
+        // with no watcher and only a stderr warning.
+        let new_watch_handle: Option<WatchHandle> = if args.watch_requested {
             // Reuse the cwd captured at server startup, not
             // std::env::current_dir() — the latter follows runtime
             // chdir() calls (rare in MCP children but possible in tests
@@ -1677,34 +1684,76 @@ async fn promoter_task(args: PromoterArgs) {
             config.skip_migrations = true;
             let db_path_str = args.db_path.to_string_lossy().into_owned();
             match watch::spawn_watch(config, &db_path_str) {
-                Ok(handle) => {
-                    // If watch_cell is poisoned, dropping `handle` here
-                    // signals shutdown to the watcher thread (its
-                    // shutdown flag flips in Drop). That's the best we
-                    // can do; the server stays Primary with no watcher
-                    // — degraded but not corrupt — and we leave
-                    // watcher_active = false so `cartog_stats` surfaces
-                    // the degradation.
-                    match args.watch_cell.lock() {
-                        Ok(mut guard) => {
-                            *guard = Some(handle);
-                            args.watcher_active
-                                .store(true, std::sync::atomic::Ordering::Relaxed);
-                        }
-                        Err(_) => {
-                            tracing::error!(
-                                "watch_cell mutex poisoned; post-promotion watcher discarded — \
-                                 server is Primary but will not auto-reindex"
-                            );
-                            drop(handle);
-                        }
-                    }
-                }
+                Ok(handle) => Some(handle),
                 Err(e) => {
-                    tracing::warn!(error = %e, "post-promotion watcher failed to start");
+                    tracing::warn!(
+                        error = %e,
+                        "post-promotion watcher failed to start; rolling back promotion and retrying"
+                    );
+                    drop(rw);
+                    drop(new_lock);
+                    continue;
+                }
+            }
+        } else {
+            None
+        };
+
+        // From here on the commit is one-way: install RW DB, lock, watcher
+        // (if any), and flip role. A poisoned cell is fatal for symmetric
+        // reasons — letting the lock Drop unlink the PID file while role
+        // stays ReadOnly would let a fresh `cartog serve` win the next
+        // O_EXCL acquire alongside our still-running RW DB connection.
+        match args.db.lock() {
+            Ok(mut guard) => {
+                *guard = rw;
+            }
+            Err(_) => {
+                tracing::error!("db mutex poisoned; cannot promote, exiting promoter task");
+                drop(new_lock);
+                if let Some(h) = new_watch_handle {
+                    drop(h);
+                }
+                return;
+            }
+        }
+        match args.lock_cell.lock() {
+            Ok(mut guard) => {
+                *guard = Some(new_lock);
+            }
+            Err(_) => {
+                tracing::error!(
+                    "lock_cell mutex poisoned; cannot install serve lock, exiting promoter task without flipping role"
+                );
+                drop(new_lock);
+                if let Some(h) = new_watch_handle {
+                    drop(h);
+                }
+                return;
+            }
+        }
+        if let Some(handle) = new_watch_handle {
+            // If watch_cell is poisoned, dropping `handle` here signals
+            // shutdown to the watcher thread (its shutdown flag flips in
+            // Drop). We've already committed the lock and DB swap, so we
+            // can't roll back — proceed degraded with watcher_active=false
+            // so `cartog_stats` surfaces the missing watcher.
+            match args.watch_cell.lock() {
+                Ok(mut guard) => {
+                    *guard = Some(handle);
+                    args.watcher_active
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+                Err(_) => {
+                    tracing::error!(
+                        "watch_cell mutex poisoned; post-promotion watcher discarded — \
+                         server is Primary but will not auto-reindex"
+                    );
+                    drop(handle);
                 }
             }
         }
+        args.role.store(Role::Primary);
 
         info!("promoted to primary for {}", args.db_path.display());
         return;
@@ -2167,20 +2216,26 @@ mod tests {
     fn serve_to_watch_slot_preserves_db_scope() {
         // The watcher slot is derived from the serve slot so both PID files
         // for the same DB share their scope suffix.
-        assert_eq!(serve_to_watch_slot("serve"), "watch");
-        assert_eq!(serve_to_watch_slot("serve-abc123"), "watch-abc123");
-        // Unknown prefix falls back to the global watch slot.
-        assert_eq!(serve_to_watch_slot("unknown-prefix"), "watch");
+        assert_eq!(serve_to_watch_slot("serve").unwrap(), "watch");
+        assert_eq!(serve_to_watch_slot("serve-abc123").unwrap(), "watch-abc123");
         // Off-pattern inputs that start with the bytes "serve" but are NOT
-        // a serve-family slot must fall back to the global slot rather than
-        // produce a silently-corrupted "watch{rest}" string.
-        assert_eq!(serve_to_watch_slot("server"), "watch");
-        assert_eq!(serve_to_watch_slot("serverless"), "watch");
-        assert_eq!(serve_to_watch_slot("servefoo"), "watch");
-        assert_eq!(serve_to_watch_slot("Serve"), "watch");
-        assert_eq!(serve_to_watch_slot(""), "watch");
-        // Trailing-dash with empty hex: must fall back, not emit "watch-".
-        assert_eq!(serve_to_watch_slot("serve-"), "watch");
+        // a serve-family slot must be REJECTED — silently folding them to
+        // the global watch slot would let distinct embedders collide on
+        // `watch.pid` while their serve slots stay distinct.
+        for bad in [
+            "unknown-prefix",
+            "server",
+            "serverless",
+            "servefoo",
+            "Serve",
+            "",
+            "serve-", // trailing-dash with empty hex
+        ] {
+            assert!(
+                serve_to_watch_slot(bad).is_err(),
+                "expected off-pattern slot {bad:?} to be rejected"
+            );
+        }
     }
 
     #[test]
@@ -2481,16 +2536,24 @@ mod tests {
         pinned: Option<PinnedAttach>,
         serve_slot: &str,
     ) -> PromoterArgs {
+        // Test embedding provider: the reconcile step on promotion needs
+        // SOMETHING to fingerprint, but the test paths never actually write
+        // embeddings — the default rag config matches the secondary's, so
+        // reconcile is a no-op.
+        let test_provider =
+            rag::create_embedding_provider(&rag::EmbeddingProviderConfig::default())
+                .expect("test embedding provider should construct");
         PromoterArgs {
             db,
             role,
             lock_cell: Arc::new(Mutex::new(None)),
             watch_cell: Arc::new(Mutex::new(None)),
             watcher_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            embedding_provider: Arc::new(Mutex::new(test_provider)),
             db_path: db_path.clone(),
             state_dir,
             serve_slot: serve_slot.to_string(),
-            watch_slot: serve_to_watch_slot(serve_slot),
+            watch_slot: serve_to_watch_slot(serve_slot).expect("test slot must be valid"),
             cwd: std::env::current_dir().unwrap(),
             primary,
             pinned,
@@ -2770,14 +2833,21 @@ mod tests {
         let watch_cell = Arc::clone(&args.watch_cell);
 
         let handle = tokio::task::spawn(promoter_task(args));
-        // Give the promoter time to promote + spawn the watcher thread.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
         // The expected watcher PID file uses the SCOPED watch slot derived
         // via `serve_to_watch_slot(scoped_slot)`.
-        let expected_watch_slot = serve_to_watch_slot(scoped_slot);
+        let expected_watch_slot = serve_to_watch_slot(scoped_slot).expect("scoped slot is valid");
         let expected_watch_pid = state_dir.join(format!("{expected_watch_slot}.pid"));
         let global_watch_pid = state_dir.join(format!("{}.pid", watch::WATCH_LOCK_SLOT));
+
+        // Poll for up to 5s in 50ms increments — the watcher startup walks
+        // the cwd, sweeps stale locks, and creates the debouncer; on a
+        // loaded CI machine the cumulative cost can exceed any small fixed
+        // sleep, so a fixed sleep here was a flake source.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !expected_watch_pid.exists() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
         assert!(
             expected_watch_pid.exists(),
             "watcher should have claimed the scoped slot at {expected_watch_pid:?}"

--- a/crates/cartog-process-lock/src/lib.rs
+++ b/crates/cartog-process-lock/src/lib.rs
@@ -297,6 +297,13 @@ pub struct ActiveLock {
     pub start_time: Option<u64>,
 }
 
+/// Soft cap on the number of `*.pid` files inspected per scan. A heavy
+/// user with hundreds of cohabiting projects in the same state dir would
+/// otherwise pay a `kill(pid, 0)` syscall per file on every long-lived
+/// command launch; capping bounds the cost. Entries beyond the cap are
+/// reaped on a subsequent run.
+const SCAN_CAP: usize = 256;
+
 /// Scan `state_dir` for `*.pid` files. Returns one [`ActiveLock`] per file
 /// whose recorded PID is still alive on this machine. Stale files (process
 /// gone) are deleted as a side-effect so the directory stays clean.
@@ -304,17 +311,26 @@ pub struct ActiveLock {
 /// A missing or unreadable directory yields an empty vec — long-lived
 /// commands may not have run yet, which is the common case on a fresh
 /// install.
+///
+/// At most [`SCAN_CAP`] entries are inspected; pathological accumulation
+/// across many cohabiting projects is reaped progressively across multiple
+/// long-lived command launches rather than in one O(N) sweep.
 pub fn find_active_locks(state_dir: &Path) -> Vec<ActiveLock> {
     let entries = match fs::read_dir(state_dir) {
         Ok(e) => e,
         Err(_) => return Vec::new(),
     };
     let mut active = Vec::new();
+    let mut inspected: usize = 0;
     for entry in entries.flatten() {
+        if inspected >= SCAN_CAP {
+            break;
+        }
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) != Some(PID_EXTENSION) {
             continue;
         }
+        inspected += 1;
         let slot = match path.file_stem().and_then(|s| s.to_str()) {
             Some(s) if !s.is_empty() => s.to_string(),
             _ => continue,

--- a/crates/cartog-process-lock/src/lib.rs
+++ b/crates/cartog-process-lock/src/lib.rs
@@ -297,12 +297,18 @@ pub struct ActiveLock {
     pub start_time: Option<u64>,
 }
 
-/// Soft cap on the number of `*.pid` files inspected per scan. A heavy
-/// user with hundreds of cohabiting projects in the same state dir would
-/// otherwise pay a `kill(pid, 0)` syscall per file on every long-lived
-/// command launch; capping bounds the cost. Entries beyond the cap are
-/// reaped on a subsequent run.
-const SCAN_CAP: usize = 256;
+/// Soft cap on the number of `*.pid` files the opportunistic reaper
+/// inspects per call. A heavy user with hundreds of cohabiting projects
+/// in the same state dir would otherwise pay a `kill(pid, 0)` syscall
+/// per file on every long-lived command launch; capping bounds the
+/// reaper cost. Entries beyond the cap are reaped on a subsequent run.
+///
+/// The cap is ONLY applied to [`sweep_stale_locks`]. Live-peer detection
+/// via [`find_active_locks`] is uncapped: capping there would create
+/// false negatives (a real peer at index 257 would not be reported), and
+/// callers like `cartog self update` would then proceed to swap binaries
+/// while a live primary keeps writing.
+const REAPER_SCAN_CAP: usize = 256;
 
 /// Scan `state_dir` for `*.pid` files. Returns one [`ActiveLock`] per file
 /// whose recorded PID is still alive on this machine. Stale files (process
@@ -312,10 +318,17 @@ const SCAN_CAP: usize = 256;
 /// commands may not have run yet, which is the common case on a fresh
 /// install.
 ///
-/// At most [`SCAN_CAP`] entries are inspected; pathological accumulation
-/// across many cohabiting projects is reaped progressively across multiple
-/// long-lived command launches rather than in one O(N) sweep.
+/// Uncapped: this is the correctness path used by `cartog self update`,
+/// `cartog self migrate-db`, and the watch-slot promoter to decide whether
+/// a live peer exists. Missing a real peer here is unsafe.
 pub fn find_active_locks(state_dir: &Path) -> Vec<ActiveLock> {
+    scan_locks(state_dir, None)
+}
+
+/// Internal scan with an optional cap on entries inspected. `None` =
+/// uncapped (correctness); `Some(n)` = inspect at most `n` entries (used
+/// by the opportunistic reaper in [`sweep_stale_locks`]).
+fn scan_locks(state_dir: &Path, cap: Option<usize>) -> Vec<ActiveLock> {
     let entries = match fs::read_dir(state_dir) {
         Ok(e) => e,
         Err(_) => return Vec::new(),
@@ -323,8 +336,10 @@ pub fn find_active_locks(state_dir: &Path) -> Vec<ActiveLock> {
     let mut active = Vec::new();
     let mut inspected: usize = 0;
     for entry in entries.flatten() {
-        if inspected >= SCAN_CAP {
-            break;
+        if let Some(limit) = cap {
+            if inspected >= limit {
+                break;
+            }
         }
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) != Some(PID_EXTENSION) {
@@ -372,26 +387,30 @@ pub fn find_active_locks(state_dir: &Path) -> Vec<ActiveLock> {
     active
 }
 
-/// Reap stale PID files in `state_dir`. Side-effect equivalent of
-/// [`find_active_locks`] without the return value.
+/// Reap stale PID files in `state_dir`. Opportunistic — capped at
+/// [`REAPER_SCAN_CAP`] entries per call to bound the cost on a state
+/// dir that has accumulated many cohabiting projects. Entries beyond
+/// the cap are reaped on a subsequent run.
 ///
-/// Each `*.pid` whose recorded PID is dead (or whose recorded start_time
-/// disagrees with the live PID, i.e. PID-reuse) is unlinked via
-/// [`unlink_if_unchanged`] so a concurrent writer landing fresh content in
-/// the TOCTOU window is preserved. Malformed files (unreadable on two
-/// consecutive reads) are removed unconditionally because there is no
-/// holder identity to protect.
+/// Each inspected `*.pid` whose recorded PID is dead (or whose recorded
+/// start_time disagrees with the live PID, i.e. PID-reuse) is unlinked
+/// via [`unlink_if_unchanged`] so a concurrent writer landing fresh
+/// content in the TOCTOU window is preserved. Malformed files
+/// (unreadable on two consecutive reads) are removed unconditionally
+/// because there is no holder identity to protect.
 ///
-/// Called from [`ProcessLock::acquire`] so every long-lived command launch
-/// (`cartog serve`, `cartog watch`, promoter handoff) reaps leftovers from
-/// crashed peers before claiming its own slot. Cost is one `read_dir` plus
-/// one `kill(pid, 0)` per file — sub-millisecond on a state dir with a
-/// handful of entries.
+/// Called from [`ProcessLock::acquire`] so every long-lived command
+/// launch (`cartog serve`, `cartog watch`, promoter handoff) reaps
+/// leftovers from crashed peers before claiming its own slot.
+///
+/// NOT a replacement for [`find_active_locks`]: this call is allowed to
+/// miss entries (they'll be reaped next time). Live-peer detection must
+/// use [`find_active_locks`] (uncapped) instead.
 ///
 /// A missing or unreadable `state_dir` is a no-op (the caller will create
 /// it during their own acquire).
 pub fn sweep_stale_locks(state_dir: &Path) {
-    let _ = find_active_locks(state_dir);
+    let _ = scan_locks(state_dir, Some(REAPER_SCAN_CAP));
 }
 
 /// Unlink the PID file at `path` only if its current contents still match
@@ -1138,6 +1157,43 @@ mod tests {
         let missing = parent.path().join("does-not-exist");
         sweep_stale_locks(&missing);
         // No assertion needed — absence of panic is the test.
+    }
+
+    #[test]
+    fn find_active_locks_is_uncapped_so_real_peers_are_never_missed() {
+        // Regression: an earlier version capped find_active_locks at 256
+        // entries to bound startup cost, but that made `cartog self
+        // update` proceed past a live peer hiding beyond the cap. The
+        // cap MUST only apply to the opportunistic reaper
+        // (sweep_stale_locks); the live-peer query must inspect every
+        // entry. We pad with REAPER_SCAN_CAP+1 stale files, place our
+        // own live PID at the end of read_dir order (by lexical sort:
+        // "zzz-live"), and assert it's returned.
+        let dir = TempDir::new().unwrap();
+        for i in 0..=REAPER_SCAN_CAP {
+            // Stale: PID well past Linux pid_max default.
+            fs::write(
+                dir.path().join(format!("aaa-stale-{i:04}.pid")),
+                "4194304\n0\n",
+            )
+            .unwrap();
+        }
+        let live_slot = "zzz-live";
+        let live_path = dir.path().join(format!("{live_slot}.pid"));
+        let pid = std::process::id();
+        let payload = match process_start_time(pid) {
+            Some(st) => format!("{pid}\n{st}\n"),
+            None => format!("{pid}\n"),
+        };
+        fs::write(&live_path, &payload).unwrap();
+
+        let active = find_active_locks(dir.path());
+        assert!(
+            active.iter().any(|a| a.slot == live_slot),
+            "find_active_locks must NOT miss a live peer beyond REAPER_SCAN_CAP \
+             (found slots: {slots:?})",
+            slots = active.iter().map(|a| &a.slot).collect::<Vec<_>>(),
+        );
     }
 
     #[test]

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -167,7 +167,25 @@ impl WatchHandle {
 impl Drop for WatchHandle {
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
-        // Don't join on drop — the thread will exit on next loop iteration.
+        // Best-effort join with a bounded deadline. Without this, the
+        // watcher thread keeps holding the PID `ProcessLock` until its
+        // next `recv_timeout` (~1s for idle, up to `config.debounce`
+        // worst case), so a fresh `cartog watch` started right after Drop
+        // would observe AcquireError::Held — confusing the user who saw
+        // the previous process exit. We try briefly (~1.5s) then return:
+        // we'd rather leak the thread than block shutdown for several
+        // seconds on a hung debouncer. Callers wanting deterministic
+        // cleanup should call `stop()` explicitly (it joins unbounded).
+        if let Some(handle) = self.thread.take() {
+            let deadline = std::time::Instant::now() + Duration::from_millis(1500);
+            while !handle.is_finished() && std::time::Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+            // else: leak the JoinHandle (process is shutting down anyway).
+        }
     }
 }
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1445,8 +1445,14 @@ pub fn cmd_watch(
     config.rag_delay = Duration::from_secs(rag_delay);
     config.rag_config = provider_config;
     config.json_events = json;
+    // pid_lock_dir/slot must be both-or-neither: a sandboxed host with no
+    // resolvable state dir falls back to untracked mode rather than hard-
+    // failing on the inverse half-config check in validate_pid_lock_config.
     config.pid_lock_dir = crate::state::default_state_dir();
-    config.pid_lock_slot = Some(crate::state::slot_for_db("watch", db_path));
+    config.pid_lock_slot = config
+        .pid_lock_dir
+        .as_ref()
+        .map(|_| crate::state::slot_for_db("watch", db_path));
 
     let db_path_str = db_path.to_string_lossy();
     watch::run_watch(config, &db_path_str)

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -211,9 +211,16 @@ fn main() -> Result<()> {
         } => commands::ide::cmd_ide(client, scope, yes, dry_run, no_watch, cli.json),
         Command::Serve { watch, rag } => {
             let runtime = tokio::runtime::Runtime::new()?;
+            // pid_lock_dir/slot must be both-or-neither: a sandboxed host with no
+            // resolvable state dir falls back to untracked mode rather than
+            // hard-failing on the inverse half-config check in acquire_serve_lock.
+            let pid_lock_dir = state::default_state_dir();
+            let pid_lock_slot = pid_lock_dir
+                .as_ref()
+                .map(|_| state::slot_for_db("serve", &db_path));
             let opts = mcp::ServerOptions {
-                pid_lock_dir: state::default_state_dir(),
-                pid_lock_slot: Some(state::slot_for_db("serve", &db_path)),
+                pid_lock_dir,
+                pid_lock_slot,
             };
             runtime.block_on(mcp::run_server(&db_path, watch, rag, provider_config, opts))
         }

--- a/crates/cartog/src/state.rs
+++ b/crates/cartog/src/state.rs
@@ -163,9 +163,20 @@ fn resolve_db_path_for_slot(db_path: &Path) -> PathBuf {
             break;
         }
     }
-    // Step 3: no ancestor canonicalized (path entirely missing). Hash
-    // the raw path verbatim. This branch is best-effort.
-    db_path.to_path_buf()
+    // Step 3: no ancestor canonicalized (path entirely missing). Walk
+    // components() to drop CurDir (`.`) and collapse redundant separators
+    // before hashing, so logically-equivalent inputs like `/x/y/db` and
+    // `/x/./y/db` still produce the same slot. The branch is still
+    // best-effort — components() does NOT resolve `..` or symlinks — but
+    // the most common drift (a stray `./`) is eliminated.
+    let mut normalized = PathBuf::new();
+    for component in db_path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
 }
 
 impl State {
@@ -556,6 +567,28 @@ mod tests {
         assert_eq!(
             slot_a, slot_b,
             "equivalent paths with missing parent must produce the same slot"
+        );
+    }
+
+    #[test]
+    fn slot_for_db_step3_normalizes_curdir_when_no_ancestor_exists() {
+        // When NO ancestor exists at all (every step-2 canonicalize fails),
+        // step 3 used to hash the raw path verbatim — so `/missing/x/db`
+        // and `/missing/./x/db` produced different slots and two peers
+        // racing to create the same logical DB could each win their own
+        // O_EXCL election. Components-level normalization fixes the common
+        // `./` drift without resolving symlinks or `..`.
+        let bare = slot_for_db(
+            "serve",
+            Path::new("/nonexistent-cartog-root/proj/db.sqlite"),
+        );
+        let dotted = slot_for_db(
+            "serve",
+            Path::new("/nonexistent-cartog-root/./proj/db.sqlite"),
+        );
+        assert_eq!(
+            bare, dotted,
+            "step-3 fallback must normalize CurDir to keep equivalent missing paths consistent"
         );
     }
 


### PR DESCRIPTION
## Summary

Addresses 11 findings from the xhigh code review of PRs #63 (edge-resolution
state=3 external) and #64 (DB-scoped PID lock slots). Five grouped commits:

| Commit | Findings | What it fixes |
|---|---|---|
| `fix(cli): gate pid_lock_slot on default_state_dir` | #1 | Hard regression: `cartog serve` / `cartog watch` failed on sandboxed hosts where `default_state_dir()` returns None |
| `fix(lsp): symmetric raw-path fallback in parse_definition_response` | #2 | Sticky External (state=3) when LSP returns URI for a not-yet-existing file (regression of c2daed7) |
| `fix(mcp): harden promoter handoff against partial promotion` | #3, #4, #5, #7, #13 | Reconcile fingerprint on promotion, spawn-then-flip ordering, surface watcher errors, typed slot-pair guard, replace 300ms flake sleep with poll-with-deadline |
| `fix(watch,db,process-lock): bounded Drop join, state-guarded edge marks, capped sweep` | #6, #9, #10, #11 | `WatchHandle::Drop` joins for up to 1.5s, `mark_edge_*` carry `WHERE resolution_state = 0`, sweep capped at 256, fix docstrings claiming invalidate reopens state {2, 3} |
| `fix(state): normalize CurDir in slot_for_db step-3` | #4 (sweep) | `slot_for_db` step-3 fallback now drops `CurDir` lexically so `/x/y/db` and `/x/./y/db` hash to the same slot |

Findings deliberately NOT addressed (REFUTED in verification):
- `lang_resolved` gate on External path — intentional and documented
- `slot_for_db` cwd-anchor re-derivation — no caller re-derives
- Case-C unlink in `ProcessLock::acquire` — `hard_link` is atomic, no mid-write window

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` (~870 tests, all green)
- [x] New regression tests:
  - `parse_definition_response` symmetric fallback on missing target (cartog-lsp)
  - `slot_for_db` step-3 CurDir normalization (cartog/state)
  - `serve_to_watch_slot` rejects off-pattern slots (cartog-mcp)
- [x] `promoter_spawns_watcher_with_db_scoped_watch_slot` converted from fixed 300ms sleep to 5s deadline poll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed definition path resolution when canonical paths differ from raw paths.
  * Improved path normalization in fallback handling.
  * Enhanced watcher thread shutdown and recovery.

* **Improvements**
  * Stricter validation of configuration settings with early error reporting.
  * Better database promotion consistency with embedding provider reconciliation.
  * Added performance optimizations for lock detection scanning.
  * Improved configuration consistency for coupled settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->