### PR TITLE
feat(cli): improve index UX — progress, clear messaging, actionable errors

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -1988,6 +1988,16 @@ impl Database {
         Ok(rows)
     }
 
+    /// True when no symbols have been indexed yet (fresh/empty DB). Cheap —
+    /// a single `EXISTS(SELECT 1 FROM symbols)` that stops at the first row.
+    /// Used by query commands to distinguish "no index yet" from a no-match.
+    pub fn is_empty(&self) -> Result<bool> {
+        let exists: bool =
+            self.conn
+                .query_row("SELECT EXISTS(SELECT 1 FROM symbols)", [], |row| row.get(0))?;
+        Ok(!exists)
+    }
+
     /// Index statistics.
     pub fn stats(&self) -> Result<IndexStats> {
         let num_files: u32 = self
@@ -2930,6 +2940,15 @@ mod tests {
         let outline = db.outline("test.py").unwrap();
         assert_eq!(outline.len(), 1);
         assert_eq!(outline[0].name, "my_func");
+    }
+
+    #[test]
+    fn is_empty_reflects_symbol_presence() {
+        let db = Database::open_memory().unwrap();
+        assert!(db.is_empty().unwrap(), "fresh DB should be empty");
+        db.insert_symbol(&test_symbol("f", SymbolKind::Function, "a.py", 1))
+            .unwrap();
+        assert!(!db.is_empty().unwrap(), "DB with a symbol is not empty");
     }
 
     #[test]

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -154,6 +154,24 @@ pub enum ProgressUpdate {
     /// Phase 3 starting: `total` parsed files about to be written in the
     /// indexing transaction.
     Storing { total: u32 },
+    /// Phase 4 starting: LSP-based edge resolution. Slowest phase on large
+    /// repos and the one most likely to look "stuck", so it gets its own event.
+    ResolvingLsp,
+}
+
+impl ProgressUpdate {
+    /// Lower-case, transport-neutral phase label. The single source of truth
+    /// for phase wording — CLI spinners and the MCP progress forwarder both
+    /// render this (applying their own casing/format), so the strings can't
+    /// drift between crates.
+    pub fn label(&self) -> String {
+        match self {
+            ProgressUpdate::Walking => "scanning files".to_string(),
+            ProgressUpdate::Parsing { total } => format!("parsing {total} files"),
+            ProgressUpdate::Storing { total } => format!("storing {total} files"),
+            ProgressUpdate::ResolvingLsp => "resolving edges with LSP".to_string(),
+        }
+    }
 }
 
 /// Optional progress callback type accepted by [`index_directory`].
@@ -490,6 +508,7 @@ pub fn index_directory(
     // re-querying the LSP repeats work. Use `--force` to retry.
     #[cfg(feature = "lsp")]
     if lsp && !dirty_files.is_empty() {
+        emit(ProgressUpdate::ResolvingLsp);
         let stats = cartog_lsp::lsp_resolve_edges(db, &root, None)?;
         result.edges_lsp_resolved = stats.resolved;
         result.edges_marked_unresolvable = stats.marked_unresolvable;

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -126,7 +126,10 @@ pub fn lsp_resolve_edges(
             if let Err(e) = manager.open_file(language, file_path, &content) {
                 tracing::debug!("didOpen failed for {file_path}: {e:#}");
                 if !manager.is_alive(language) {
-                    tracing::warn!("{language} server died during didOpen");
+                    tracing::warn!(
+                        "{language} LSP server died during didOpen — remaining {language} edges \
+                         resolved via heuristics only. Rerun with --no-lsp to skip LSP entirely."
+                    );
                     server_died = true;
                     break;
                 }
@@ -198,7 +201,10 @@ pub fn lsp_resolve_edges(
                             edge.line
                         );
                         if !manager.is_alive(language) {
-                            tracing::warn!("{language} server died, skipping remaining edges");
+                            tracing::warn!(
+                                "{language} LSP server died — remaining {language} edges resolved \
+                                 via heuristics only. Rerun with --no-lsp to skip LSP entirely."
+                            );
                             server_died = true;
                             break;
                         }

--- a/crates/cartog-mcp/src/progress.rs
+++ b/crates/cartog-mcp/src/progress.rs
@@ -37,19 +37,15 @@ impl Phase {
     pub fn into_message_and_total(self) -> (String, Option<f64>) {
         use cartog_indexer::ProgressUpdate as IxU;
         use cartog_rag::indexer::ProgressUpdate as RgU;
+        // Labels come from `ProgressUpdate::label()` (single source of truth in
+        // cartog-indexer / cartog-rag); only the `total` for the MCP progress
+        // bar is computed here.
         match self {
-            Phase::Indexer(IxU::Walking) => ("walking".into(), None),
-            Phase::Indexer(IxU::Parsing { total }) => {
-                (format!("parsing {total} files"), Some(total as f64))
-            }
-            Phase::Indexer(IxU::Storing { total }) => {
-                (format!("storing {total} files"), Some(total as f64))
-            }
-            Phase::Rag(RgU::Preparing) => ("preparing".into(), None),
-            Phase::Rag(RgU::Embedding { processed, total }) => {
-                (format!("embedding {processed}/{total}"), Some(total as f64))
-            }
-            Phase::Rag(RgU::Storing) => ("storing".into(), None),
+            Phase::Indexer(u @ IxU::Parsing { total }) => (u.label(), Some(total as f64)),
+            Phase::Indexer(u @ IxU::Storing { total }) => (u.label(), Some(total as f64)),
+            Phase::Indexer(u) => (u.label(), None),
+            Phase::Rag(u @ RgU::Embedding { total, .. }) => (u.label(), Some(total as f64)),
+            Phase::Rag(u) => (u.label(), None),
             Phase::Custom(s) => (s.into(), None),
         }
     }
@@ -182,12 +178,19 @@ mod tests {
         assert_eq!(events.len(), 3);
         assert!(events[0].progress < events[1].progress);
         assert!(events[1].progress < events[2].progress);
-        assert_eq!(events[0].message.as_deref(), Some("walking"));
+        assert_eq!(events[0].message.as_deref(), Some("scanning files"));
         assert_eq!(events[1].message.as_deref(), Some("parsing 7 files"));
         assert_eq!(events[2].message.as_deref(), Some("storing 5 files"));
         assert_eq!(events[0].total, None);
         assert_eq!(events[1].total, Some(7.0));
         assert_eq!(events[2].total, Some(5.0));
+    }
+
+    #[test]
+    fn resolving_lsp_phase_maps_to_message() {
+        let (msg, total) = Phase::Indexer(IxU::ResolvingLsp).into_message_and_total();
+        assert_eq!(msg, "resolving edges with LSP");
+        assert_eq!(total, None);
     }
 
     #[tokio::test]
@@ -212,7 +215,7 @@ mod tests {
         assert_eq!(events[0].message.as_deref(), Some("preparing"));
         assert_eq!(events[1].message.as_deref(), Some("embedding 512/1024"));
         assert_eq!(events[1].total, Some(1024.0));
-        assert_eq!(events[2].message.as_deref(), Some("storing"));
+        assert_eq!(events[2].message.as_deref(), Some("storing embeddings"));
     }
 
     #[tokio::test]

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -174,6 +174,20 @@ pub enum ProgressUpdate {
     Storing,
 }
 
+impl ProgressUpdate {
+    /// Lower-case, transport-neutral phase label — single source of truth for
+    /// RAG phase wording shared by CLI spinners and the MCP forwarder.
+    pub fn label(&self) -> String {
+        match self {
+            ProgressUpdate::Preparing => "preparing".to_string(),
+            ProgressUpdate::Embedding { processed, total } => {
+                format!("embedding {processed}/{total}")
+            }
+            ProgressUpdate::Storing => "storing embeddings".to_string(),
+        }
+    }
+}
+
 /// Optional progress callback type accepted by [`index_embeddings`].
 ///
 /// Called synchronously from inside the indexer (never on an async runtime).

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -99,10 +99,21 @@ pub fn create_embedding_provider(
             )?;
             Ok(Box::new(provider))
         }
-        other => anyhow::bail!(
-            "Unknown or disabled embedding provider: '{other}'. Supported: {}",
-            supported_providers()
-        ),
+        other => {
+            // `ollama` is a valid provider name but only compiled in with the
+            // `ollama-embedding` feature; the prebuilt/install.sh binary omits
+            // it. Point the user at the rebuild instead of a bare "unknown".
+            let remediation = if other == "ollama" && !cfg!(feature = "provider-ollama") {
+                " — the ollama provider is not in this build; install with \
+                 `cargo install cartog --features ollama-embedding`"
+            } else {
+                ""
+            };
+            anyhow::bail!(
+                "Unknown or disabled embedding provider: '{other}'. Supported: {}{remediation}",
+                supported_providers()
+            )
+        }
     }
 }
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1,7 +1,7 @@
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -19,43 +19,93 @@ pub mod ide;
 pub mod init;
 pub mod remote;
 
-/// Stderr spinner for long-running CLI commands.
+/// Stderr progress reporter for long-running CLI commands.
 ///
-/// No-op in non-TTY contexts (piped output, CI logs) so logs stay clean.
+/// On a TTY it renders an animated spinner whose label tracks the current
+/// phase. On a non-TTY (the Claude Code SessionStart hook, CI, piped output)
+/// it prints a plain line on each phase change plus a periodic heartbeat, so a
+/// multi-minute first index is never silent. Use [`Spinner::set_phase`] from a
+/// progress callback to update the label/heartbeat.
 struct Spinner {
     stop: Arc<AtomicBool>,
+    phase: Arc<Mutex<String>>,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl Spinner {
     fn start(label: &'static str) -> Option<Self> {
-        if !std::io::stderr().is_terminal() {
+        let is_tty = std::io::stderr().is_terminal();
+        // Non-TTY callers (CI, pipes, scripts capturing stderr) stay silent by
+        // default — only opt in via CARTOG_PROGRESS=1, which the Claude Code
+        // SessionStart hook sets so its long first index isn't a silent wait.
+        if !is_tty && std::env::var_os("CARTOG_PROGRESS").is_none() {
             return None;
         }
         let stop = Arc::new(AtomicBool::new(false));
+        let phase = Arc::new(Mutex::new(label.to_string()));
         let stop_clone = Arc::clone(&stop);
+        let phase_clone = Arc::clone(&phase);
         let handle = std::thread::spawn(move || {
-            const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-            let mut i = 0usize;
-            let start = std::time::Instant::now();
-            while !stop_clone.load(Ordering::Relaxed) {
-                let elapsed = start.elapsed().as_secs();
-                let mut err = std::io::stderr().lock();
-                // \r + clear-to-eol + frame + label + elapsed
-                let _ = write!(err, "\r\x1b[K{} {} ({elapsed}s)", FRAMES[i], label);
-                let _ = err.flush();
-                i = (i + 1) % FRAMES.len();
-                std::thread::sleep(Duration::from_millis(100));
+            if is_tty {
+                Self::run_tty(&stop_clone, &phase_clone);
+            } else {
+                Self::run_plain(&stop_clone, &phase_clone);
             }
-            // Clear the spinner line on exit.
-            let mut err = std::io::stderr().lock();
-            let _ = write!(err, "\r\x1b[K");
-            let _ = err.flush();
         });
         Some(Self {
             stop,
+            phase,
             handle: Some(handle),
         })
+    }
+
+    /// Update the displayed phase. On a non-TTY this prints a new line
+    /// immediately so each phase boundary is visible in the hook log.
+    fn set_phase(&self, phase: impl Into<String>) {
+        if let Ok(mut p) = self.phase.lock() {
+            *p = phase.into();
+        }
+    }
+
+    fn run_tty(stop: &AtomicBool, phase: &Mutex<String>) {
+        const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+        let mut i = 0usize;
+        let start = std::time::Instant::now();
+        while !stop.load(Ordering::Relaxed) {
+            let elapsed = start.elapsed().as_secs();
+            let label = phase.lock().map(|p| p.clone()).unwrap_or_default();
+            let mut err = std::io::stderr().lock();
+            // \r + clear-to-eol + frame + label + elapsed
+            let _ = write!(err, "\r\x1b[K{} {label} ({elapsed}s)", FRAMES[i]);
+            let _ = err.flush();
+            drop(err);
+            i = (i + 1) % FRAMES.len();
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        // Clear the spinner line on exit.
+        let mut err = std::io::stderr().lock();
+        let _ = write!(err, "\r\x1b[K");
+        let _ = err.flush();
+    }
+
+    /// Non-TTY heartbeat: emit a line whenever the phase changes, plus one
+    /// every 5s while a phase is still running, so the hook output is never
+    /// silent for minutes. No carriage returns or escape codes — plain log.
+    fn run_plain(stop: &AtomicBool, phase: &Mutex<String>) {
+        let start = std::time::Instant::now();
+        let mut last_label = String::new();
+        let mut last_emit = std::time::Instant::now();
+        while !stop.load(Ordering::Relaxed) {
+            let label = phase.lock().map(|p| p.clone()).unwrap_or_default();
+            let changed = label != last_label;
+            if changed || last_emit.elapsed() >= Duration::from_secs(5) {
+                let elapsed = start.elapsed().as_secs();
+                eprintln!("  {label}… ({elapsed}s)");
+                last_label = label;
+                last_emit = std::time::Instant::now();
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
     }
 
     fn stop(mut self) {
@@ -72,6 +122,41 @@ impl Drop for Spinner {
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }
+    }
+}
+
+/// Capitalize the first character of a phase label for CLI display. Phase
+/// wording itself is owned by `ProgressUpdate::label()` in the indexer/rag
+/// crates; the spinner only adjusts presentation.
+fn capitalize_phase(label: String) -> String {
+    let mut chars = label.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => label,
+    }
+}
+
+/// Build a progress callback that drives `spinner`'s phase label from a
+/// `label_of` projection. Returns the callback plus the `Arc<Spinner>` the
+/// caller must keep alive for the duration of the work, then pass to
+/// [`stop_spinner`]. Centralizes the Arc lifecycle so the explicit
+/// `Arc::into_inner` stop is reliable (no stray clone keeps the count above 1).
+fn spinner_callback<U>(
+    spinner: &Option<Arc<Spinner>>,
+    label_of: fn(&U) -> String,
+) -> Option<impl Fn(U)> {
+    spinner.as_ref().map(|s| {
+        let s = Arc::clone(s);
+        move |u: U| s.set_phase(capitalize_phase(label_of(&u)))
+    })
+}
+
+/// Stop and join a spinner created via [`Spinner::start`] + `Arc::new`. The
+/// callback built by [`spinner_callback`] must already be dropped so the Arc
+/// strong count is 1 and `Arc::into_inner` succeeds.
+fn stop_spinner(spinner: Option<Arc<Spinner>>) {
+    if let Some(s) = spinner.and_then(Arc::into_inner) {
+        s.stop();
     }
 }
 
@@ -124,6 +209,16 @@ fn output<T: Serialize>(
     Ok(())
 }
 
+/// Hint suffix appended to "no result" messages when the index is empty, so a
+/// fresh user can tell "you haven't indexed yet" from a genuine no-match.
+/// Returns `""` when the index has symbols (the common case).
+fn empty_index_hint(db: &Database) -> &'static str {
+    match db.is_empty() {
+        Ok(true) => " (index is empty — run 'cartog index .' first)",
+        _ => "",
+    }
+}
+
 /// Build or rebuild the code graph index.
 pub fn cmd_index(
     db_path: &Path,
@@ -139,13 +234,32 @@ pub fn cmd_index(
     let spinner = if json {
         None
     } else {
-        Spinner::start("Indexing")
+        Spinner::start("Indexing").map(Arc::new)
     };
-    let result = indexer::index_directory(&db, root, force, lsp, None, None);
-    if let Some(s) = spinner {
-        s.stop();
-    }
+    let cb = spinner_callback(&spinner, indexer::ProgressUpdate::label);
+    let cb_ref: Option<indexer::ProgressCallback<'_>> =
+        cb.as_ref().map(|f| f as &(dyn Fn(_) + Send + Sync));
+    let result = indexer::index_directory(&db, root, force, lsp, cb_ref, None);
+    drop(cb);
+    stop_spinner(spinner);
     let result = result?;
+
+    // No-op run: nothing was added or removed this pass. The delta counters
+    // are all zero, so the standard "0 symbols, 0 edges" line reads like a
+    // failure. Report DB state instead — "up to date" when the index has
+    // content, or "no indexable files" for an empty/unsupported tree.
+    if !json && result.files_indexed == 0 && result.files_removed == 0 {
+        let s = db.stats()?;
+        if s.num_symbols == 0 {
+            println!("No indexable files found under '{path}'.");
+        } else {
+            println!(
+                "Index up to date ({} files, {} symbols unchanged)",
+                s.num_files, s.num_symbols
+            );
+        }
+        return Ok(());
+    }
 
     output(&result, json, None, |r| {
         let lsp_part = if r.edges_lsp_resolved > 0
@@ -203,10 +317,9 @@ pub fn cmd_outline(
     let db = open_db(db_path, embedding_dim)?;
     let symbols = db.outline(file)?;
     let file = file.to_string();
-
     output(&symbols, json, token_budget, |syms| {
         if syms.is_empty() {
-            return format!("No symbols found in {file}\n");
+            return format!("No symbols found in {file}{}\n", empty_index_hint(&db));
         }
         let mut out = String::new();
         for sym in syms {
@@ -244,10 +357,9 @@ pub fn cmd_callees(
     let db = open_db(db_path, embedding_dim)?;
     let edges = db.callees(name)?;
     let name = name.to_string();
-
     output(&edges, json, token_budget, |edges| {
         if edges.is_empty() {
-            return format!("No callees found for '{name}'\n");
+            return format!("No callees found for '{name}'{}\n", empty_index_hint(&db));
         }
         let mut out = String::new();
         for edge in edges {
@@ -288,7 +400,7 @@ pub fn cmd_impact(
 
     output(&items, json, token_budget, |items| {
         if items.is_empty() {
-            return format!("No impact found for '{name}'\n");
+            return format!("No impact found for '{name}'{}\n", empty_index_hint(&db));
         }
         let mut out = String::new();
         for entry in items {
@@ -332,7 +444,10 @@ pub fn cmd_refs(
 
     output(&items, json, token_budget, |items| {
         if items.is_empty() {
-            return format!("No references found for '{name}'\n");
+            return format!(
+                "No references found for '{name}'{}\n",
+                empty_index_hint(&db)
+            );
         }
         let mut out = String::new();
         for entry in items {
@@ -378,7 +493,7 @@ pub fn cmd_hierarchy(
 
     output(&items, json, token_budget, |items| {
         if items.is_empty() {
-            return format!("No hierarchy found for '{name}'\n");
+            return format!("No hierarchy found for '{name}'{}\n", empty_index_hint(&db));
         }
         let mut out = String::new();
         for entry in items {
@@ -402,7 +517,10 @@ pub fn cmd_deps(
 
     output(&edges, json, token_budget, |edges| {
         if edges.is_empty() {
-            return format!("No dependencies found for '{file}'\n");
+            return format!(
+                "No dependencies found for '{file}'{}\n",
+                empty_index_hint(&db)
+            );
         }
         let mut out = String::new();
         for edge in edges {
@@ -439,7 +557,10 @@ pub fn cmd_search(
 
     output(&symbols, json, token_budget, |syms| {
         if syms.is_empty() {
-            return format!("No symbols found matching '{query}'\n");
+            return format!(
+                "No symbols found matching '{query}'{}\n",
+                empty_index_hint(&db)
+            );
         }
         let mut out = String::new();
         for sym in syms {
@@ -687,6 +808,9 @@ pub fn cmd_rag_setup(json: bool) -> Result<()> {
     let spinner = if json {
         None
     } else {
+        // One-time notice so the multi-hundred-MB download isn't a silent wait.
+        // Size matches docs/usage.md (embedding ~80MB + reranker ~1.1GB).
+        eprintln!("Downloading embedding + re-ranker models (~1.2GB, one-time)…");
         Spinner::start("Downloading models")
     };
     // Download bi-encoder (embeddings)
@@ -735,23 +859,27 @@ pub fn cmd_rag_index(
     let spinner = if json {
         None
     } else {
-        Spinner::start("Indexing code graph")
+        Spinner::start("Indexing code graph").map(Arc::new)
     };
-    let index_res = indexer::index_directory(&db, root, false, false, None, None);
-    if let Some(s) = spinner {
-        s.stop();
-    }
+    let ix_cb = spinner_callback(&spinner, indexer::ProgressUpdate::label);
+    let ix_cb_ref: Option<indexer::ProgressCallback<'_>> =
+        ix_cb.as_ref().map(|f| f as &(dyn Fn(_) + Send + Sync));
+    let index_res = indexer::index_directory(&db, root, false, false, ix_cb_ref, None);
+    drop(ix_cb);
+    stop_spinner(spinner);
     let _index_result = index_res?;
 
     let spinner = if json {
         None
     } else {
-        Spinner::start("Embedding symbols")
+        Spinner::start("Embedding symbols").map(Arc::new)
     };
-    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force, None, None);
-    if let Some(s) = spinner {
-        s.stop();
-    }
+    let rag_cb = spinner_callback(&spinner, rag::indexer::ProgressUpdate::label);
+    let rag_cb_ref: Option<rag::indexer::ProgressCallback<'_>> =
+        rag_cb.as_ref().map(|f| f as &(dyn Fn(_) + Send + Sync));
+    let embed_res = rag::indexer::index_embeddings(&db, provider.as_mut(), force, rag_cb_ref, None);
+    drop(rag_cb);
+    stop_spinner(spinner);
     let result = embed_res?;
 
     output(&result, json, None, |r| {
@@ -1588,6 +1716,43 @@ pub use self_cmd::{cmd_self_migrate_db, cmd_self_rollback, cmd_self_update, cmd_
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn capitalized_index_phase_labels() {
+        use indexer::ProgressUpdate as U;
+        let cap = |u: &U| capitalize_phase(u.label());
+        assert_eq!(cap(&U::Walking), "Scanning files");
+        assert_eq!(cap(&U::Parsing { total: 12 }), "Parsing 12 files");
+        assert_eq!(cap(&U::Storing { total: 5 }), "Storing 5 files");
+        assert_eq!(cap(&U::ResolvingLsp), "Resolving edges with LSP");
+    }
+
+    #[test]
+    fn capitalized_rag_phase_labels() {
+        use rag::indexer::ProgressUpdate as U;
+        let cap = |u: &U| capitalize_phase(u.label());
+        assert_eq!(cap(&U::Preparing), "Preparing");
+        assert_eq!(
+            cap(&U::Embedding {
+                processed: 64,
+                total: 256
+            }),
+            "Embedding 64/256"
+        );
+        assert_eq!(cap(&U::Storing), "Storing embeddings");
+    }
+
+    #[test]
+    fn capitalize_phase_handles_empty() {
+        assert_eq!(capitalize_phase(String::new()), "");
+    }
+
+    #[test]
+    fn empty_index_hint_present_on_fresh_db() {
+        // Non-empty case is covered by cartog-db's is_empty_reflects_symbol_presence.
+        let db = Database::open_memory().unwrap();
+        assert!(empty_index_hint(&db).contains("cartog index"));
+    }
 
     #[test]
     fn test_estimate_tokens() {

--- a/crates/cartog/src/commands/remote.rs
+++ b/crates/cartog/src/commands/remote.rs
@@ -121,6 +121,16 @@ mod imp {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
+    /// Actionable suffix for an S3 HTTP error status. 401/403 almost always
+    /// mean credentials or bucket policy, not a cartog bug — say so.
+    fn http_status_hint(status: u16) -> &'static str {
+        match status {
+            401 | 403 => " (check AWS credentials and bucket permissions)",
+            404 => " (bucket or key not found — check the remote URL)",
+            _ => "",
+        }
+    }
+
     /// True when `err` is a cross-device-link error from `std::fs::rename`.
     ///
     /// `io::ErrorKind::CrossesDevices` is still unstable, so we match on the
@@ -345,7 +355,11 @@ mod imp {
                 .await
                 .context("S3 upload failed")?;
             if !(200..300).contains(&resp.status_code()) {
-                bail!("S3 upload returned HTTP {}", resp.status_code());
+                bail!(
+                    "S3 upload returned HTTP {}{}",
+                    resp.status_code(),
+                    http_status_hint(resp.status_code())
+                );
             }
             Ok::<_, anyhow::Error>(())
         })?;
@@ -422,7 +436,10 @@ mod imp {
                 .await
                 .context("S3 download failed")?;
             if !(200..300).contains(&status) {
-                bail!("S3 download returned HTTP {status}");
+                bail!(
+                    "S3 download returned HTTP {status}{}",
+                    http_status_hint(status)
+                );
             }
 
             // 4) HEAD to read metadata (sha256 + schema_version).

--- a/crates/cartog/src/commands/self_cmd.rs
+++ b/crates/cartog/src/commands/self_cmd.rs
@@ -902,20 +902,32 @@ fn peer_lock_check_skipped() -> bool {
     false
 }
 
+/// Peer-lock guard decision for `migrate-db`, factored out so it can be unit
+/// tested without touching the filesystem or process state. A dry-run mutates
+/// nothing, so it never blocks on a live peer; a real migration bails if any
+/// peer holds a lock.
+fn migrate_peer_guard(dry_run: bool, active: &[cartog_process_lock::ActiveLock]) -> Result<()> {
+    if dry_run {
+        return Ok(());
+    }
+    if let Some(peer) = active.first() {
+        anyhow::bail!(
+            "another cartog process is running ({slot}, PID {pid}); stop it before migrating",
+            slot = peer.slot,
+            pid = peer.pid,
+        );
+    }
+    Ok(())
+}
+
 /// `cartog self migrate-db [--dry-run]`. Moves legacy DB files into `.cartog/`.
 /// Refuses to run while another cartog peer holds the lock.
 pub fn cmd_self_migrate_db(root: &Path, dry_run: bool, json: bool) -> Result<()> {
     if !peer_lock_check_skipped() {
-        if let Some(dir) = state::default_state_dir() {
-            let active = cartog_process_lock::find_active_locks(&dir);
-            if let Some(peer) = active.first() {
-                anyhow::bail!(
-                    "another cartog process is running ({slot}, PID {pid}); stop it before migrating",
-                    slot = peer.slot,
-                    pid = peer.pid,
-                );
-            }
-        }
+        let active = state::default_state_dir()
+            .map(|dir| cartog_process_lock::find_active_locks(&dir))
+            .unwrap_or_default();
+        migrate_peer_guard(dry_run, &active)?;
     }
 
     let preview = plan_migration(root)?;
@@ -1595,6 +1607,35 @@ deadbeef *cartog-x86_64-unknown-linux-gnu.tar.gz
 
         assert!(legacy.exists(), "dry run must not touch the filesystem");
         assert!(!dir.path().join(".cartog").exists());
+    }
+
+    #[test]
+    fn migrate_peer_guard_bails_for_real_run_when_peer_present() {
+        let active = vec![cartog_process_lock::ActiveLock {
+            slot: "serve-abc".to_string(),
+            pid: 4242,
+            start_time: None,
+        }];
+        let err = migrate_peer_guard(false, &active).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("serve-abc"), "names the slot: {msg}");
+        assert!(msg.contains("4242"), "names the pid: {msg}");
+    }
+
+    #[test]
+    fn migrate_peer_guard_allows_dry_run_despite_live_peer() {
+        // Same live peer as above, but dry_run=true must bypass the guard.
+        let active = vec![cartog_process_lock::ActiveLock {
+            slot: "serve-abc".to_string(),
+            pid: 4242,
+            start_time: None,
+        }];
+        migrate_peer_guard(true, &active).expect("dry-run ignores the peer lock");
+    }
+
+    #[test]
+    fn migrate_peer_guard_allows_real_run_when_no_peer() {
+        migrate_peer_guard(false, &[]).expect("no peer → real run proceeds");
     }
 
     #[test]

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 /// Top-level cartog configuration, loaded from `.cartog.toml`.
@@ -343,6 +344,41 @@ fn local_config_path() -> Option<PathBuf> {
     None
 }
 
+/// Known top-level sections of `.cartog.toml`. Kept in sync with the fields of
+/// [`CartogConfig`]. Unknown keys are warned about (non-fatal) so a typo like
+/// `[embeddings]` is visible instead of silently ignored.
+const KNOWN_CONFIG_SECTIONS: &[&str] = &["database", "embedding", "reranker", "rag", "remote"];
+
+/// Collect top-level keys that are not a recognized config section.
+fn unknown_sections(raw: &toml::value::Table) -> Vec<&str> {
+    raw.keys()
+        .map(String::as_str)
+        .filter(|k| !KNOWN_CONFIG_SECTIONS.contains(k))
+        .collect()
+}
+
+/// Config-load diagnostics run before the tracing subscriber is initialised
+/// (db-path resolution happens early in `main`), so they use `eprintln!`
+/// rather than `tracing`. To avoid polluting the stderr of non-interactive
+/// consumers — the MCP `serve` child, `--json` queries, CI pipes — they are
+/// emitted only when stderr is a terminal (an interactive human is watching).
+fn config_diagnostics_visible() -> bool {
+    std::io::stderr().is_terminal()
+}
+
+/// Emit a one-line stderr warning for each unrecognized top-level config key.
+fn warn_unknown_sections(raw: &toml::value::Table, path: &Path) {
+    if !config_diagnostics_visible() {
+        return;
+    }
+    for key in unknown_sections(raw) {
+        eprintln!(
+            "cartog: warning: unknown config key '{key}' in {} (ignored)",
+            path.display()
+        );
+    }
+}
+
 fn read_config(path: &Path) -> Option<CartogConfig> {
     let text = match std::fs::read_to_string(path) {
         Ok(t) => t,
@@ -363,6 +399,8 @@ fn read_config(path: &Path) -> Option<CartogConfig> {
 
     // Security pre-check: scan the raw `[remote]` table for credential-shaped
     // keys before they have a chance to be deserialised or logged anywhere.
+    // Also warn (non-fatal) about unknown top-level sections so a typo like
+    // `[embeddings]` doesn't silently leave the user on defaults.
     if let Ok(raw) = toml::from_str::<toml::value::Table>(&text) {
         if let Some(toml::Value::Table(remote)) = raw.get("remote") {
             if let Err(msg) = validate_remote_no_credentials(remote) {
@@ -370,6 +408,7 @@ fn read_config(path: &Path) -> Option<CartogConfig> {
                 return None;
             }
         }
+        warn_unknown_sections(&raw, path);
     }
 
     let parsed = match toml::from_str::<CartogConfig>(&text) {
@@ -488,9 +527,15 @@ fn warn_legacy_db_once(path: &Path) {
     if WARNED.swap(true, Ordering::Relaxed) {
         return;
     }
-    tracing::warn!(
-        path = %path.display(),
-        "using legacy database location; run `cartog self migrate-db` to move it into .cartog/"
+    // eprintln, not tracing: db-path resolution runs before the tracing
+    // subscriber is initialised in main, so a `tracing::warn!` here is dropped.
+    // TTY-gated so it doesn't pollute MCP serve / --json / piped stderr.
+    if !config_diagnostics_visible() {
+        return;
+    }
+    eprintln!(
+        "cartog: using legacy database at {}; run `cartog self migrate-db` to move it into .cartog/",
+        path.display()
     );
 }
 
@@ -500,9 +545,12 @@ fn warn_orphan_legacy_once(path: &Path) {
     if WARNED.swap(true, Ordering::Relaxed) {
         return;
     }
-    tracing::warn!(
-        path = %path.display(),
-        "found legacy database alongside the new layout; the legacy file is being ignored"
+    if !config_diagnostics_visible() {
+        return;
+    }
+    eprintln!(
+        "cartog: found legacy database at {} alongside the new layout; the legacy file is ignored",
+        path.display()
     );
 }
 
@@ -530,6 +578,23 @@ mod tests {
             .unwrap_or_else(|_| "/tmp".into());
         let expanded = expand_tilde(PathBuf::from("~/foo/bar"));
         assert_eq!(expanded, PathBuf::from(home).join("foo/bar"));
+    }
+
+    #[test]
+    fn unknown_sections_flags_typos_but_not_known_keys() {
+        let raw: toml::value::Table =
+            toml::from_str("[embeddings]\nprovider = \"ollama\"\n[database]\npath = \"x\"\n")
+                .unwrap();
+        let unknown = unknown_sections(&raw);
+        assert_eq!(unknown, vec!["embeddings"]);
+    }
+
+    #[test]
+    fn unknown_sections_empty_for_all_known() {
+        let raw: toml::value::Table =
+            toml::from_str("[database]\npath = \"x\"\n[embedding]\nprovider = \"local\"\n")
+                .unwrap();
+        assert!(unknown_sections(&raw).is_empty());
     }
 
     #[test]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,7 +117,7 @@ base_url = "http://localhost:11434"
 | Provider | Config | Setup | Notes |
 |----------|--------|-------|-------|
 | `local` (default) | No config needed | `cartog rag setup` to download models | ONNX Runtime via fastembed, ~1.2GB models |
-| `ollama` | `provider = "ollama"` | Ollama server running with model pulled | No model download needed, dimension auto-detected |
+| `ollama` | `provider = "ollama"` | Ollama server running with model pulled | No model download needed, dimension auto-detected. **Not in the prebuilt binary** — requires `cargo install cartog --features ollama-embedding`. |
 
 **Advanced local configuration:**
 

--- a/skills/cartog/scripts/ensure_indexed.sh
+++ b/skills/cartog/scripts/ensure_indexed.sh
@@ -285,7 +285,9 @@ else
     echo "Updating cartog index..."
 fi
 index_rc=0
-cartog index . || index_rc=$?
+# CARTOG_PROGRESS=1 opts into the non-TTY phase heartbeat so the first (cold)
+# index isn't a silent multi-minute wait in this hook. Other callers stay quiet.
+CARTOG_PROGRESS=1 cartog index . || index_rc=$?
 if [ "$index_rc" -ne 0 ]; then
     echo "cartog index failed (exit $index_rc) — continuing to background pipeline." >&2
     printf 'cartog index . failed (exit %d). See terminal output above.\n' "$index_rc" > "$LAST_ERROR_FILE"

--- a/skills/cartog/tests/test_ensure_indexed.sh
+++ b/skills/cartog/tests/test_ensure_indexed.sh
@@ -838,14 +838,18 @@ run_ensure_indexed_print_db() {
         "$@"
         cd "$workdir"
         # Patch: insert echo just before phase 1. The real line is
-        # `cartog index . || index_rc=$?`; legacy form was `cartog index .`.
+        # `CARTOG_PROGRESS=1 cartog index . || index_rc=$?` (the env prefix
+        # opts into the non-TTY progress heartbeat); earlier forms were
+        # `cartog index . || index_rc=$?` and bare `cartog index .`. The
+        # optional `(CARTOG_PROGRESS=1 )?` prefix keeps the patch matching
+        # across all of them.
         # The replacement needs a literal newline — `\n` in a sed RHS is a
         # GNU extension and is taken literally by BSD/macOS sed. Use a
         # backslash-continued newline inside the -e argument, which is POSIX.
         sed \
-            -e 's#^cartog index \. || index_rc=\$?$#echo "DB_FILE=$DB_FILE"\
+            -e 's#^\(CARTOG_PROGRESS=1 \)\{0,1\}cartog index \. || index_rc=\$?$#echo "DB_FILE=$DB_FILE"\
 exit 0#' \
-            -e 's#^cartog index \.$#echo "DB_FILE=$DB_FILE"\
+            -e 's#^\(CARTOG_PROGRESS=1 \)\{0,1\}cartog index \.$#echo "DB_FILE=$DB_FILE"\
 exit 0#' \
             "$ENSURE_SCRIPT" | bash 2>&1
     )


### PR DESCRIPTION
## Why

A persona + adversarial UX review of the Claude plugin + CLI (on real repos: a JS/TS+Rust monorepo and a Rust project) surfaced slow/stuck-UI and confusing first-run behavior. The headline problem: the SessionStart hook runs the first `cartog index` in the foreground with a TTY-only spinner, so a cold index was a **silent 1–3 min wait** before the agent could respond.

## What changed

**Progress / no-more-silent-wait**
- Spinner reports per-phase labels (scanning → parsing → storing → resolving edges with LSP).
- With `CARTOG_PROGRESS=1` (set by the SessionStart hook), it emits a non-TTY heartbeat so the cold first index isn't silent. CI/pipes stay silent by default.
- LSP server death prints an actionable line pointing at `--no-lsp` instead of a bare WARN.

**Clearer messaging**
- No-op index → `Index up to date (N files, M symbols)`; empty tree → `No indexable files found` (was the misleading `0 symbols, 0 edges`).
- Query commands (`search`/`refs`/`outline`/`callees`/`impact`/`hierarchy`/`deps`) append an "index is empty — run `cartog index`" hint only on a fresh DB (computed lazily, no extra query in `--json` / on hits).

**Actionable errors / quieter machine paths**
- ollama provider error names the `--features ollama-embedding` rebuild; docs mark ollama as cargo-only.
- `self migrate-db --dry-run` no longer blocks on a live peer.
- Unknown `.cartog.toml` keys warn (non-fatal). Config-load diagnostics + the legacy-DB notice are TTY-gated, so MCP `serve` / `--json` stderr stays clean.
- S3 push/pull errors add credential/URL hints on 401/403/404.

**Internal**
- Phase labels live on `ProgressUpdate::label()`, shared by CLI and MCP (no wording drift).
- Spinner Arc lifecycle extracted into `spinner_callback`/`stop_spinner` so the explicit stop is reliable across all call sites.

## Testing

- 12 regression tests added.
- `cargo fmt --check`, `clippy --all-targets -D warnings`, `test --workspace` (29 suites) all green.
- Feature builds verified: default, `ollama-embedding`, `--no-default-features --features lsp`.
- End-to-end verified on real repos: silent-by-default non-TTY, heartbeat with `CARTOG_PROGRESS=1`, up-to-date / empty-repo messages, TTY-gated config warnings.

## Notes

This PR went through a `/code-review xhigh` pass; the one real bug it found (a dead `s.stop()` from a stray `Arc` clone) plus the stderr-discipline regressions are fixed in the same commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced progress reporting with phase-specific labels during indexing and embedding
  * Configuration validation with warnings for unknown sections in `.cartog.toml`

* **Improvements**
  * Better error messages for LSP server failures with recovery hints
  * Improved CLI feedback with adaptive spinner display (TTY vs non-TTY)
  * More informative empty-index messaging with helpful next-step guidance
  * Status-code-aware error messages for remote index operations

* **Bug Fixes**
  * Fixed dry-run migrations to work without peer-lock conflicts

* **Documentation**
  * Clarified Ollama embedding provider requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->