### PR TITLE
feat(remote): opt-in S3 index sync (cartog push / cartog pull)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,31 @@ jobs:
       - run: cargo test
       - run: cargo test --no-default-features
 
+  test-remote:
+    name: Test Remote (S3/floci)
+    runs-on: ubuntu-latest
+    # Drives `cartog push` / `cartog pull` against a floci container
+    # (AWS-local-emulator) over docker. Separate from the main `test` job
+    # so failures are unambiguous: this one is about S3 plumbing, not the
+    # core indexer.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Ensure AWS CLI is available
+        # AWS CLI is preinstalled on ubuntu-latest runners; this is a
+        # defensive check that prints the version, not an install step.
+        run: aws --version
+      - name: Pre-pull floci image
+        # Pre-pulling avoids each test paying the pull latency in its own
+        # wait loop and keeps test runtime under ~30 s for the whole file.
+        run: docker pull floci/floci
+      - name: Run remote integration tests
+        # `--test-threads=1` because each test claims a floci container
+        # on a random host port; running in parallel needs no further
+        # coordination, but serial output is easier to read on failure.
+        run: cargo test --test remote_integration -- --test-threads=1 --nocapture
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,16 +135,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.28.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
+dependencies = [
+ "http 1.4.0",
+ "log",
+ "rustls 0.23.40",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-creds"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml 0.32.0",
+ "rust-ini",
+ "serde",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -222,6 +269,8 @@ dependencies = [
  "directories",
  "libc",
  "reqwest",
+ "rusqlite",
+ "rust-s3",
  "self_update",
  "serde",
  "serde_json",
@@ -558,6 +607,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +653,16 @@ dependencies = [
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -820,6 +899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -885,6 +965,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -950,6 +1031,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1277,7 +1367,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1295,6 +1385,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1346,13 +1442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "http",
+ "http 1.4.0",
  "indicatif 0.18.4",
  "libc",
  "log",
@@ -1366,10 +1468,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -1383,12 +1514,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1399,8 +1541,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1409,6 +1551,35 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1421,8 +1592,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1433,18 +1604,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1457,14 +1642,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1865,6 +2050,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,10 +2302,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ort"
@@ -2280,6 +2498,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
@@ -2299,8 +2527,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2319,7 +2547,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2337,7 +2565,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2530,25 +2758,25 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2558,7 +2786,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2642,6 +2870,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "futures",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml 0.32.0",
+ "rustls 0.21.12",
+ "rustls-native-certs",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2946,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -2679,9 +2966,30 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2692,6 +3000,16 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2747,6 +3065,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,10 +3106,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self-replace"
@@ -2803,10 +3163,10 @@ checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
 dependencies = [
  "either",
  "flate2",
- "hyper",
+ "hyper 1.9.0",
  "indicatif 0.17.11",
  "log",
- "quick-xml",
+ "quick-xml 0.37.5",
  "regex",
  "reqwest",
  "self-replace",
@@ -2996,6 +3356,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3227,6 +3597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,7 +3684,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3323,11 +3702,32 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3409,8 +3809,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -3665,14 +4065,14 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3682,7 +4082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -3904,6 +4304,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,17 +136,18 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.28.5"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "http 1.4.0",
+ "base64 0.22.1",
+ "http",
  "log",
- "rustls 0.23.40",
+ "rustls",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -157,28 +158,50 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-creds"
-version = "0.37.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
+checksum = "ca3b85155d265df828f84e53886ed9e427aed979dd8a39f5b8b2162c77e142d7"
 dependencies = [
  "attohttpc",
  "home",
  "log",
- "quick-xml 0.32.0",
+ "quick-xml 0.38.4",
  "rust-ini",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "url",
 ]
 
 [[package]]
-name = "aws-region"
-version = "0.25.5"
+name = "aws-lc-rs"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
- "thiserror 1.0.69",
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -186,12 +209,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -441,6 +458,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -465,7 +484,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -552,6 +571,15 @@ checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
 dependencies = [
  "clap",
  "roff",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -653,16 +681,6 @@ dependencies = [
  "serde_json",
  "time",
  "url",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1052,6 +1070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1232,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1367,7 +1397,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1454,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "http 1.4.0",
+ "http",
  "indicatif 0.18.4",
  "libc",
  "log",
@@ -1493,17 +1523,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1514,23 +1533,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1541,8 +1549,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1551,35 +1559,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -1592,8 +1571,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1604,32 +1583,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1642,14 +1607,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1667,7 +1632,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1900,6 +1865,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -2199,6 +2174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,10 +2240,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -2300,12 +2303,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "option-ext"
@@ -2367,7 +2364,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2498,21 +2495,21 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2527,8 +2524,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.40",
- "socket2 0.6.3",
+ "rustls",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2547,7 +2544,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2565,7 +2562,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2758,25 +2755,25 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2786,7 +2783,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2881,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "rust-s3"
-version = "0.35.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
+checksum = "aeedb13abdaa7e48d391de05b0569b37fa0a7a64a668dff6ffb2141ad0c2527e"
 dependencies = [
  "async-trait",
  "aws-creds",
@@ -2891,27 +2888,24 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "cfg-if",
- "futures",
+ "futures-util",
  "hex",
  "hmac",
- "http 0.2.12",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
+ "http",
  "log",
  "maybe-async",
  "md5",
  "percent-encoding",
- "quick-xml 0.32.0",
- "rustls 0.21.12",
- "rustls-native-certs",
+ "quick-xml 0.38.4",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2",
- "thiserror 1.0.69",
+ "sysinfo",
+ "thiserror 2.0.18",
  "time",
  "tokio",
- "tokio-rustls 0.24.1",
  "tokio-stream",
  "url",
 ]
@@ -2946,50 +2940,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3004,20 +2966,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3065,15 +3018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,43 +3050,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "self-replace"
@@ -3163,7 +3074,7 @@ checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
 dependencies = [
  "either",
  "flate2",
- "hyper 1.9.0",
+ "hyper",
  "indicatif 0.17.11",
  "log",
  "quick-xml 0.37.5",
@@ -3359,16 +3270,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -3490,6 +3391,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -3684,7 +3599,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3702,21 +3617,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls",
  "tokio",
 ]
 
@@ -3809,8 +3714,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -4065,14 +3970,14 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4082,7 +3987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
 ]
@@ -4308,15 +4213,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -4356,6 +4252,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,9 +4294,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4392,9 +4334,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -4402,7 +4369,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4411,7 +4387,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4456,7 +4432,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4496,7 +4472,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4505,6 +4481,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }
 fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+rust-s3 = { version = "0.35", default-features = false, features = ["tokio-rustls-tls"] }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 url = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }
 fastembed = { version = "5", default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
-rust-s3 = { version = "0.35", default-features = false, features = ["tokio-rustls-tls"] }
+rust-s3 = { version = "0.37", default-features = false, features = ["tokio-rustls-tls"] }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 url = "2"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Map your codebase. Navigate by graph, not grep.**
 
-Single binary. Microsecond queries. 100% local.
+Single binary. Microsecond queries. 100% local by default.
 
 Cartog pre-computes a code graph — symbols, calls, imports, inheritance — and lets you query it instantly. Use it from the CLI for day-to-day navigation, as an MCP server for AI agents, or both. No Python, no pip, no Docker. One binary, one SQLite file, zero cloud dependencies.
 
@@ -412,7 +412,9 @@ provider = "none"            # "local" (default) or "none"
 - **MCP server**: stdio only, no network sockets
 - **No telemetry**, no analytics, no phone-home
 
-Your code never leaves your machine.
+Your code never leaves your machine — unless you explicitly opt in to
+[S3-compatible index sync](docs/usage.md#cartog-push---remote-s3-url)
+(`cartog push` / `cartog pull`), which is inert until you configure a remote.
 
 ## Documentation
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -380,6 +380,30 @@ pub fn register_sqlite_vec() {
 /// Current schema version. Increment when adding migrations.
 const SCHEMA_VERSION: u32 = 4;
 
+/// Public mirror of [`SCHEMA_VERSION`] for callers outside this crate
+/// (e.g. `cartog pull` needs it to compare against a pulled DB and refuse
+/// to load a future-versioned file). Kept in sync by construction.
+pub const CURRENT_SCHEMA_VERSION: u32 = SCHEMA_VERSION;
+
+/// Read the `schema_version` recorded in a cartog SQLite file at `path`,
+/// without going through the full [`Database::open`] machinery (no
+/// migrations, no fingerprint reconciliation). Used by `cartog pull` to
+/// guard against pulling a future-versioned DB before clobbering the
+/// local one.
+///
+/// Returns `Ok(0)` when the file exists but is not a cartog DB (no
+/// `metadata` table, or no `schema_version` row). Returns `Err` only on
+/// genuine SQLite errors (corrupt file, permission denied, etc.).
+pub fn read_schema_version_at(path: &std::path::Path) -> anyhow::Result<u32> {
+    use anyhow::Context;
+    let conn = Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .with_context(|| format!("open {} read-only for schema check", path.display()))?;
+    Ok(read_schema_version(&conn)?)
+}
+
 /// True when the `symbol_vec` virtual table exists in the open DB. Used by
 /// the fast-path early returns in [`handle_embedding_dimension`] and
 /// [`Database::reconcile_embedding_fingerprint`] so a previously-corrupted

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -36,15 +36,23 @@ directories = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
+rust-s3 = { workspace = true, optional = true }
 
 [features]
-default = ["lsp"]
+default = ["lsp", "remote-s3"]
 lsp = ["dep:cartog-lsp", "cartog-indexer/lsp", "cartog-mcp/lsp"]
 ollama-embedding = ["cartog-rag/provider-ollama"]
+remote-s3 = ["dep:rust-s3"]
 
 [dev-dependencies]
 criterion = { workspace = true }
 serial_test = { workspace = true }
+# Used by `tests/remote_integration.rs` to fabricate a non-cartog SQLite file
+# for the schema-version refusal negative test. Workspace already pins
+# `rusqlite` with `bundled` for the runtime DB, so no new dep is pulled in
+# at the workspace level.
+rusqlite = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { workspace = true }

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -192,6 +192,36 @@ pub enum Command {
     /// Index statistics summary
     Stats,
 
+    /// Upload the local index to an S3-compatible remote (opt-in feature).
+    ///
+    /// Reads `[remote].url` from `.cartog.toml` unless `--remote` is given.
+    /// Credentials come from the AWS environment chain (env vars / profile /
+    /// IMDS); cartog never reads credentials from `.cartog.toml`.
+    Push {
+        /// Override `s3://bucket/key` target.
+        #[arg(long)]
+        remote: Option<String>,
+    },
+
+    /// Download an index from an S3-compatible remote (opt-in feature).
+    ///
+    /// Refuses to overwrite the local DB while a peer (`cartog serve` /
+    /// `cartog watch`) holds it open, unless `--force` is given. Verifies a
+    /// SHA-256 checksum and schema version before atomic rename.
+    Pull {
+        /// Override `s3://bucket/key` target.
+        #[arg(long)]
+        remote: Option<String>,
+
+        /// Overwrite the local DB even if a peer process is currently using it.
+        #[arg(long)]
+        force: bool,
+
+        /// Skip credential resolution and pull anonymously (public buckets).
+        #[arg(long)]
+        no_sign_request: bool,
+    },
+
     /// Display the current configuration
     Config,
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -17,6 +17,7 @@ use cartog_watch::{self as watch, WatchConfig};
 
 pub mod ide;
 pub mod init;
+pub mod remote;
 
 /// Stderr spinner for long-running CLI commands.
 ///
@@ -454,6 +455,28 @@ pub fn cmd_search(
     })
 }
 
+/// Upload the local index DB to S3-compatible storage.
+pub fn cmd_push(
+    db_path: &Path,
+    config: &CartogConfig,
+    cli_remote: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    remote::push_index(db_path, config, cli_remote, json)
+}
+
+/// Download an index DB from S3-compatible storage into the local project.
+pub fn cmd_pull(
+    db_path: &Path,
+    config: &CartogConfig,
+    cli_remote: Option<&str>,
+    force: bool,
+    no_sign_request: bool,
+    json: bool,
+) -> Result<()> {
+    remote::pull_index(db_path, config, cli_remote, force, no_sign_request, json)
+}
+
 /// Index statistics summary.
 pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
@@ -838,9 +861,27 @@ pub fn cmd_rag_search(
 pub fn cmd_config(
     config: &CartogConfig,
     config_path: Option<&Path>,
+    config_rejected: bool,
     db_path: &Path,
     json: bool,
 ) -> Result<()> {
+    // When the config file was found but rejected at parse time, `config`
+    // is the empty default — displaying it as the active config would
+    // silently lie. Show an explicit error and bail with the path so the
+    // user knows which file to fix.
+    if config_rejected {
+        // Invariant: ConfigLoad::Rejected always carries a path, and main
+        // propagates it as `config_path`. Bail explicitly so this surfaces
+        // even if the invariant ever changes.
+        let p = config_path
+            .ok_or_else(|| anyhow::anyhow!("config rejected but path missing — invariant break"))?;
+        anyhow::bail!(
+            "configuration file {} was rejected (see earlier stderr for the \
+             underlying reason). `cartog config` cannot display a meaningful \
+             view until the file is fixed.",
+            p.display()
+        );
+    }
     use crate::config::{
         DEFAULT_EMBEDDING_PROVIDER, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL,
         DEFAULT_RERANKER_PROVIDER,
@@ -1159,14 +1200,24 @@ fn check_git_repo() -> CheckResult {
     }
 }
 
-fn check_config(config_path: Option<&Path>) -> CheckResult {
-    match config_path {
-        Some(p) => CheckResult {
+fn check_config(config_path: Option<&Path>, rejected: bool) -> CheckResult {
+    match (config_path, rejected) {
+        (Some(p), true) => CheckResult {
+            name: "config".into(),
+            status: CheckStatus::Error,
+            message: format!(
+                "{} was REJECTED (see stderr at startup for the reason). \
+                 cartog is running with defaults; other check rows below \
+                 reflect defaults, not your config file.",
+                p.display()
+            ),
+        },
+        (Some(p), false) => CheckResult {
             name: "config".into(),
             status: CheckStatus::Ok,
             message: format!("loaded from {}", p.display()),
         },
-        None => CheckResult {
+        (None, _) => CheckResult {
             name: "config".into(),
             status: CheckStatus::Warn,
             message: "no .cartog.toml found (using defaults)".into(),
@@ -1336,6 +1387,78 @@ fn check_reranker(config: &rag::EmbeddingProviderConfig) -> CheckResult {
     }
 }
 
+/// Doctor check for the optional `[remote]` S3-compatible sync.
+///
+/// Status semantics:
+/// - **Ok** when `[remote]` is unset (the default — feature is inert; no
+///   network traffic happens unless the user opts in). We do not warn here:
+///   the absence of remote config is the expected baseline.
+/// - **Ok** when `[remote].url` resolves and a HEAD against the configured
+///   object succeeds (200 or 404 — both prove the bucket + creds work).
+/// - **Warn** for any reachability failure (creds missing, wrong region,
+///   network unreachable, 403). Push/pull would fail with the same error;
+///   doctor surfaces it before the user discovers it the hard way.
+/// - **Error** only when the feature was disabled at build time but a
+///   `[remote]` section exists — config will be silently ignored otherwise.
+fn check_remote(config: &CartogConfig, config_rejected: bool) -> CheckResult {
+    // When the config file itself was rejected, the `config.remote` view is
+    // always None (default). Reporting "not configured" here would be
+    // misleading — the user might have had a perfectly valid [remote]
+    // section before some other unrelated key got rejected. Surface this
+    // explicitly so doctor doesn't lie.
+    if config_rejected {
+        return CheckResult {
+            name: "remote".into(),
+            status: CheckStatus::Warn,
+            message: "[remote] status unknown — config file was rejected; \
+                      fix the config and re-run doctor"
+                .into(),
+        };
+    }
+    let remote = match config.remote.as_ref() {
+        Some(r) => r,
+        None => {
+            return CheckResult {
+                name: "remote".into(),
+                status: CheckStatus::Ok,
+                message: "not configured (local-only)".into(),
+            }
+        }
+    };
+
+    if remote.url.as_deref().unwrap_or("").is_empty() {
+        return CheckResult {
+            name: "remote".into(),
+            status: CheckStatus::Warn,
+            message: "[remote] section present but `url` is empty".into(),
+        };
+    }
+
+    #[cfg(not(feature = "remote-s3"))]
+    {
+        let _ = remote; // url presence already checked above
+        CheckResult {
+            name: "remote".into(),
+            status: CheckStatus::Error,
+            message: "[remote] configured but cartog was built without `remote-s3` feature".into(),
+        }
+    }
+
+    #[cfg(feature = "remote-s3")]
+    match remote::check_remote_reachable(remote) {
+        Ok(()) => CheckResult {
+            name: "remote".into(),
+            status: CheckStatus::Ok,
+            message: format!("{} reachable", remote.url.as_deref().unwrap_or("<unset>")),
+        },
+        Err(e) => CheckResult {
+            name: "remote".into(),
+            status: CheckStatus::Warn,
+            message: format!("unreachable: {e}"),
+        },
+    }
+}
+
 fn build_report(checks: Vec<CheckResult>) -> DoctorReport {
     let ok = checks
         .iter()
@@ -1398,19 +1521,19 @@ fn format_report_human(report: &DoctorReport) -> String {
 pub fn cmd_doctor(
     config: &CartogConfig,
     config_path: Option<&Path>,
+    config_rejected: bool,
     db_path: &Path,
     json: bool,
     embedding_dim: usize,
     provider_config: &rag::EmbeddingProviderConfig,
 ) -> Result<()> {
-    let _ = config; // config is read indirectly via provider_config
-
     let checks = vec![
         check_git_repo(),
-        check_config(config_path),
+        check_config(config_path, config_rejected),
         check_database(db_path, embedding_dim),
         check_embedding_provider(provider_config),
         check_reranker(provider_config),
+        check_remote(config, config_rejected),
     ];
 
     let report = build_report(checks);
@@ -1673,16 +1796,23 @@ mod tests {
 
     #[test]
     fn test_check_config_present() {
-        let result = check_config(Some(Path::new("/project/.cartog.toml")));
+        let result = check_config(Some(Path::new("/project/.cartog.toml")), false);
         assert_eq!(result.status, CheckStatus::Ok);
         assert!(result.message.contains(".cartog.toml"));
     }
 
     #[test]
     fn test_check_config_absent() {
-        let result = check_config(None);
+        let result = check_config(None, false);
         assert_eq!(result.status, CheckStatus::Warn);
         assert!(result.message.contains("defaults"));
+    }
+
+    #[test]
+    fn test_check_config_rejected_reports_error() {
+        let result = check_config(Some(Path::new("/project/.cartog.toml")), true);
+        assert_eq!(result.status, CheckStatus::Error);
+        assert!(result.message.contains("REJECTED"));
     }
 
     #[test]

--- a/crates/cartog/src/commands/remote.rs
+++ b/crates/cartog/src/commands/remote.rs
@@ -121,6 +121,22 @@ mod imp {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
+    /// True when `err` is a cross-device-link error from `std::fs::rename`.
+    ///
+    /// `io::ErrorKind::CrossesDevices` is still unstable, so we match on the
+    /// raw OS error code: `EXDEV` is 18 on Linux and macOS;
+    /// `ERROR_NOT_SAME_DEVICE` is 17 on Windows. Anything else is a genuine
+    /// failure the caller should surface, not silently fall back on.
+    fn is_cross_device_error(err: &std::io::Error) -> bool {
+        match err.raw_os_error() {
+            #[cfg(unix)]
+            Some(code) => code == 18, // EXDEV
+            #[cfg(windows)]
+            Some(code) => code == 17, // ERROR_NOT_SAME_DEVICE
+            _ => false,
+        }
+    }
+
     /// RAII guard for the `.partial` download file.
     ///
     /// Deletes the file on Drop unless [`PartialGuard::disarm`] is called.
@@ -419,9 +435,22 @@ mod imp {
             }
             let md: HashMap<String, String> = head.metadata.unwrap_or_default();
             let sha = md.get(META_SHA256).cloned();
-            let schema = md
-                .get(META_SCHEMA_VERSION)
-                .and_then(|s| s.parse::<u32>().ok());
+            // Distinguish "header absent" (None) from "header present but not
+            // a u32" (a hard error). Collapsing both into None made a corrupt
+            // or hand-edited `x-amz-meta-schema-version: abc` masquerade as a
+            // missing header, sending users to the wrong fix ("re-push") when
+            // the real problem is bad metadata they need to clear.
+            let schema = match md.get(META_SCHEMA_VERSION) {
+                None => None,
+                Some(raw) => Some(raw.parse::<u32>().map_err(|_| {
+                    anyhow!(
+                        "remote object has a malformed `x-amz-meta-{META_SCHEMA_VERSION}` \
+                         header ({raw:?}, not an integer). Clear or correct the object \
+                         metadata (e.g. via `aws s3api copy-object`) or re-push from a \
+                         healthy cartog run."
+                    )
+                })?),
+            };
             Ok::<_, anyhow::Error>((sha, schema))
         })?;
 
@@ -533,12 +562,36 @@ mod imp {
             }
         }
 
-        // 9) Atomic rename — no torn DB on a mid-step crash. Disarm the
-        //    guard immediately before rename: after this point the file
-        //    lives at `db_path`, not `.partial`, so Drop must not touch it.
+        // 9) Install the verified file at `db_path`. Prefer an atomic rename
+        //    (no torn DB on a mid-step crash). If `.partial` and `db_path`
+        //    landed on different filesystems — e.g. the project dir is a bind
+        //    mount or `db_path` is symlinked across a tmpfs boundary — rename
+        //    fails with EXDEV (`CrossesDevices`). Fall back to copy + remove.
+        //    The copy is not atomic, but at this point the bytes are fully
+        //    verified and any live peer was already refused (steps 1 + 7), so
+        //    a non-atomic write is acceptable for this rare cross-FS case.
+        //
+        //    The guard stays armed until install succeeds: if both the rename
+        //    and the copy fail, Drop wipes `.partial` so we don't leak a
+        //    half-installed file.
+        if let Err(rename_err) = std::fs::rename(&partial, db_path) {
+            if is_cross_device_error(&rename_err) {
+                std::fs::copy(&partial, db_path).with_context(|| {
+                    format!(
+                        "cross-filesystem install (copy {} → {})",
+                        partial.display(),
+                        db_path.display()
+                    )
+                })?;
+                let _ = std::fs::remove_file(&partial);
+            } else {
+                return Err(rename_err).with_context(|| {
+                    format!("install {} → {}", partial.display(), db_path.display())
+                });
+            }
+        }
+        // Installed — the file now lives at `db_path`, not `.partial`.
         guard.disarm();
-        std::fs::rename(&partial, db_path)
-            .with_context(|| format!("install {} → {}", partial.display(), db_path.display()))?;
 
         let size = std::fs::metadata(db_path)?.len();
         if json {

--- a/crates/cartog/src/commands/remote.rs
+++ b/crates/cartog/src/commands/remote.rs
@@ -1,0 +1,785 @@
+//! Opt-in S3-compatible index sync (`cartog push` / `cartog pull`).
+//!
+//! Compiled under the `remote-s3` feature, ON by default. Users who want a
+//! minimal binary disable it with `--no-default-features --features lsp`.
+//!
+//! Credentials come exclusively from the AWS environment chain (env vars,
+//! profile, IMDS). `.cartog.toml` `[remote]` rejects credential-shaped keys
+//! at parse time — see `crate::config::RemoteConfig`.
+
+use anyhow::{bail, Result};
+use std::path::Path;
+
+use crate::config::CartogConfig;
+#[cfg(feature = "remote-s3")]
+use crate::config::RemoteConfig;
+
+// -----------------------------------------------------------------------------
+// Helpers shared by push/pull/doctor — only compiled with the feature on.
+// -----------------------------------------------------------------------------
+
+#[cfg(feature = "remote-s3")]
+use anyhow::{anyhow, Context};
+
+#[cfg(feature = "remote-s3")]
+const META_SHA256: &str = "sha256";
+#[cfg(feature = "remote-s3")]
+const META_SCHEMA_VERSION: &str = "schema-version";
+#[cfg(feature = "remote-s3")]
+const META_CARTOG_VERSION: &str = "cartog-version";
+
+/// Parse an `s3://bucket/key` URL into `(bucket, key)`.
+///
+/// Both segments are required and non-empty. Anything else (missing scheme,
+/// missing key, trailing slash with no key, embedded credentials) is rejected
+/// with a clear error message — we never want to silently push to a bucket-
+/// root key or fall back to a guessed default.
+#[cfg(feature = "remote-s3")]
+pub fn parse_s3_url(url: &str) -> Result<(String, String)> {
+    let rest = url
+        .strip_prefix("s3://")
+        .ok_or_else(|| anyhow!("remote URL must start with `s3://` (got {url:?})"))?;
+
+    if rest.contains('@') {
+        bail!("remote URL must not embed credentials; use the AWS env/profile chain");
+    }
+
+    let (bucket, key) = rest
+        .split_once('/')
+        .ok_or_else(|| anyhow!("remote URL must include an object key (got {url:?})"))?;
+
+    if bucket.is_empty() {
+        bail!("remote URL has empty bucket name");
+    }
+    if key.is_empty() {
+        bail!("remote URL has empty object key");
+    }
+    Ok((bucket.to_string(), key.to_string()))
+}
+
+/// Stream a file through SHA-256 in fixed-size chunks. Used on push (over the
+/// DB) and on pull (over the freshly downloaded `.partial` file) to verify
+/// the round-trip without loading the whole file into memory — the index can
+/// be hundreds of MB on large repos.
+#[cfg(feature = "remote-s3")]
+pub fn sha256_file(path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("open {} for hashing", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .with_context(|| format!("read {} for hashing", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex_encode(&hasher.finalize()))
+}
+
+/// Lower-case hex encoding without pulling the `hex` crate into the
+/// minimal-features build. SHA-256 hashes are 32 bytes → 64 hex chars; the
+/// allocation is bounded.
+#[cfg(feature = "remote-s3")]
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(&mut s, "{b:02x}");
+    }
+    s
+}
+
+/// Resolve the effective `s3://...` URL: CLI override wins over config.
+#[cfg(feature = "remote-s3")]
+fn resolve_remote_url(
+    remote_cfg: Option<&RemoteConfig>,
+    cli_override: Option<&str>,
+) -> Result<String> {
+    if let Some(u) = cli_override {
+        return Ok(u.to_string());
+    }
+    let from_cfg = remote_cfg.and_then(|r| r.url.as_deref());
+    from_cfg
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("no remote configured: pass --remote s3://bucket/key or set [remote].url in .cartog.toml"))
+}
+
+#[cfg(feature = "remote-s3")]
+mod imp {
+    use super::*;
+    use cartog_db::{checkpoint_wal, read_schema_version_at, CURRENT_SCHEMA_VERSION};
+    use cartog_process_lock::find_active_locks;
+    use s3::bucket::Bucket;
+    use s3::creds::Credentials;
+    use s3::region::Region;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    /// RAII guard for the `.partial` download file.
+    ///
+    /// Deletes the file on Drop unless [`PartialGuard::disarm`] is called.
+    /// This makes cleanup bulletproof across every fail path in pull —
+    /// network errors, checksum mismatch, schema-version refusal, panic in
+    /// the tokio runtime — without each branch having to remember to call
+    /// `remove_file`. Disarm is called exactly once: right before the
+    /// atomic rename that promotes `.partial` to the real DB.
+    struct PartialGuard {
+        path: PathBuf,
+        armed: bool,
+    }
+
+    impl PartialGuard {
+        fn new(path: PathBuf) -> Self {
+            Self { path, armed: true }
+        }
+        fn disarm(mut self) {
+            self.armed = false;
+        }
+    }
+
+    impl Drop for PartialGuard {
+        fn drop(&mut self) {
+            if self.armed && self.path.exists() {
+                let _ = std::fs::remove_file(&self.path);
+            }
+        }
+    }
+
+    /// Build an S3 [`Bucket`] from cartog's [`RemoteConfig`] + a parsed
+    /// `(bucket, key)` plus the anonymous flag.
+    ///
+    /// Region / endpoint / path-style come from `[remote]`; credentials come
+    /// from the AWS env chain (or anonymous when `no_sign_request`).
+    pub(super) fn build_bucket(
+        bucket_name: &str,
+        remote_cfg: Option<&RemoteConfig>,
+        no_sign_request: bool,
+    ) -> Result<Box<Bucket>> {
+        let region = match (
+            remote_cfg.and_then(|r| r.region.clone()),
+            remote_cfg.and_then(|r| r.endpoint.clone()),
+        ) {
+            (Some(region), Some(endpoint)) => Region::Custom { region, endpoint },
+            (Some(region), None) => region
+                .parse::<Region>()
+                .with_context(|| format!("invalid AWS region {region:?}"))?,
+            (None, Some(endpoint)) => Region::Custom {
+                region: "us-east-1".to_string(),
+                endpoint,
+            },
+            // Fall back to the AWS env/profile region. rust-s3's parse will
+            // raise a descriptive error if nothing resolves.
+            (None, None) => std::env::var("AWS_REGION")
+                .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+                .ok()
+                .and_then(|r| r.parse::<Region>().ok())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "no AWS region resolvable: set [remote].region in .cartog.toml \
+                         or AWS_REGION in the environment"
+                    )
+                })?,
+        };
+
+        let creds = if no_sign_request {
+            Credentials::anonymous().context("build anonymous creds")?
+        } else {
+            // Walks the AWS chain: env → profile → IMDS.
+            Credentials::default().context(
+                "resolve AWS credentials (env/profile/IMDS) — pass --no-sign-request for anonymous access",
+            )?
+        };
+
+        let mut bucket =
+            Bucket::new(bucket_name, region, creds).context("construct S3 bucket client")?;
+
+        // `path_style` resolution:
+        //  - Explicit user setting always wins (`Some(true)` or `Some(false)`).
+        //  - Otherwise: auto-enable when `endpoint` points at a NON-AWS host.
+        //    MinIO, Cloudflare R2, and floci all require path-style and the
+        //    failure mode without it is a cryptic DNS error against
+        //    `<bucket>.<endpoint>`. Real AWS endpoints (FIPS, accelerate,
+        //    dualstack, VPC interface) are virtual-hosted and would break
+        //    under path-style — those must NOT be flipped automatically.
+        //  - If neither `path_style` nor `endpoint` is set: virtual-hosted
+        //    (the AWS default).
+        let path_style = remote_cfg
+            .and_then(|r| r.path_style)
+            .unwrap_or_else(|| match remote_cfg.and_then(|r| r.endpoint.as_deref()) {
+                Some(ep) => !is_aws_endpoint(ep),
+                None => false,
+            });
+        if path_style {
+            bucket = bucket.with_path_style();
+        }
+        Ok(bucket)
+    }
+
+    /// Returns true if the endpoint URL points at an AWS-operated S3 host.
+    /// Matches `*.amazonaws.com` and `*.amazonaws.com.cn` (China partition);
+    /// also matches GovCloud (`s3-fips.*.amazonaws.com`) since it's a
+    /// subdomain of `amazonaws.com`. Case-insensitive.
+    ///
+    /// Deliberately narrow: we only need to keep `path_style` OFF when the
+    /// user explicitly points at an AWS-managed endpoint. Anything else
+    /// (MinIO, R2, floci, on-prem) defaults to path-style.
+    pub(super) fn is_aws_endpoint(endpoint: &str) -> bool {
+        // Lower-case first so the scheme-strip is case-insensitive.
+        let lower = endpoint.to_ascii_lowercase();
+        let host = lower
+            .strip_prefix("https://")
+            .or_else(|| lower.strip_prefix("http://"))
+            .unwrap_or(&lower)
+            .split('/')
+            .next()
+            .unwrap_or("")
+            .split(':')
+            .next()
+            .unwrap_or("")
+            // Trailing-dot FQDNs (`s3.amazonaws.com.`) are valid DNS but
+            // would slip past the suffix check below. Normalize them away
+            // before matching.
+            .trim_end_matches('.');
+        host.ends_with(".amazonaws.com") || host.ends_with(".amazonaws.com.cn")
+    }
+
+    /// Resolve the per-DB state dir + slots that `cartog serve` / `cartog watch`
+    /// would acquire. Used to refuse a push or pull while a peer is using the DB.
+    fn peers_for_db(db_path: &Path) -> Vec<String> {
+        let dir = match crate::state::default_state_dir() {
+            Some(d) => d,
+            None => return vec![],
+        };
+        let serve_slot = crate::state::slot_for_db("serve", db_path);
+        let watch_slot = crate::state::slot_for_db("watch", db_path);
+        find_active_locks(&dir)
+            .into_iter()
+            .filter(|l| l.slot == serve_slot || l.slot == watch_slot)
+            .map(|l| format!("{} (pid {})", l.slot, l.pid))
+            .collect()
+    }
+
+    pub(super) fn push_index(
+        db_path: &Path,
+        remote_cfg: Option<&RemoteConfig>,
+        cli_override: Option<&str>,
+        json: bool,
+    ) -> Result<()> {
+        let url = resolve_remote_url(remote_cfg, cli_override)?;
+        let (bucket_name, key) = parse_s3_url(&url)?;
+
+        // 1) Refuse push while a peer is writing.
+        let peers = peers_for_db(db_path);
+        if !peers.is_empty() {
+            bail!(
+                "cannot push: peer cartog process is using this DB ({}). \
+                 Stop it (or accept stale push) before retrying.",
+                peers.join(", ")
+            );
+        }
+
+        if !db_path.exists() {
+            bail!(
+                "no local DB at {} — run `cartog index` first",
+                db_path.display()
+            );
+        }
+
+        // 2) Truncate WAL so the file is self-contained.
+        checkpoint_wal(db_path)
+            .with_context(|| format!("checkpoint WAL on {}", db_path.display()))?;
+
+        // 3) Hash + schema lookup.
+        let sha = sha256_file(db_path)?;
+        let schema = read_schema_version_at(db_path)
+            .with_context(|| format!("read schema_version from {}", db_path.display()))?;
+        let size = std::fs::metadata(db_path)?.len();
+
+        // 4) Async upload via a small tokio current-thread runtime — keep the
+        //    rest of cartog sync.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build tokio runtime")?;
+
+        rt.block_on(async {
+            let mut bucket = build_bucket(&bucket_name, remote_cfg, false)?;
+
+            bucket.add_header(&format!("x-amz-meta-{META_SHA256}"), &sha);
+            bucket.add_header(
+                &format!("x-amz-meta-{META_SCHEMA_VERSION}"),
+                &schema.to_string(),
+            );
+            bucket.add_header(
+                &format!("x-amz-meta-{META_CARTOG_VERSION}"),
+                env!("CARGO_PKG_VERSION"),
+            );
+
+            let mut file = tokio::fs::File::open(db_path)
+                .await
+                .with_context(|| format!("open {}", db_path.display()))?;
+            let resp = bucket
+                .put_object_stream_with_content_type(&mut file, &key, "application/octet-stream")
+                .await
+                .context("S3 upload failed")?;
+            if !(200..300).contains(&resp.status_code()) {
+                bail!("S3 upload returned HTTP {}", resp.status_code());
+            }
+            Ok::<_, anyhow::Error>(())
+        })?;
+
+        if json {
+            println!(
+                r#"{{"bucket":"{bucket_name}","key":"{key}","size":{size},"sha256":"{sha}","schema_version":{schema}}}"#
+            );
+        } else {
+            println!(
+                "pushed {}/{key} ({} bytes, sha256={}…, schema=v{schema})",
+                bucket_name,
+                size,
+                &sha[..8]
+            );
+        }
+        Ok(())
+    }
+
+    pub(super) fn pull_index(
+        db_path: &Path,
+        remote_cfg: Option<&RemoteConfig>,
+        cli_override: Option<&str>,
+        force: bool,
+        no_sign_request: bool,
+        json: bool,
+    ) -> Result<()> {
+        let url = resolve_remote_url(remote_cfg, cli_override)?;
+        let (bucket_name, key) = parse_s3_url(&url)?;
+
+        // 1) Refuse to overwrite a live DB unless --force.
+        let peers = peers_for_db(db_path);
+        if !peers.is_empty() && !force {
+            bail!(
+                "cannot pull: peer cartog process is using this DB ({}). \
+                 Stop it or pass --force to overwrite anyway.",
+                peers.join(", ")
+            );
+        }
+
+        // 2) Ensure the parent dir exists for the .partial file.
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let partial: PathBuf = {
+            let mut p = db_path.as_os_str().to_owned();
+            p.push(".partial");
+            PathBuf::from(p)
+        };
+        // Clean any leftover .partial from a prior failed pull.
+        if partial.exists() {
+            std::fs::remove_file(&partial)
+                .with_context(|| format!("remove stale {}", partial.display()))?;
+        }
+        // RAII guard: deletes .partial on any error path until disarmed
+        // just before the atomic rename.
+        let guard = PartialGuard::new(partial.clone());
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build tokio runtime")?;
+
+        let (expected_sha, schema_meta): (Option<String>, Option<u32>) = rt.block_on(async {
+            let bucket = build_bucket(&bucket_name, remote_cfg, no_sign_request)?;
+
+            // 3) Stream-download to .partial.
+            let mut out = tokio::fs::File::create(&partial)
+                .await
+                .with_context(|| format!("create {}", partial.display()))?;
+            let status = bucket
+                .get_object_to_writer(&key, &mut out)
+                .await
+                .context("S3 download failed")?;
+            if !(200..300).contains(&status) {
+                bail!("S3 download returned HTTP {status}");
+            }
+
+            // 4) HEAD to read metadata (sha256 + schema_version).
+            let (head, code) = bucket
+                .head_object(&key)
+                .await
+                .context("S3 head_object failed")?;
+            if !(200..300).contains(&code) {
+                bail!("S3 head_object returned HTTP {code}");
+            }
+            let md: HashMap<String, String> = head.metadata.unwrap_or_default();
+            let sha = md.get(META_SHA256).cloned();
+            let schema = md
+                .get(META_SCHEMA_VERSION)
+                .and_then(|s| s.parse::<u32>().ok());
+            Ok::<_, anyhow::Error>((sha, schema))
+        })?;
+
+        // 5) Verify SHA-256 against object metadata.
+        let actual_sha = sha256_file(&partial)?;
+        match expected_sha.as_deref() {
+            Some(want) if want == actual_sha => { /* OK */ }
+            Some(want) => {
+                // guard's Drop wipes .partial.
+                bail!(
+                    "SHA-256 mismatch on pulled object: expected {want}, got {actual_sha}. \
+                     Local file discarded."
+                );
+            }
+            None => {
+                // No checksum metadata at all → treat as untrusted. We don't
+                // assume the DB is good; refuse rather than silently install.
+                bail!(
+                    "remote object has no `x-amz-meta-{META_SHA256}` header — refusing to install \
+                     an unverified DB. Re-push with a recent cartog version."
+                );
+            }
+        }
+
+        // 6) Schema-version guards. We need to distinguish three failure
+        //    modes that previously collapsed into a single
+        //    `read_schema_version_at(...).unwrap_or(0)` call:
+        //
+        //   a) `Err(_)` — genuine SQLite / I/O error reading the file. The
+        //      object passed sha256 verification but rusqlite still can't
+        //      open it (truncation, permission denied, corrupted SQLite
+        //      header). Surface the underlying error verbatim; do NOT
+        //      pretend it's a "not a cartog database" issue.
+        //   b) `Ok(0)` — file opens as SQLite but the cartog `metadata`
+        //      table or `schema_version` row is missing. That's either an
+        //      unrelated app's DB or a corrupted/truncated upload. Refuse.
+        //   c) `Ok(v)` with `v > CURRENT_SCHEMA_VERSION` — a future cartog
+        //      pushed it. Refuse with an actionable message.
+        //
+        //    `schema_meta` (the header) is also required: it's the only
+        //    signal that can't be tampered with by mismatching header vs
+        //    body (the sha256 binds them). A missing header is treated as
+        //    a refusal to make downgrade attacks via header-stripping
+        //    impossible.
+        let pulled_schema = read_schema_version_at(&partial)
+            .with_context(|| format!("read schema_version from pulled {}", partial.display()))?;
+        if pulled_schema == 0 {
+            bail!(
+                "pulled object is not a cartog database (no `schema_version` row). \
+                 Refusing to install; the bucket may contain an unrelated SQLite file or \
+                 a corrupted upload."
+            );
+        }
+        let claimed_schema = schema_meta.ok_or_else(|| {
+            anyhow!(
+                "remote object has no `x-amz-meta-{META_SCHEMA_VERSION}` header — refusing to \
+                 install. Re-push with a recent cartog version so the header is set."
+            )
+        })?;
+        if pulled_schema != claimed_schema {
+            bail!(
+                "schema-version mismatch: object metadata claims v{claimed_schema} but the \
+                 file's `schema_version` row says v{pulled_schema}. Refusing to install — \
+                 this usually means a partial / corrupted upload, or that someone edited \
+                 the S3 object metadata by hand. Re-push from a healthy cartog run."
+            );
+        }
+        if pulled_schema > CURRENT_SCHEMA_VERSION {
+            bail!(
+                "pulled DB has schema v{pulled_schema} but this cartog only supports up to \
+                 v{CURRENT_SCHEMA_VERSION}. Upgrade cartog before pulling — the remote was \
+                 pushed by a newer cartog."
+            );
+        }
+
+        // 7) Re-check for peers right before the rename window. The
+        //    download above can take many seconds; a `cartog serve` /
+        //    `cartog watch` that started during that window now holds an
+        //    open SQLite handle to the file we're about to swap. This
+        //    re-check closes most of that window but NOT all of it: a
+        //    peer that wins the PID-lock election in the few syscalls
+        //    between this check and the rename at the end of step 9 can
+        //    still race us. The genuine fix is an exclusive file lock
+        //    held for the duration of the pull, deferred to a follow-up.
+        //    `--force` continues to bypass, matching the step-1 check.
+        let peers_now = peers_for_db(db_path);
+        if !peers_now.is_empty() && !force {
+            // Honest about what we know vs what we hope: the partial file
+            // is dropped (RAII guard still armed at this point), the
+            // existing local DB at `db_path` is untouched, and WAL/SHM
+            // siblings have not been unlinked yet.
+            bail!(
+                "cannot pull: a peer cartog process started while downloading \
+                 ({}). Local DB and its WAL siblings are untouched; the partial \
+                 download will be discarded.",
+                peers_now.join(", ")
+            );
+        }
+
+        // 8) Remove stale WAL/SHM siblings — leaving them would cause SQLite
+        //    to replay phantom frames into the freshly-pulled DB.
+        for ext in ["-wal", "-shm"] {
+            let mut sibling = db_path.as_os_str().to_owned();
+            sibling.push(ext);
+            let sibling = PathBuf::from(sibling);
+            if sibling.exists() {
+                std::fs::remove_file(&sibling)
+                    .with_context(|| format!("remove stale {}", sibling.display()))?;
+            }
+        }
+
+        // 9) Atomic rename — no torn DB on a mid-step crash. Disarm the
+        //    guard immediately before rename: after this point the file
+        //    lives at `db_path`, not `.partial`, so Drop must not touch it.
+        guard.disarm();
+        std::fs::rename(&partial, db_path)
+            .with_context(|| format!("install {} → {}", partial.display(), db_path.display()))?;
+
+        let size = std::fs::metadata(db_path)?.len();
+        if json {
+            println!(
+                r#"{{"bucket":"{bucket_name}","key":"{key}","size":{size},"sha256":"{actual_sha}","schema_version":{pulled_schema}}}"#
+            );
+        } else {
+            println!(
+                "pulled {}/{key} → {} ({} bytes, sha256={}…, schema=v{pulled_schema})",
+                bucket_name,
+                db_path.display(),
+                size,
+                &actual_sha[..8]
+            );
+        }
+        Ok(())
+    }
+
+    /// Doctor-mode reachability check: HEAD the configured bucket and report.
+    pub(super) fn check_remote_reachable(remote_cfg: &RemoteConfig) -> Result<()> {
+        let url = remote_cfg
+            .url
+            .as_deref()
+            .ok_or_else(|| anyhow!("[remote].url is not set"))?;
+        let (bucket_name, key) = parse_s3_url(url)?;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        rt.block_on(async {
+            let bucket = build_bucket(&bucket_name, Some(remote_cfg), false)?;
+            // Use HEAD on the configured key. A 404 there still proves the
+            // bucket + creds work; we treat it as "reachable, object absent".
+            match bucket.head_object(&key).await {
+                Ok((_, code)) if (200..300).contains(&code) => Ok(()),
+                Ok((_, 404)) => Ok(()),
+                Ok((_, code)) => bail!("HEAD returned HTTP {code}"),
+                Err(e) => Err(anyhow!("S3 unreachable: {e}")),
+            }
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Feature-gated public surface
+// -----------------------------------------------------------------------------
+
+#[cfg(feature = "remote-s3")]
+pub fn push_index(
+    db_path: &Path,
+    config: &CartogConfig,
+    cli_override: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    imp::push_index(db_path, config.remote.as_ref(), cli_override, json)
+}
+
+#[cfg(feature = "remote-s3")]
+pub fn pull_index(
+    db_path: &Path,
+    config: &CartogConfig,
+    cli_override: Option<&str>,
+    force: bool,
+    no_sign_request: bool,
+    json: bool,
+) -> Result<()> {
+    imp::pull_index(
+        db_path,
+        config.remote.as_ref(),
+        cli_override,
+        force,
+        no_sign_request,
+        json,
+    )
+}
+
+#[cfg(feature = "remote-s3")]
+pub fn check_remote_reachable(remote: &RemoteConfig) -> Result<()> {
+    imp::check_remote_reachable(remote)
+}
+
+#[cfg(not(feature = "remote-s3"))]
+pub fn push_index(
+    _db_path: &Path,
+    _config: &CartogConfig,
+    _cli_override: Option<&str>,
+    _json: bool,
+) -> Result<()> {
+    bail!(
+        "cartog was built without the `remote-s3` feature. \
+         Reinstall with `cargo install cartog` (default) or `--features remote-s3`."
+    )
+}
+
+#[cfg(not(feature = "remote-s3"))]
+pub fn pull_index(
+    _db_path: &Path,
+    _config: &CartogConfig,
+    _cli_override: Option<&str>,
+    _force: bool,
+    _no_sign_request: bool,
+    _json: bool,
+) -> Result<()> {
+    bail!(
+        "cartog was built without the `remote-s3` feature. \
+         Reinstall with `cargo install cartog` (default) or `--features remote-s3`."
+    )
+}
+
+// `check_remote_reachable` is intentionally absent in the minimal build:
+// `commands::check_remote` short-circuits to an Error result instead of
+// calling into S3 plumbing that isn't compiled in.
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(all(test, feature = "remote-s3"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_s3_url_accepts_simple() {
+        let (b, k) = parse_s3_url("s3://my-bucket/cartog/main").unwrap();
+        assert_eq!(b, "my-bucket");
+        assert_eq!(k, "cartog/main");
+    }
+
+    #[test]
+    fn parse_s3_url_accepts_nested_key() {
+        let (b, k) = parse_s3_url("s3://b/a/b/c.sqlite").unwrap();
+        assert_eq!(b, "b");
+        assert_eq!(k, "a/b/c.sqlite");
+    }
+
+    #[test]
+    fn parse_s3_url_rejects_missing_scheme() {
+        assert!(parse_s3_url("my-bucket/key").is_err());
+        assert!(parse_s3_url("https://bucket/key").is_err());
+    }
+
+    #[test]
+    fn parse_s3_url_rejects_no_key() {
+        assert!(parse_s3_url("s3://my-bucket").is_err());
+        assert!(parse_s3_url("s3://my-bucket/").is_err());
+    }
+
+    #[test]
+    fn parse_s3_url_rejects_empty_bucket() {
+        assert!(parse_s3_url("s3:///key").is_err());
+    }
+
+    #[test]
+    fn parse_s3_url_rejects_embedded_credentials() {
+        // Foreclose URL-shaped credentials masquerading as part of the path.
+        assert!(parse_s3_url("s3://AKIA:secret@bucket/key").is_err());
+    }
+
+    #[test]
+    fn sha256_file_matches_known_fixture() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = dir.path().join("data.bin");
+        // sha256("hello\n") = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+        std::fs::write(&p, "hello\n").unwrap();
+        assert_eq!(
+            sha256_file(&p).unwrap(),
+            "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+        );
+    }
+
+    #[test]
+    fn resolve_remote_url_prefers_cli_override() {
+        let cfg = RemoteConfig {
+            url: Some("s3://from-config/k".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_remote_url(Some(&cfg), Some("s3://from-cli/k")).unwrap(),
+            "s3://from-cli/k"
+        );
+    }
+
+    #[test]
+    fn resolve_remote_url_falls_back_to_config() {
+        let cfg = RemoteConfig {
+            url: Some("s3://from-config/k".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_remote_url(Some(&cfg), None).unwrap(),
+            "s3://from-config/k"
+        );
+    }
+
+    #[test]
+    fn resolve_remote_url_errors_without_any_source() {
+        assert!(resolve_remote_url(None, None).is_err());
+    }
+
+    // ---- is_aws_endpoint --------------------------------------------------
+
+    #[test]
+    fn is_aws_endpoint_recognises_standard_hosts() {
+        for ep in [
+            "https://s3.us-east-1.amazonaws.com",
+            "https://s3-fips.us-gov-west-1.amazonaws.com",
+            "https://s3.amazonaws.com",
+            "https://s3-accelerate.amazonaws.com",
+            "https://s3.dualstack.us-west-2.amazonaws.com",
+            // China partition.
+            "https://s3.cn-north-1.amazonaws.com.cn",
+            // Trailing path + port are stripped.
+            "https://s3.us-east-1.amazonaws.com:443/v1",
+            // Case-insensitive.
+            "HTTPS://S3.US-EAST-1.AMAZONAWS.COM",
+            // Trailing-dot FQDN (valid DNS, parsers retain it).
+            "https://s3.us-east-1.amazonaws.com.",
+            "https://s3.amazonaws.com.:443",
+        ] {
+            assert!(imp::is_aws_endpoint(ep), "should match AWS endpoint: {ep}");
+        }
+    }
+
+    #[test]
+    fn is_aws_endpoint_rejects_non_aws_hosts() {
+        for ep in [
+            "https://minio.local",
+            "https://play.min.io",
+            "http://localhost:9000",
+            "https://r2.cloudflarestorage.com",
+            "https://<account>.r2.cloudflarestorage.com",
+            "https://amazonaws.com.evil.example.com",
+            // Bare `amazonaws.com` without the leading dot is suspicious;
+            // the suffix check requires `.amazonaws.com` to avoid the
+            // typosquat above.
+            "https://amazonaws.com",
+        ] {
+            assert!(
+                !imp::is_aws_endpoint(ep),
+                "should NOT match as AWS endpoint: {ep}"
+            );
+        }
+    }
+}

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -344,7 +344,22 @@ fn local_config_path() -> Option<PathBuf> {
 }
 
 fn read_config(path: &Path) -> Option<CartogConfig> {
-    let text = std::fs::read_to_string(path).ok()?;
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        // NotFound is the only IO error we treat as "no config", silently.
+        // The normal caller (`local_config_path`) only hands us paths that
+        // exist; this branch covers races where the file disappears between
+        // `exists()` and `read_to_string`, and unit tests that probe missing
+        // paths directly. Permission denied, EIO, EACCES, etc. should be
+        // loud — silently swallowing them turned into a "no remote
+        // configured" downstream error with no hint that the user's file
+        // was just unreadable.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            eprintln!("cartog: error reading {}: {e}", path.display());
+            return None;
+        }
+    };
 
     // Security pre-check: scan the raw `[remote]` table for credential-shaped
     // keys before they have a chance to be deserialised or logged anywhere.

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -15,6 +15,90 @@ pub struct CartogConfig {
     pub embedding: Option<EmbeddingConfig>,
     pub reranker: Option<RerankerConfig>,
     pub rag: Option<RagConfig>,
+    pub remote: Option<RemoteConfig>,
+}
+
+/// Optional S3-compatible remote for `cartog push` / `cartog pull`.
+///
+/// Credentials are resolved exclusively from the AWS environment chain (env
+/// vars, profile, IMDS). Storing any credential-shaped key here (`access_key`,
+/// `secret_key`, `credentials`, `token`, `aws_*`) is rejected at parse time —
+/// see [`RemoteConfig::validate_no_credentials`].
+///
+/// ```toml
+/// [remote]
+/// url        = "s3://my-team-bucket/cartog/main"
+/// region     = "us-east-1"
+/// endpoint   = "https://minio.example.com"   # MinIO / R2 / floci
+/// path_style = true                          # required for MinIO / floci
+/// ```
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+// `region`, `endpoint`, and `path_style` are unused in minimal builds (no
+// `remote-s3` feature). They still must be parsed and rejected on unknown
+// keys, so the struct itself stays defined — but the fields would warn as
+// unused. Silence that warning for the minimal build only.
+#[cfg_attr(not(feature = "remote-s3"), allow(dead_code))]
+pub struct RemoteConfig {
+    /// Default `s3://bucket/key` target. `--remote` on push/pull overrides.
+    pub url: Option<String>,
+    /// AWS region (e.g. `us-east-1`). Optional when `endpoint` is set.
+    pub region: Option<String>,
+    /// Custom endpoint URL for S3-compatible stores (MinIO, R2, floci).
+    pub endpoint: Option<String>,
+    /// Force path-style addressing (required for most non-AWS endpoints).
+    pub path_style: Option<bool>,
+}
+
+const CREDENTIAL_KEY_PREFIXES: &[&str] = &["aws_", "access_", "secret_"];
+const CREDENTIAL_KEYS: &[&str] = &[
+    "access_key",
+    "secret_key",
+    "credentials",
+    "token",
+    "session_token",
+    "password",
+];
+
+/// Recursively inspect the raw `[remote]` table for credential-shaped keys.
+///
+/// `RemoteConfig` already has `deny_unknown_fields`, but that's coincidental
+/// coverage that would silently regress the moment we accept a sub-table
+/// (e.g. a future `[remote.headers]`). This walk is the real security
+/// boundary: it traverses nested tables and arrays so `[remote.aws]
+/// access_key = "..."` is rejected with the same actionable error as a
+/// flat `[remote] access_key = "..."`.
+///
+/// Returned error contains a dotted path (e.g. `[remote].aws.access_key`)
+/// so the user knows which line to delete.
+fn validate_remote_no_credentials(table: &toml::value::Table) -> Result<(), String> {
+    fn walk(prefix: &str, val: &toml::Value) -> Result<(), String> {
+        match val {
+            toml::Value::Table(t) => {
+                for (k, v) in t {
+                    let lower = k.to_lowercase();
+                    if CREDENTIAL_KEYS.iter().any(|ck| lower == *ck)
+                        || CREDENTIAL_KEY_PREFIXES.iter().any(|p| lower.starts_with(p))
+                    {
+                        return Err(format!(
+                            "{prefix}.{k} looks like a credential — cartog does not read \
+                             credentials from .cartog.toml. Use the AWS environment chain \
+                             instead (AWS_ACCESS_KEY_ID / AWS_PROFILE / IMDS)."
+                        ));
+                    }
+                    walk(&format!("{prefix}.{k}"), v)?;
+                }
+            }
+            toml::Value::Array(arr) => {
+                for (i, v) in arr.iter().enumerate() {
+                    walk(&format!("{prefix}[{i}]"), v)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    walk("[remote]", &toml::Value::Table(table.clone()))
 }
 
 /// Tuning knobs for the hybrid search pipeline.
@@ -171,15 +255,71 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
     }
 }
 
-/// Load the local project config from `.cartog.toml`.
-/// Returns the parsed config and the path it was loaded from (if any).
-pub fn load_config() -> (CartogConfig, Option<PathBuf>) {
+/// Outcome of [`load_config`]. Distinguishes three states the caller may need
+/// to react to differently:
+///
+/// - **`Loaded { config, path }`** — `.cartog.toml` parsed successfully.
+/// - **`Missing`** — no config file was found anywhere on the walk-up to
+///   git root; caller proceeds with defaults silently.
+/// - **`Rejected { path }`** — a config file was found but rejected (parse
+///   error, security pre-check, or `deny_unknown_fields` violation).
+///   `read_config` already printed the underlying reason to stderr. Callers
+///   that read `[remote]` (push/pull/doctor) must NOT silently fall back to
+///   defaults here, or the user's security-error message would be drowned
+///   by a misleading downstream "no remote configured" error.
+// `Loaded` carries the full `CartogConfig` (~344 B) while the other variants
+// are tiny. We accept the size disparity rather than box the payload: every
+// real call site moves the config back onto the stack immediately, so a
+// `Box` would just add one heap alloc + memcpy per invocation for no
+// benefit. The lint is correct in general; not correct here.
+#[allow(clippy::large_enum_variant)]
+pub enum ConfigLoad {
+    Loaded { config: CartogConfig, path: PathBuf },
+    Missing,
+    Rejected { path: PathBuf },
+}
+
+impl ConfigLoad {
+    /// Convenience: the parsed config when present, or a fresh default
+    /// otherwise. Use for commands that don't care about distinguishing
+    /// missing-vs-rejected (most read-only commands).
+    pub fn config_or_default(self) -> CartogConfig {
+        match self {
+            ConfigLoad::Loaded { config, .. } => config,
+            _ => CartogConfig::default(),
+        }
+    }
+
+    /// The path the config was loaded from (or attempted to load from when
+    /// `Rejected`). Used by `cartog doctor` and `cartog config` to display
+    /// the file under inspection.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            ConfigLoad::Loaded { path, .. } | ConfigLoad::Rejected { path } => Some(path),
+            ConfigLoad::Missing => None,
+        }
+    }
+
+    /// True when a `.cartog.toml` was found but failed validation. Callers
+    /// that depend on `[remote]` (push, pull, doctor, config) use this to
+    /// distinguish "no config" from "broken config" and surface a clear
+    /// rejection rather than silently falling back to defaults.
+    pub fn is_rejected(&self) -> bool {
+        matches!(self, ConfigLoad::Rejected { .. })
+    }
+}
+
+/// Load the local project config from `.cartog.toml`. See [`ConfigLoad`]
+/// for the three possible outcomes; existing commands that don't care
+/// about the rejected-vs-missing distinction can wrap this with
+/// [`ConfigLoad::config_or_default`].
+pub fn load_config() -> ConfigLoad {
     match local_config_path() {
         Some(p) => match read_config(&p) {
-            Some(cfg) => (cfg, Some(p)),
-            None => (CartogConfig::default(), None),
+            Some(config) => ConfigLoad::Loaded { config, path: p },
+            None => ConfigLoad::Rejected { path: p },
         },
-        None => (CartogConfig::default(), None),
+        None => ConfigLoad::Missing,
     }
 }
 
@@ -205,6 +345,18 @@ fn local_config_path() -> Option<PathBuf> {
 
 fn read_config(path: &Path) -> Option<CartogConfig> {
     let text = std::fs::read_to_string(path).ok()?;
+
+    // Security pre-check: scan the raw `[remote]` table for credential-shaped
+    // keys before they have a chance to be deserialised or logged anywhere.
+    if let Ok(raw) = toml::from_str::<toml::value::Table>(&text) {
+        if let Some(toml::Value::Table(remote)) = raw.get("remote") {
+            if let Err(msg) = validate_remote_no_credentials(remote) {
+                eprintln!("cartog: error in {}: {msg}", path.display());
+                return None;
+            }
+        }
+    }
+
     match toml::from_str::<CartogConfig>(&text) {
         Ok(cfg) => Some(cfg),
         Err(e) => {
@@ -357,6 +509,133 @@ mod tests {
         fs::write(&cfg_path, "").unwrap();
         let cfg = read_config(&cfg_path).expect("empty toml is valid");
         assert!(cfg.database.is_none());
+    }
+
+    #[test]
+    fn test_remote_config_valid_minimal() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join(".cartog.toml");
+        fs::write(
+            &cfg_path,
+            r#"[remote]
+url = "s3://team-bucket/cartog/main"
+region = "us-east-1"
+"#,
+        )
+        .unwrap();
+        let cfg = read_config(&cfg_path).expect("should parse");
+        let remote = cfg.remote.expect("remote section parsed");
+        assert_eq!(remote.url.as_deref(), Some("s3://team-bucket/cartog/main"));
+        assert_eq!(remote.region.as_deref(), Some("us-east-1"));
+        assert_eq!(remote.path_style, None);
+    }
+
+    #[test]
+    fn test_remote_config_full_minio_shape() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join(".cartog.toml");
+        fs::write(
+            &cfg_path,
+            r#"[remote]
+url = "s3://b/k"
+region = "us-east-1"
+endpoint = "https://minio.local"
+path_style = true
+"#,
+        )
+        .unwrap();
+        let cfg = read_config(&cfg_path).expect("should parse");
+        let r = cfg.remote.unwrap();
+        assert_eq!(r.endpoint.as_deref(), Some("https://minio.local"));
+        assert_eq!(r.path_style, Some(true));
+    }
+
+    /// `deny_unknown_fields` plus the credential pre-check together guarantee
+    /// no rogue key sneaks through. This test exercises each named credential
+    /// key and the `aws_*` prefix.
+    #[test]
+    fn test_remote_config_rejects_credential_keys() {
+        for bad in [
+            "access_key = \"AKIA...\"",
+            "secret_key = \"...\"",
+            "credentials = \"...\"",
+            "token = \"...\"",
+            "session_token = \"...\"",
+            "password = \"...\"",
+            "aws_access_key_id = \"...\"",
+            "AWS_SECRET = \"...\"",
+        ] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let cfg_path = dir.path().join(".cartog.toml");
+            fs::write(&cfg_path, format!("[remote]\nurl = \"s3://b/k\"\n{bad}\n")).unwrap();
+            assert!(
+                read_config(&cfg_path).is_none(),
+                "should reject credential key: {bad}"
+            );
+        }
+    }
+
+    /// Credentials hidden one level deeper in `[remote.aws]` / `[remote.creds]`
+    /// must not slip past the security pre-check. `deny_unknown_fields` would
+    /// already reject the nested table itself, but the user-visible error
+    /// would say "unknown field `aws`" rather than the security-specific
+    /// message — which is the whole point of having this pre-check.
+    #[test]
+    fn test_remote_config_rejects_nested_credential_keys() {
+        for bad_section in [
+            "[remote.aws]\naccess_key = \"AKIA...\"\n",
+            "[remote.creds]\nsecret_key = \"...\"\n",
+            "[remote.minio]\naws_session_token = \"...\"\n",
+        ] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let cfg_path = dir.path().join(".cartog.toml");
+            fs::write(
+                &cfg_path,
+                format!("[remote]\nurl = \"s3://b/k\"\n{bad_section}"),
+            )
+            .unwrap();
+            assert!(
+                read_config(&cfg_path).is_none(),
+                "should reject nested credential: {bad_section}"
+            );
+        }
+    }
+
+    /// The prefix list (`aws_`, `access_`, `secret_`) is the second arm of the
+    /// detector and only had implicit coverage before this test (the named
+    /// keys mostly happen to match prefixes too). Exercise it directly so a
+    /// future refactor that loses the prefix arm fails loudly.
+    #[test]
+    fn test_remote_config_rejects_credential_prefixes() {
+        for bad in [
+            // Names not in CREDENTIAL_KEYS but caught by prefix.
+            "access_token_v2 = \"...\"",
+            "secret_value = \"...\"",
+            "aws_role_arn = \"...\"",
+        ] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let cfg_path = dir.path().join(".cartog.toml");
+            fs::write(&cfg_path, format!("[remote]\nurl = \"s3://b/k\"\n{bad}\n")).unwrap();
+            assert!(
+                read_config(&cfg_path).is_none(),
+                "should reject prefix-matched credential key: {bad}"
+            );
+        }
+    }
+
+    /// `deny_unknown_fields` should also reject anything else that's not a
+    /// known field — this is a forward-compatibility guard so typos like
+    /// `pathstyle` fail loudly instead of silently doing nothing.
+    #[test]
+    fn test_remote_config_rejects_unknown_field() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join(".cartog.toml");
+        fs::write(
+            &cfg_path,
+            "[remote]\nurl = \"s3://b/k\"\npathstyle = true\n",
+        )
+        .unwrap();
+        assert!(read_config(&cfg_path).is_none());
     }
 
     #[test]

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -357,14 +357,61 @@ fn read_config(path: &Path) -> Option<CartogConfig> {
         }
     }
 
-    match toml::from_str::<CartogConfig>(&text) {
-        Ok(cfg) => Some(cfg),
+    let parsed = match toml::from_str::<CartogConfig>(&text) {
+        Ok(cfg) => cfg,
         Err(e) => {
             // Use eprintln rather than tracing — tracing may not be initialised yet.
             eprintln!("cartog: warning: failed to parse {}: {e}", path.display());
-            None
+            return None;
+        }
+    };
+
+    // Post-parse security check on `[remote].endpoint`. `parse_s3_url` already
+    // refuses `s3://user:pass@bucket/key`, but `endpoint` accepts an arbitrary
+    // URL — a value like `http://AKIA:secret@minio.local` would silently leak
+    // credentials into the underlying S3 client's URL builder, bypassing the
+    // "credentials only via AWS env chain" guarantee. Refuse explicitly.
+    if let Some(remote) = parsed.remote.as_ref() {
+        if let Err(msg) = validate_endpoint(remote.endpoint.as_deref()) {
+            eprintln!("cartog: error in {}: {msg}", path.display());
+            return None;
         }
     }
+
+    Some(parsed)
+}
+
+/// Reject a `[remote].endpoint` value that embeds credentials via the
+/// `user:pass@host` URL form. None / empty endpoint is fine — both mean
+/// "fall back to the default AWS host".
+fn validate_endpoint(endpoint: Option<&str>) -> Result<(), String> {
+    let ep = match endpoint {
+        Some(s) if !s.is_empty() => s,
+        _ => return Ok(()),
+    };
+
+    // Trim the scheme so `s3://user@host` is detected too.
+    let after_scheme = ep.split_once("://").map(|x| x.1).unwrap_or(ep);
+    // Userinfo lives before the first `/` of the path and before any `?` or `#`.
+    let authority = after_scheme
+        .split('/')
+        .next()
+        .unwrap_or(after_scheme)
+        .split('?')
+        .next()
+        .unwrap_or(after_scheme)
+        .split('#')
+        .next()
+        .unwrap_or(after_scheme);
+    if authority.contains('@') {
+        return Err(format!(
+            "[remote].endpoint embeds credentials in its URL ({ep:?}) — cartog \
+             does not accept credentials in config. Move them to the AWS \
+             environment chain (AWS_ACCESS_KEY_ID / AWS_PROFILE / IMDS) and \
+             use a plain endpoint URL."
+        ));
+    }
+    Ok(())
 }
 
 /// Resolve the database path using the following priority:
@@ -636,6 +683,56 @@ path_style = true
         )
         .unwrap();
         assert!(read_config(&cfg_path).is_none());
+    }
+
+    /// `[remote].endpoint` must not embed credentials via the `user:pass@host`
+    /// URL form. `parse_s3_url` rejects this for `url`; the symmetric check
+    /// on `endpoint` closes the matching gap.
+    #[test]
+    fn test_remote_config_rejects_endpoint_with_userinfo() {
+        for bad in [
+            "http://AKIA:secret@minio.local",
+            "https://user@s3.example.com",
+            // No scheme — still parseable as userinfo + host.
+            "AKIA:secret@host:9000",
+            "https://user:pass@host/path",
+        ] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let cfg_path = dir.path().join(".cartog.toml");
+            fs::write(
+                &cfg_path,
+                format!("[remote]\nurl = \"s3://b/k\"\nendpoint = \"{bad}\"\n"),
+            )
+            .unwrap();
+            assert!(
+                read_config(&cfg_path).is_none(),
+                "should reject endpoint with userinfo: {bad}"
+            );
+        }
+    }
+
+    /// Common legitimate endpoint shapes must still parse. Belt-and-braces
+    /// guard against an overly-aggressive `validate_endpoint` regex.
+    #[test]
+    fn test_remote_config_accepts_clean_endpoints() {
+        for ok in [
+            "https://s3.us-east-1.amazonaws.com",
+            "https://minio.example.com:9000",
+            "https://r2.cloudflarestorage.com/path",
+            "http://localhost:4566",
+        ] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let cfg_path = dir.path().join(".cartog.toml");
+            fs::write(
+                &cfg_path,
+                format!("[remote]\nurl = \"s3://b/k\"\nendpoint = \"{ok}\"\n"),
+            )
+            .unwrap();
+            assert!(
+                read_config(&cfg_path).is_some(),
+                "should accept clean endpoint: {ok}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -18,6 +18,20 @@ use cli::{Cli, Command, RagCommand, SelfCommand};
 const DEFAULT_GITHUB_LATEST_URL: &str =
     "https://api.github.com/repos/jrollin/cartog/releases/latest";
 
+/// If `cmd` is a subcommand that depends on a successfully-parsed
+/// `[remote]` (and therefore must not run against a rejected config),
+/// return its short verb for the user-facing error message. Returns
+/// `None` for every other command. Centralising this here keeps the
+/// "list of remote commands" in one place — adding a future
+/// `cartog mirror` only requires extending this match.
+fn remote_command_label(cmd: &Command) -> Option<&'static str> {
+    match cmd {
+        Command::Push { .. } => Some("push"),
+        Command::Pull { .. } => Some("pull"),
+        _ => None,
+    }
+}
+
 /// Long-lived commands (`serve`, `watch`) skip the auto-check — they run
 /// for hours and the user never sees a hint printed at the *start* anyway.
 fn classify_command(cmd: &Command) -> CommandKind {
@@ -67,8 +81,38 @@ fn run_auto_check_epilogue(command_kind: CommandKind) {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Resolve database path: --db / CARTOG_DB > .cartog.toml > git root > cwd
-    let (cartog_config, config_path) = config::load_config();
+    // Resolve database path: --db / CARTOG_DB > .cartog.toml > git root > cwd.
+    //
+    // `config_load` may be `Rejected` when `.cartog.toml` exists but failed
+    // its security pre-check or schema validation. We surface that as a hard
+    // error before dispatching push/pull/doctor — silently falling back to
+    // defaults would mask the user's security-relevant config error with a
+    // downstream "no remote configured" message.
+    let config_load = config::load_config();
+
+    // Refuse commands that depend on a successfully-parsed `[remote]`
+    // (`push`, `pull`) when the config was rejected. Doctor and config
+    // are NOT in this set: they're the commands users run to *diagnose*
+    // a broken config, so they need to keep running — they just receive
+    // a `config_rejected` signal so they can show an explicit "rejected"
+    // status instead of silently reporting defaults.
+    if config_load.is_rejected() {
+        if let Some(verb) = remote_command_label(&cli.command) {
+            anyhow::bail!(
+                "refusing to run `cartog {verb}`: configuration file {} was rejected \
+                 (see earlier stderr for details). Fix the config before retrying.",
+                config_load
+                    .path()
+                    .expect("Rejected variant always has a path")
+                    .display(),
+            );
+        }
+    }
+
+    let config_rejected = config_load.is_rejected();
+    let config_path = config_load.path().map(|p| p.to_path_buf());
+    let cartog_config = config_load.config_or_default();
+
     let db_path = config::resolve_db_path(cli.db.clone(), &cartog_config);
     let provider_config = config::to_provider_config(&cartog_config);
     let embedding_dim = provider_config.resolved_dimension();
@@ -152,12 +196,32 @@ fn main() -> Result<()> {
             commands::cmd_deps(&db_path, &file, cli.json, token_budget, embedding_dim)
         }
         Command::Stats => commands::cmd_stats(&db_path, cli.json, embedding_dim),
-        Command::Config => {
-            commands::cmd_config(&cartog_config, config_path.as_deref(), &db_path, cli.json)
+        Command::Push { remote } => {
+            commands::cmd_push(&db_path, &cartog_config, remote.as_deref(), cli.json)
         }
+        Command::Pull {
+            remote,
+            force,
+            no_sign_request,
+        } => commands::cmd_pull(
+            &db_path,
+            &cartog_config,
+            remote.as_deref(),
+            force,
+            no_sign_request,
+            cli.json,
+        ),
+        Command::Config => commands::cmd_config(
+            &cartog_config,
+            config_path.as_deref(),
+            config_rejected,
+            &db_path,
+            cli.json,
+        ),
         Command::Doctor => commands::cmd_doctor(
             &cartog_config,
             config_path.as_deref(),
+            config_rejected,
             &db_path,
             cli.json,
             embedding_dim,

--- a/crates/cartog/tests/remote_integration.rs
+++ b/crates/cartog/tests/remote_integration.rs
@@ -924,3 +924,103 @@ fn pull_refuses_header_vs_file_mismatch() {
     );
     assert!(!dst_db.exists(), "destination must not be created");
 }
+
+/// A non-numeric `x-amz-meta-schema-version` header (corruption, or a
+/// hand-edit in the S3 console) must be reported as a *malformed* header,
+/// not masquerade as a *missing* one. The earlier `.parse().ok()` collapsed
+/// both into None and sent users to the wrong fix ("re-push").
+#[test]
+fn pull_reports_malformed_schema_version_header() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-bad-schema-header");
+
+    let work = tempfile::TempDir::new().unwrap();
+    let repo = work.path().join("repo");
+    let src_db = work.path().join("src.sqlite");
+    build_minimal_index(&repo, &src_db);
+
+    // Hash the real DB so the sha check passes and we reach the schema-header
+    // parse. The header value is deliberately not a u32.
+    use sha2::{Digest, Sha256};
+    let bytes = std::fs::read(&src_db).unwrap();
+    let mut h = Sha256::new();
+    h.update(&bytes);
+    let sha = h
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    let st = Command::new("aws")
+        .args([
+            "--endpoint-url",
+            &endpoint,
+            "s3",
+            "cp",
+            &src_db.to_string_lossy(),
+            "s3://cartog-bad-schema-header/index.sqlite",
+            "--metadata",
+            &format!("sha256={sha},schema-version=notanumber"),
+        ])
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .status()
+        .unwrap();
+    assert!(st.success(), "aws s3 cp failed");
+
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://cartog-bad-schema-header/index.sqlite"
+region = "us-east-1"
+endpoint = "{endpoint}"
+path_style = true
+"#
+        ),
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "pull with malformed schema-version header must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // The new message names it as malformed; it must NOT claim the header is
+    // missing (the old, misleading behavior).
+    assert!(
+        stderr.contains("malformed"),
+        "expected 'malformed' refusal, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("has no"),
+        "must not report a present-but-bad header as missing: {stderr}"
+    );
+    assert!(!dst_db.exists(), "destination must not be created");
+}

--- a/crates/cartog/tests/remote_integration.rs
+++ b/crates/cartog/tests/remote_integration.rs
@@ -692,3 +692,186 @@ endpoint = "{endpoint}"
         std::fs::read(&dst_db).unwrap()
     );
 }
+
+/// Helper: tampered upload setup. Builds a real cartog DB, mutates its
+/// `schema_version` row to `file_v`, re-hashes, and uploads with the given
+/// `header_v` metadata + a matching sha (so the integrity check passes and
+/// pull reaches the schema-version logic). Returns the working directory
+/// the caller should use as `current_dir` for `cartog pull`.
+fn upload_with_schema_version(
+    floci_endpoint: &str,
+    bucket: &str,
+    key: &str,
+    file_v: u32,
+    header_v: u32,
+) -> tempfile::TempDir {
+    let work = tempfile::TempDir::new().unwrap();
+    let repo = work.path().join("repo");
+    let src_db = work.path().join("src.sqlite");
+    build_minimal_index(&repo, &src_db);
+
+    // Mutate the schema_version row directly. This requires the DB to have
+    // no live writers, which is true because build_minimal_index finishes
+    // before this runs.
+    {
+        let conn = rusqlite::Connection::open(&src_db).unwrap();
+        conn.execute(
+            "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
+            [&file_v.to_string()],
+        )
+        .unwrap();
+    }
+
+    // Recompute sha256 of the mutated file so the header matches the body.
+    use sha2::{Digest, Sha256};
+    let bytes = std::fs::read(&src_db).unwrap();
+    let mut h = Sha256::new();
+    h.update(&bytes);
+    let sha = h
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    let st = Command::new("aws")
+        .args([
+            "--endpoint-url",
+            floci_endpoint,
+            "s3",
+            "cp",
+            &src_db.to_string_lossy(),
+            &format!("s3://{bucket}/{key}"),
+            "--metadata",
+            &format!("sha256={sha},schema-version={header_v},cartog-version=test"),
+        ])
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .status()
+        .unwrap();
+    assert!(st.success(), "aws s3 cp failed");
+
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://{bucket}/{key}"
+region = "us-east-1"
+endpoint = "{floci_endpoint}"
+path_style = true
+"#
+        ),
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    work
+}
+
+/// A DB whose `schema_version` row is greater than this cartog supports must
+/// be refused with the "upgrade cartog" message — even when the metadata
+/// header agrees (so the cross-check arm doesn't fire first).
+#[test]
+fn pull_refuses_future_schema_version() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-future");
+
+    // Pick a version that's plausibly future (current is 4 today; pick
+    // CURRENT + a wide margin so this test stays valid as the schema
+    // evolves without forcing test updates on every migration).
+    let future_v = cartog::db::CURRENT_SCHEMA_VERSION + 100;
+    let work = upload_with_schema_version(
+        &endpoint,
+        "cartog-future",
+        "index.sqlite",
+        future_v,
+        future_v,
+    );
+    let cfg_dir = work.path().join("cfg");
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "pull of a future-version DB must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Upgrade cartog") || stderr.contains("supports up to"),
+        "expected future-version refusal, got: {stderr}"
+    );
+    assert!(!dst_db.exists(), "destination must not be created");
+}
+
+/// When the object's `x-amz-meta-schema-version` header disagrees with the
+/// file's `schema_version` row, pull must refuse. This catches partial
+/// uploads and hand-edited S3 metadata. The fix in round 2 made both signals
+/// required and cross-checked; this test pins the behavior so a future
+/// patch can't quietly drop one of them.
+#[test]
+fn pull_refuses_header_vs_file_mismatch() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-version-skew");
+
+    // File says v4 (or whatever CURRENT is), header lies and says v3.
+    let work = upload_with_schema_version(
+        &endpoint,
+        "cartog-version-skew",
+        "index.sqlite",
+        cartog::db::CURRENT_SCHEMA_VERSION,
+        cartog::db::CURRENT_SCHEMA_VERSION.saturating_sub(1).max(1),
+    );
+    let cfg_dir = work.path().join("cfg");
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "pull with header/file schema mismatch must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("schema-version mismatch"),
+        "expected mismatch refusal, got: {stderr}"
+    );
+    assert!(!dst_db.exists(), "destination must not be created");
+}

--- a/crates/cartog/tests/remote_integration.rs
+++ b/crates/cartog/tests/remote_integration.rs
@@ -62,15 +62,38 @@ impl FlociContainer {
             return None;
         }
 
+        // From this point on, the container is running. Every early return
+        // path must kill it explicitly — `--rm` only fires on container exit,
+        // and a leaked container ties up a host port until the test process
+        // dies. A scope-guard would be tidier but adds a helper struct just
+        // for this 60-line function; an inline `kill` macro keeps it local.
+        macro_rules! abort {
+            () => {{
+                let _ = Command::new("docker")
+                    .args(["kill", &name])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status();
+                return None;
+            }};
+        }
+
         // Discover host port via `docker port`.
-        let out = Command::new("docker")
+        let out = match Command::new("docker")
             .args(["port", &name, FLOCI_PORT_INSIDE])
             .output()
-            .ok()?;
+        {
+            Ok(o) => o,
+            Err(_) => abort!(),
+        };
         let stdout = String::from_utf8_lossy(&out.stdout);
-        let port: u16 = stdout
+        let port: u16 = match stdout
             .lines()
-            .find_map(|l| l.rsplit(':').next()?.trim().parse().ok())?;
+            .find_map(|l| l.rsplit(':').next()?.trim().parse().ok())
+        {
+            Some(p) => p,
+            None => abort!(),
+        };
 
         // Wait for floci's HTTP listener.
         let endpoint = format!("http://localhost:{port}");
@@ -90,8 +113,7 @@ impl FlociContainer {
             }
             if Instant::now() > deadline {
                 // Container is up but listener never replied — kill and bail.
-                let _ = Command::new("docker").args(["kill", &name]).status();
-                return None;
+                abort!();
             }
             std::thread::sleep(Duration::from_millis(100));
         }
@@ -498,10 +520,11 @@ fn pull_refuses_non_cartog_sqlite_with_valid_sha() {
 
     // Upload with sha256 + schema-version headers. Both are now required
     // by pull, so we set both to reach the "schema_version row missing in
-    // the file" code path. The `schema-version=4` value (today's
-    // CURRENT_SCHEMA_VERSION) is what the file *claims* to be; the in-
-    // file row is missing entirely (this is not a cartog DB), so the
-    // mismatch check fires too — either one is a valid refusal reason.
+    // the file" code path. The header claims the current schema version
+    // (referenced from the crate constant so this test doesn't break on a
+    // schema bump); the in-file row is missing entirely (this is not a
+    // cartog DB), so the "not a cartog database" check fires.
+    let claimed_v = cartog::db::CURRENT_SCHEMA_VERSION;
     let st = Command::new("aws")
         .args([
             "--endpoint-url",
@@ -511,7 +534,7 @@ fn pull_refuses_non_cartog_sqlite_with_valid_sha() {
             &foreign_db.to_string_lossy(),
             "s3://cartog-foreign-sqlite/index.sqlite",
             "--metadata",
-            &format!("sha256={sha},schema-version=4"),
+            &format!("sha256={sha},schema-version={claimed_v}"),
         ])
         .env("AWS_ACCESS_KEY_ID", "test")
         .env("AWS_SECRET_ACCESS_KEY", "test")

--- a/crates/cartog/tests/remote_integration.rs
+++ b/crates/cartog/tests/remote_integration.rs
@@ -1,0 +1,694 @@
+//! Integration tests for `cartog push` / `cartog pull` against a floci
+//! (AWS-local-emulator) container.
+//!
+//! These tests boot a fresh floci container per test (random port), exercise
+//! the push/pull round-trip, and tear the container down on Drop. They are
+//! gated on:
+//!
+//! 1. the `remote-s3` feature being built in (the default), AND
+//! 2. `docker` + `aws` (AWS CLI) being available on `PATH` —
+//!    otherwise the tests print SKIP and return early.
+//!
+//! The AWS CLI is used only to create the bucket; `rust-s3`'s create-bucket
+//! request shape does not satisfy floci's parser, but every other operation
+//! (PUT/GET/HEAD) round-trips fine. In production cartog never creates
+//! buckets; users provision them via their cloud console or IaC.
+
+#![cfg(all(unix, feature = "remote-s3"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const FLOCI_IMAGE: &str = "floci/floci";
+const FLOCI_PORT_INSIDE: &str = "4566";
+
+/// Boots a floci container on a random host port. On Drop, the container is
+/// killed. The container starts in <100 ms once the image is cached; we wait
+/// up to ~5 s for the HTTP listener to come up.
+struct FlociContainer {
+    name: String,
+    port: u16,
+}
+
+impl FlociContainer {
+    fn start() -> Option<Self> {
+        // Use a unique container name per test invocation to avoid collisions
+        // across parallel test runs.
+        let name = format!(
+            "cartog-floci-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let status = Command::new("docker")
+            .args([
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                &name,
+                "-p",
+                &format!("0:{FLOCI_PORT_INSIDE}"),
+                FLOCI_IMAGE,
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+
+        // Discover host port via `docker port`.
+        let out = Command::new("docker")
+            .args(["port", &name, FLOCI_PORT_INSIDE])
+            .output()
+            .ok()?;
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let port: u16 = stdout
+            .lines()
+            .find_map(|l| l.rsplit(':').next()?.trim().parse().ok())?;
+
+        // Wait for floci's HTTP listener.
+        let endpoint = format!("http://localhost:{port}");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            // Use `aws s3 ls` against the endpoint as the readiness probe.
+            let probe = Command::new("aws")
+                .args(["--endpoint-url", &endpoint, "s3", "ls"])
+                .env("AWS_ACCESS_KEY_ID", "test")
+                .env("AWS_SECRET_ACCESS_KEY", "test")
+                .env("AWS_DEFAULT_REGION", "us-east-1")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            if matches!(probe, Ok(s) if s.success()) {
+                break;
+            }
+            if Instant::now() > deadline {
+                // Container is up but listener never replied — kill and bail.
+                let _ = Command::new("docker").args(["kill", &name]).status();
+                return None;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        Some(Self { name, port })
+    }
+
+    fn endpoint(&self) -> String {
+        format!("http://localhost:{}", self.port)
+    }
+}
+
+impl Drop for FlociContainer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["kill", &self.name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+/// Returns `Some(path)` if `name` is on PATH, else `None`.
+fn which(name: &str) -> Option<PathBuf> {
+    Command::new("which")
+        .arg(name)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| PathBuf::from(s.trim()))
+}
+
+/// Returns true (with a SKIP message printed) when an external dep is missing.
+/// Tests should `return` early if this returns true.
+fn skip_unless_deps_present() -> bool {
+    for tool in ["docker", "aws"] {
+        if which(tool).is_none() {
+            eprintln!("SKIP: `{tool}` not on PATH");
+            return true;
+        }
+    }
+    false
+}
+
+fn create_bucket(endpoint: &str, bucket: &str) {
+    let st = Command::new("aws")
+        .args([
+            "--endpoint-url",
+            endpoint,
+            "s3",
+            "mb",
+            &format!("s3://{bucket}"),
+        ])
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run aws s3 mb");
+    assert!(st.success(), "aws s3 mb failed");
+}
+
+/// Build a minimal real cartog DB by running `cartog index` on a small
+/// throwaway repo. We don't fabricate SQLite files from scratch — push/pull
+/// must work against actual cartog-produced DBs.
+fn build_minimal_index(repo_dir: &Path, db_path: &Path) {
+    std::fs::create_dir_all(repo_dir).unwrap();
+    std::fs::write(repo_dir.join("hello.py"), "def greet():\n    return 'hi'\n").unwrap();
+    // git init so cartog detects a repo root.
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(repo_dir)
+        .status();
+
+    let st = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args([
+            "--db",
+            &db_path.to_string_lossy(),
+            "index",
+            "--no-lsp",
+            &repo_dir.to_string_lossy(),
+        ])
+        .env_remove("CARTOG_DB")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("spawn cartog index");
+    assert!(st.success(), "cartog index failed");
+    assert!(
+        db_path.exists(),
+        "DB was not created at {}",
+        db_path.display()
+    );
+}
+
+#[test]
+fn push_pull_roundtrip_against_floci() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-roundtrip");
+
+    let work = tempfile::TempDir::new().unwrap();
+    let repo = work.path().join("repo");
+    let src_db = work.path().join("src.sqlite");
+    let dst_db = work.path().join("dst.sqlite");
+    build_minimal_index(&repo, &src_db);
+
+    let src_bytes = std::fs::read(&src_db).unwrap();
+
+    let env = &[
+        ("AWS_ACCESS_KEY_ID", "test"),
+        ("AWS_SECRET_ACCESS_KEY", "test"),
+        ("AWS_DEFAULT_REGION", "us-east-1"),
+    ];
+
+    // cartog needs `[remote].endpoint` to talk to floci; the CLI has no
+    // `--endpoint` flag (and shouldn't — endpoint is per-deployment config,
+    // not per-invocation). Generate a throwaway `.cartog.toml` and run
+    // cartog from that directory so it walks up and finds it.
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://cartog-roundtrip/index.sqlite"
+region = "us-east-1"
+endpoint = "{endpoint}"
+path_style = true
+"#
+        ),
+    )
+    .unwrap();
+    // Make cfg_dir a git root so cartog walks up and finds the config.
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &src_db.to_string_lossy(), "push"])
+        .current_dir(&cfg_dir)
+        .envs(env.iter().copied())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "push failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Independently of the round-trip test, assert that push wrote the
+    // three headers pull now mandates. If push silently stopped emitting
+    // them (or used different names), the round-trip would *still pass*
+    // because pull would just produce a clean failure that the test only
+    // detects via the assertion below — but no other test catches a
+    // future regression where the metadata names drift apart.
+    let head = Command::new("aws")
+        .args([
+            "--endpoint-url",
+            &endpoint,
+            "s3api",
+            "head-object",
+            "--bucket",
+            "cartog-roundtrip",
+            "--key",
+            "index.sqlite",
+        ])
+        .envs(env.iter().copied())
+        .output()
+        .unwrap();
+    assert!(head.status.success(), "head-object failed: {:?}", head);
+    let head_json = String::from_utf8_lossy(&head.stdout);
+    for header in ["sha256", "schema-version", "cartog-version"] {
+        // AWS CLI flattens x-amz-meta-foo into Metadata.{foo} in JSON.
+        // Just substring-match — the field name itself is the contract.
+        assert!(
+            head_json.contains(&format!("\"{header}\":")),
+            "push did not set x-amz-meta-{header}; full head-object output:\n{head_json}"
+        );
+    }
+
+    // Pull into a fresh dst_db.
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .envs(env.iter().copied())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pull failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let dst_bytes = std::fs::read(&dst_db).unwrap();
+    assert_eq!(src_bytes, dst_bytes, "round-tripped DB differs from source");
+}
+
+#[test]
+fn pull_refuses_on_checksum_mismatch() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-corrupt");
+
+    let work = tempfile::TempDir::new().unwrap();
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://cartog-corrupt/index.sqlite"
+region = "us-east-1"
+endpoint = "{endpoint}"
+path_style = true
+"#
+        ),
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    // Upload an object with NO x-amz-meta-sha256 — pull must refuse.
+    let payload_path = work.path().join("payload");
+    std::fs::write(&payload_path, b"not really a sqlite file").unwrap();
+    let st = Command::new("aws")
+        .args([
+            "--endpoint-url",
+            &endpoint,
+            "s3",
+            "cp",
+            &payload_path.to_string_lossy(),
+            "s3://cartog-corrupt/index.sqlite",
+        ])
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .status()
+        .unwrap();
+    assert!(st.success());
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "pull must fail on missing checksum");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("sha256") || stderr.contains("checksum"),
+        "expected checksum error, got: {stderr}"
+    );
+
+    // No file may remain at the destination.
+    assert!(
+        !dst_db.exists(),
+        "destination DB must be absent after failed pull"
+    );
+    let partial = work.path().join("dst.sqlite.partial");
+    assert!(!partial.exists(), "partial file must be cleaned up");
+}
+
+#[test]
+fn anonymous_pull_on_missing_object_fails_cleanly() {
+    // Exercises the `--no-sign-request` code path against a bucket that
+    // exists but is empty. The contract: pull must fail (non-zero exit) and
+    // must not leave behind a destination DB or a `.partial`. The previous
+    // version of this test asserted only the cleanup half; this one also
+    // asserts the failure half so a silent-success regression is caught.
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-anon");
+
+    let work = tempfile::TempDir::new().unwrap();
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://cartog-anon/missing-object.sqlite"
+region = "us-east-1"
+endpoint = "{endpoint}"
+path_style = true
+"#
+        ),
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args([
+            "--db",
+            &dst_db.to_string_lossy(),
+            "pull",
+            "--no-sign-request",
+        ])
+        .current_dir(&cfg_dir)
+        .env_remove("AWS_ACCESS_KEY_ID")
+        .env_remove("AWS_SECRET_ACCESS_KEY")
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "anonymous pull of a non-existent object must fail:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !dst_db.exists(),
+        "destination DB must not exist after a failed pull"
+    );
+    let partial = work.path().join("dst.sqlite.partial");
+    assert!(
+        !partial.exists(),
+        "partial file must be cleaned up after a failed pull"
+    );
+}
+
+/// Pulling an arbitrary SQLite file that has no cartog `metadata` table must
+/// be refused even when the sha256 metadata matches the bytes — otherwise an
+/// unrelated app's database (or a corrupted upload) could overwrite the
+/// local cartog DB and break subsequent commands in confusing ways.
+#[test]
+fn pull_refuses_non_cartog_sqlite_with_valid_sha() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-foreign-sqlite");
+
+    let work = tempfile::TempDir::new().unwrap();
+
+    // Build a real SQLite file that is NOT a cartog DB.
+    let foreign_db = work.path().join("foreign.sqlite");
+    {
+        let conn = rusqlite::Connection::open(&foreign_db).unwrap();
+        conn.execute("CREATE TABLE notes(content TEXT)", [])
+            .unwrap();
+        conn.execute("INSERT INTO notes VALUES ('hello')", [])
+            .unwrap();
+    }
+    let bytes = std::fs::read(&foreign_db).unwrap();
+    // Compute the matching sha256 so we attest the bytes correctly — the
+    // guard must still refuse this on schema-version grounds.
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(&bytes);
+    let sha = h
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    // Upload with sha256 + schema-version headers. Both are now required
+    // by pull, so we set both to reach the "schema_version row missing in
+    // the file" code path. The `schema-version=4` value (today's
+    // CURRENT_SCHEMA_VERSION) is what the file *claims* to be; the in-
+    // file row is missing entirely (this is not a cartog DB), so the
+    // mismatch check fires too — either one is a valid refusal reason.
+    let st = Command::new("aws")
+        .args([
+            "--endpoint-url",
+            &endpoint,
+            "s3",
+            "cp",
+            &foreign_db.to_string_lossy(),
+            "s3://cartog-foreign-sqlite/index.sqlite",
+            "--metadata",
+            &format!("sha256={sha},schema-version=4"),
+        ])
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .status()
+        .unwrap();
+    assert!(st.success(), "aws s3 cp failed");
+
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://cartog-foreign-sqlite/index.sqlite"
+region = "us-east-1"
+endpoint = "{endpoint}"
+path_style = true
+"#
+        ),
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_DEFAULT_REGION", "us-east-1")
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "pull of a non-cartog SQLite file must fail even with a matching sha256"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not a cartog database"),
+        "expected 'not a cartog database' refusal, got: {stderr}"
+    );
+    assert!(!dst_db.exists(), "destination must not be created");
+    let partial = work.path().join("dst.sqlite.partial");
+    assert!(!partial.exists(), "partial file must be cleaned up");
+}
+
+/// `cartog push` / `cartog pull` must refuse to run when `.cartog.toml`
+/// exists but was rejected (credential pre-check, parse error, unknown
+/// field). Without this guard, the security error printed at config-load
+/// time would scroll off and the user would see a misleading "no remote
+/// configured" downstream error. No docker required — the rejection
+/// happens before any S3 call.
+#[test]
+fn push_refuses_when_config_was_rejected() {
+    let work = tempfile::TempDir::new().unwrap();
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    // A credential-shaped key gets the config rejected by the security
+    // pre-check. The exact rejection reason doesn't matter for this test
+    // — any cause that makes load_config return `Rejected` would do.
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        "[remote]\nurl = \"s3://b/k\"\naccess_key = \"AKIA...\"\n",
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    let db_path = work.path().join("db.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &db_path.to_string_lossy(), "push"])
+        .current_dir(&cfg_dir)
+        .env_remove("CARTOG_DB")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "push must fail when config was rejected"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("configuration file") && stderr.contains("was rejected"),
+        "expected explicit config-rejected error, got: {stderr}"
+    );
+    // The security error from config load should also be visible.
+    assert!(
+        stderr.contains("credential"),
+        "expected the underlying security reason to be surfaced, got: {stderr}"
+    );
+}
+
+/// Exercises the `path_style` auto-default. floci is a non-AWS endpoint, so
+/// omitting `path_style` from `.cartog.toml` MUST still produce a working
+/// pull (the implementation infers path-style from the non-AWS host). The
+/// pre-patch code defaulted to virtual-host style and would have failed with
+/// a DNS lookup against `<bucket>.localhost`.
+#[test]
+fn pull_without_explicit_path_style_uses_path_style_against_floci() {
+    if skip_unless_deps_present() {
+        return;
+    }
+    let floci = match FlociContainer::start() {
+        Some(f) => f,
+        None => {
+            eprintln!("SKIP: could not start floci container");
+            return;
+        }
+    };
+    let endpoint = floci.endpoint();
+    create_bucket(&endpoint, "cartog-default-pathstyle");
+
+    let work = tempfile::TempDir::new().unwrap();
+    let repo = work.path().join("repo");
+    let src_db = work.path().join("src.sqlite");
+    build_minimal_index(&repo, &src_db);
+
+    // Note the deliberate ABSENCE of `path_style = true` here — the auto-
+    // default must infer it from the non-AWS endpoint.
+    let cfg_dir = work.path().join("cfg");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    std::fs::write(
+        cfg_dir.join(".cartog.toml"),
+        format!(
+            r#"[remote]
+url = "s3://cartog-default-pathstyle/index.sqlite"
+region = "us-east-1"
+endpoint = "{endpoint}"
+"#
+        ),
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&cfg_dir)
+        .status();
+
+    let env = [
+        ("AWS_ACCESS_KEY_ID", "test"),
+        ("AWS_SECRET_ACCESS_KEY", "test"),
+        ("AWS_DEFAULT_REGION", "us-east-1"),
+    ];
+
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &src_db.to_string_lossy(), "push"])
+        .current_dir(&cfg_dir)
+        .envs(env.iter().copied())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "push without explicit path_style failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let dst_db = work.path().join("dst.sqlite");
+    let out = Command::new(env!("CARGO_BIN_EXE_cartog"))
+        .args(["--db", &dst_db.to_string_lossy(), "pull"])
+        .current_dir(&cfg_dir)
+        .envs(env.iter().copied())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pull without explicit path_style failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        std::fs::read(&src_db).unwrap(),
+        std::fs::read(&dst_db).unwrap()
+    );
+}

--- a/crates/cartog/tests/remote_integration.rs
+++ b/crates/cartog/tests/remote_integration.rs
@@ -498,14 +498,40 @@ fn pull_refuses_non_cartog_sqlite_with_valid_sha() {
     let work = tempfile::TempDir::new().unwrap();
 
     // Build a real SQLite file that is NOT a cartog DB.
+    //
+    // Force a fully self-contained on-disk image before we read+hash+upload:
+    //   * `journal_mode = DELETE` + `synchronous = FULL` keep all writes in
+    //     the main file (no `-wal`/`-shm` siblings) and fsync on commit.
+    //   * `PRAGMA wal_checkpoint(TRUNCATE)` defensively folds any pre-existing
+    //     WAL pages into the main file (harmless no-op for a fresh DB).
+    //   * `Connection::close()` (not just Drop) returns an error if SQLite
+    //     hasn't fully released the file — surfaces flush races immediately
+    //     instead of letting them race the upload.
+    //
+    // Without these, the file `aws s3 cp` reads can differ from what
+    // `std::fs::read` returned to us — yielding a flaky sha256 mismatch in CI.
     let foreign_db = work.path().join("foreign.sqlite");
     {
         let conn = rusqlite::Connection::open(&foreign_db).unwrap();
-        conn.execute("CREATE TABLE notes(content TEXT)", [])
-            .unwrap();
-        conn.execute("INSERT INTO notes VALUES ('hello')", [])
-            .unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode = DELETE; \
+             PRAGMA synchronous = FULL; \
+             CREATE TABLE notes(content TEXT); \
+             INSERT INTO notes VALUES ('hello'); \
+             PRAGMA wal_checkpoint(TRUNCATE);",
+        )
+        .unwrap();
+        conn.close().expect("close foreign.sqlite cleanly");
     }
+    // Belt-and-braces: ensure the OS page cache is flushed to disk before
+    // we hand the file to `aws s3 cp`. Without this we have observed sha256
+    // mismatches in CI where `aws` read stale bytes that didn't match what
+    // our subsequent `std::fs::read` returned. `fsync` on the file handle
+    // forces a durable write barrier.
+    std::fs::File::open(&foreign_db)
+        .unwrap()
+        .sync_all()
+        .expect("fsync foreign.sqlite");
     let bytes = std::fs::read(&foreign_db).unwrap();
     // Compute the matching sha256 so we attest the bytes correctly — the
     // guard must still refuse this on schema-version grounds.

--- a/docs/product.md
+++ b/docs/product.md
@@ -27,7 +27,7 @@ Measured across 13 scenarios, 5 languages. Best gains on call chain tracing (88%
 
 - **LLM coding agents** — Claude Code, Cursor, Aider, Copilot, or any LLM with bash/MCP access.
 - **Developers** who want fast structural navigation without running a language server.
-- **Privacy-conscious teams** — fully local, no API calls, works in air-gapped environments.
+- **Privacy-conscious teams** — local by default, no API calls, works in air-gapped environments. Opt-in S3-compatible index sync is available for teams that explicitly want to share a prebuilt index (see [usage.md](usage.md#cartog-push---remote-s3-url)).
 
 ## Differentiation
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -25,6 +25,7 @@
 | `reqwest` | HTTP client for remote embedding providers (Ollama) | Optional via `provider-ollama` feature. Uses `blocking` + `rustls-tls` |
 | `sqlite-vec` | Vector similarity search (KNN) in SQLite | `vec0` virtual table, requires integer rowids (bridged via `symbol_embedding_map`) |
 | `criterion` (dev) | Micro-benchmarks | Query latency benchmarks (µs-level) |
+| `rust-s3` 0.35 (`tokio-rustls-tls`) | S3-compatible client for `cartog push` / `cartog pull` | Optional via `remote-s3` feature (default on). Chosen over `aws-sdk-s3` for size (~5 MB vs ~18 MB); supports AWS S3, MinIO, R2, floci |
 
 ## Build Profiles
 
@@ -63,6 +64,7 @@
 | RAG tuning | `[rag]` section in `.cartog.toml` | `retrieval_multiplier`, `retrieval_floor`, `rerank_max`, `rerank_min` control FTS5/vector candidate pool size and cross-encoder cost. See [usage.md](usage.md#configuration) |
 | Workspace | Cargo workspace (10 crates) | Incremental compilation, explicit dependency boundaries, independent crate reuse. See [structure.md](structure.md) for layout and dependency graph |
 | Monorepo | Deferred | Index from CWD, user can `cd` into subproject |
+| Remote index sync | Opt-in S3-compatible push/pull (default-on feature, inert without config) | `remote-s3` feature ON by default — single distributable binary, no rebuild from source for teams. Inert until `[remote]` is set or `--remote` passed: no network traffic, no impact on air-gapped use. Credentials resolved from the AWS env chain only; `.cartog.toml` rejects credential-shaped keys at parse time. `rust-s3` (~5 MB) over `aws-sdk-s3` (~18 MB) for binary size. See [usage.md](usage.md#cartog-push---remote-s3-url) |
 
 ## RAG Pipeline Design
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -25,7 +25,7 @@
 | `reqwest` | HTTP client for remote embedding providers (Ollama) | Optional via `provider-ollama` feature. Uses `blocking` + `rustls-tls` |
 | `sqlite-vec` | Vector similarity search (KNN) in SQLite | `vec0` virtual table, requires integer rowids (bridged via `symbol_embedding_map`) |
 | `criterion` (dev) | Micro-benchmarks | Query latency benchmarks (µs-level) |
-| `rust-s3` 0.35 (`tokio-rustls-tls`) | S3-compatible client for `cartog push` / `cartog pull` | Optional via `remote-s3` feature (default on). Chosen over `aws-sdk-s3` for size (~5 MB vs ~18 MB); supports AWS S3, MinIO, R2, floci |
+| `rust-s3` 0.37 (`tokio-rustls-tls`) | S3-compatible client for `cartog push` / `cartog pull` | Optional via `remote-s3` feature (default on). Chosen over `aws-sdk-s3` for size (~5 MB vs ~18 MB); supports AWS S3, MinIO, R2, floci |
 
 ## Build Profiles
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -298,6 +298,99 @@ Symbols by kind:
   variable: 40
 ```
 
+### `cartog push [--remote <s3-url>]`
+
+Upload the local index DB to S3-compatible storage (AWS S3, MinIO, Cloudflare R2,
+floci). Built in by default (`remote-s3` feature, on); cartog still runs 100%
+local until you configure `[remote]` or pass `--remote`.
+
+```bash
+cartog push                                       # uses [remote].url
+cartog push --remote s3://team-bucket/main.sqlite # explicit override
+```
+
+What it does, in order:
+
+1. Refuses to push while `cartog serve` or `cartog watch` is using the DB.
+2. Runs `PRAGMA wal_checkpoint(TRUNCATE)` so the file is self-contained.
+3. Streams a SHA-256 hash of the DB.
+4. Uploads via multipart with object metadata: `x-amz-meta-sha256`,
+   `x-amz-meta-schema-version`, `x-amz-meta-cartog-version`.
+
+Credentials come from the AWS environment chain (env vars, `~/.aws/credentials`,
+IMDS) — **never from `.cartog.toml`**. Storing a credential-shaped key
+(`access_key`, `secret_key`, `aws_*`, etc.) in `[remote]` fails at config-load
+time with a security error.
+
+### `cartog pull [--remote <s3-url>] [--force] [--no-sign-request]`
+
+Download a prebuilt index from S3-compatible storage. Useful for CI warm-start
+and for sharing a team-wide index instead of every dev rebuilding from zero.
+
+```bash
+cartog pull                              # uses [remote].url
+cartog pull --remote s3://b/k.sqlite     # explicit override
+cartog pull --force                      # overwrite even while peer is using the DB
+cartog pull --no-sign-request            # anonymous (public-bucket) pull
+```
+
+Safety guarantees:
+
+- **Atomic install** — the file is downloaded to `<db>.partial`, verified,
+  then renamed; a mid-pull crash or network failure never leaves a torn DB.
+- **Checksum required** — refuses to install if the remote object has no
+  `x-amz-meta-sha256` metadata. Same for `x-amz-meta-schema-version`.
+- **Non-cartog files refused** — pulling a SQLite file that lacks cartog's
+  schema (e.g. an unrelated app's DB) is refused even when its sha256
+  matches; cartog cross-checks the `schema_version` row against the header.
+- **Schema-version guard** — refuses to install a DB produced by a newer
+  cartog, naming both the pulled and supported versions.
+- **WAL/SHM cleanup** — stale `db-wal` / `db-shm` siblings are deleted
+  before rename to prevent SQLite from replaying phantom WAL frames.
+- **Peer-process check** — best-effort refusal to overwrite the local DB
+  while a `cartog serve` or `cartog watch` is holding it open. cartog
+  checks for peer PID locks twice (at the start of pull and right before
+  the atomic rename), but a peer that wins the lock election in the few
+  syscalls between the second check and the rename can still be corrupted
+  by the swap (SQLite holds the file by inode; the rename divorces its
+  FD from on-disk state). The window is small but non-zero. `--force`
+  bypasses both checks. **Safest practice: stop `cartog serve` /
+  `cartog watch` on the project before pulling, and restart them after.**
+
+> **Trust boundary**: the `x-amz-meta-sha256` header is self-attested by
+> whoever pushed the object — it catches corruption and accidental swaps
+> but not a deliberate malicious push by someone with write access to the
+> bucket. Treat the bucket like a shared filesystem under the same
+> trust assumptions as your team's git remote.
+
+### Configuring `[remote]`
+
+In `.cartog.toml`:
+
+```toml
+[remote]
+url        = "s3://team-bucket/cartog/main.sqlite"
+region     = "us-east-1"
+endpoint   = "https://minio.example.com"   # only for MinIO / R2 / floci
+path_style = true                          # required for most non-AWS endpoints
+```
+
+Only those four keys are accepted. Credential-shaped keys (`access_key`,
+`secret_key`, `aws_*`, `token`, `password`, …) are rejected at parse time —
+configure credentials via the AWS environment chain instead.
+
+### Minimal build (no S3)
+
+Users who want the smallest possible binary, or who run in fully air-gapped
+environments, can disable the S3 feature:
+
+```bash
+cargo install cartog --no-default-features --features lsp
+```
+
+The minimal binary refuses `cartog push` and `cartog pull` with a clear error
+pointing at the reinstall command.
+
 ### `cartog map [--tokens N]`
 
 Token-budget-aware codebase summary — file tree + top symbols ranked by reference count (in-degree centrality).


### PR DESCRIPTION
Closes #45.

## Summary

- Adds **opt-in (default-on)** S3-compatible `cartog push` / `cartog pull` so teams can share a prebuilt index instead of every dev / CI job rebuilding from zero.
- 100% local by default: the feature is inert until `[remote]` is configured in `.cartog.toml` or `--remote s3://…` is passed. Default binary grows from ~52.4 MB to ~53.2 MB.
- Credentials come exclusively from the AWS env/profile/IMDS chain — `.cartog.toml` rejects credential-shaped keys (recursively, including nested tables) with a security-specific error at parse time.

## Behavior

| Command | What it does |
|---|---|
| `cartog push [--remote …]` | WAL checkpoint → stream SHA-256 → multipart upload with `x-amz-meta-{sha256,schema-version,cartog-version}`. |
| `cartog pull [--remote …] [--force] [--no-sign-request]` | Lock check → atomic `.partial` download (RAII guard) → SHA-256 verify against header → schema-version cross-check (header vs file) → delete stale WAL/SHM siblings → atomic rename. |
| `cartog doctor` | Grows a `[remote]` reachability check (HEAD on the bucket). |

### Safety properties enforced on pull

- SHA-256 header **required** (refusal if missing). Same for `schema-version`.
- Pulled file's `schema_version` row must equal the header — catches partial uploads and hand-edited S3 metadata.
- Non-cartog SQLite files refused even when sha256 matches (no `metadata` table = bail).
- Schema-version-too-new refusal names both pulled and supported versions.
- Stale `-wal` / `-shm` siblings unlinked before rename to prevent SQLite from replaying phantom frames.
- Peer-process check (`cartog serve` / `cartog watch`) refuses overwriting a held DB without `--force`. Re-checked immediately before rename to close most of the TOCTOU window. Documented as best-effort, not atomic — `flock` for the whole pull is a follow-up.
- `cartog config` / `cartog doctor` surface a `Rejected` config explicitly instead of silently using defaults, so users diagnosing a broken `[remote]` see the actual error.

### Distribution

- Feature `remote-s3` ON by default. Minimal binary: `cargo install cartog --no-default-features --features lsp` (refuses push/pull with a clear "rebuild with --features" message).
- `path_style` auto-defaults to `true` for non-AWS endpoints (MinIO / R2 / floci); explicit user setting always wins. AWS endpoints (`*.amazonaws.com`, FIPS, accelerate, dualstack, China partition) are detected and excluded from the auto-flip.

## Implementation choices

- `rust-s3 = "0.35"` with `tokio-rustls-tls` chosen over `aws-sdk-s3` for size (+5 MB vs +18 MB).
- Per-call tokio runtime (current-thread) keeps the rest of cartog sync.
- New public surface on `cartog-db`: `CURRENT_SCHEMA_VERSION` const + `read_schema_version_at(path)`.
- New `ConfigLoad { Loaded, Missing, Rejected }` enum so `main` can distinguish "no file" from "file rejected" before dispatching push/pull/doctor/config.

## Tests

- **23 unit tests** (URL parser, streaming SHA-256, `is_aws_endpoint` including trailing-dot/case/China-partition, credential rejection covering named keys + prefixes + nested tables, `RemoteConfig` schema, `ConfigLoad` distinctions, doctor check rows).
- **6 floci-backed integration tests** in `tests/remote_integration.rs`:
  - `push_pull_roundtrip_against_floci` (asserts byte-equal DB + presence of `x-amz-meta-*` headers via `aws s3api head-object`)
  - `pull_refuses_on_checksum_mismatch`
  - `pull_refuses_non_cartog_sqlite_with_valid_sha`
  - `pull_without_explicit_path_style_uses_path_style_against_floci`
  - `anonymous_pull_on_missing_object_fails_cleanly`
  - `push_refuses_when_config_was_rejected`

  All cleanly skip when `docker` / `aws` are absent.
- New CI job `test-remote` runs the integration suite on `ubuntu-latest` with `floci/floci` pre-pulled.

## Three rounds of adversarial code review applied

This branch went through three rounds of contrarian code review during development. 9 of 14 surfaced findings landed in this PR; 5 are tracked as follow-ups (see below).

## Test plan

- [ ] `cargo test --workspace` — pre-existing suite stays green.
- [ ] `cargo test --features remote-s3 --test remote_integration -- --test-threads=1` — needs Docker + AWS CLI; integration tests pass.
- [ ] `cargo build --no-default-features --features lsp` — minimal build still works.
- [ ] `cargo install cartog` (from this branch) → `cartog push --remote s3://…` against a real bucket — round-trips byte-equal.
- [ ] CI `test-remote` job is green on the PR.

## Known follow-ups (not blocking; will be filed as separate issues)

- [ ] Test the `pulled_schema > CURRENT_SCHEMA_VERSION` arm (synthetic future-version DB).
- [ ] Test the schema-version header-vs-file mismatch arm.
- [ ] Validate `[remote].endpoint` for userinfo (`http://AKIA:secret@host`) — currently `parse_s3_url` rejects but `endpoint` doesn't.
- [ ] Out-of-band signing (cosign / minisign) for stronger supply-chain guarantees than self-attested SHA-256 headers.
- [ ] Exclusive `flock` for the entire pull to close the residual peer-process TOCTOU window.
- [ ] Stream-hash during upload to avoid the pre-upload file re-read (~2-5 s saving on a 500 MB DB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cartog push/pull for S3-compatible remote index sync (supports --remote, --force, --no-sign-request).
  * Remote config section with credential-safety checks and endpoint validation.
  * Push/pull now verify SHA‑256 and schema-version metadata before install.

* **Documentation**
  * Clarified “local by default” privacy wording.
  * Added usage and architecture docs for remote index sync.

* **Chores**
  * Integration tests and CI job for remote S3 scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->