### PR TITLE
Adoption: agent snippet, savings, mermaid, install alias, P0 review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,12 +436,15 @@ cartog refs validate_token --kind calls     # only call sites
 cartog callees authenticate                 # what does this call?
 cartog impact SessionManager --depth 3      # what breaks if I change this?
 cartog hierarchy BaseService                # inheritance tree
+cartog hierarchy BaseService --mermaid      # paste-into-PR diagram
 cartog deps src/routes/auth.py              # file-level imports
+cartog deps src/routes/auth.py --mermaid    # graph LR with file as root
 
 # Inspect
 cartog stats                                # index summary
 cartog savings                              # tokens saved vs grep+read baseline
 cartog map --tokens 4000                    # codebase overview by centrality
+cartog map --mermaid                        # codebase map as graph TD
 cartog changes --commits 5                  # recently changed symbols
 cartog doctor                               # environment health check
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ cartog deps src/routes/auth.py              # file-level imports
 
 # Inspect
 cartog stats                                # index summary
+cartog savings                              # tokens saved vs grep+read baseline
 cartog map --tokens 4000                    # codebase overview by centrality
 cartog changes --commits 5                  # recently changed symbols
 cartog doctor                               # environment health check

--- a/README.md
+++ b/README.md
@@ -233,8 +233,17 @@ cartog ide --client cursor                  # one client
 cartog ide --client claude-desktop --dry-run  # preview without writing
 ```
 
-Idempotent. Existing servers in each file are preserved. `cartog install` is a
-visible alias of `cartog ide` if that name feels more natural.
+Idempotent. Existing servers in each file are preserved.
+
+Prefer the brew/npm shape? `cartog install` takes editors as positional args
+and is always non-interactive — safer than `cartog ide` for scripts and agents:
+
+```bash
+cartog install cursor                 # one editor
+cartog install cursor vscode codex    # several at once
+cartog install                        # all detected editors
+cartog install cursor --dry-run       # preview
+```
 
 Prefer to wire it yourself? Pick your client below.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **Map your codebase. Navigate by graph, not grep.**
 
+**~280 tokens per query, 97% recall, 8 us to 20 ms latency, 9 languages.**
+
 Single binary. Microsecond queries. 100% local by default.
 
 Cartog pre-computes a code graph — symbols, calls, imports, inheritance — and lets you query it instantly. Use it from the CLI for day-to-day navigation, as an MCP server for AI agents, or both. No Python, no pip, no Docker. One binary, one SQLite file, zero cloud dependencies.
@@ -44,6 +46,15 @@ cartog refs validate_token    # who calls this?              (< 500 us)
 cartog impact validate_token  # what breaks if I change it?  (< 20 ms)
 cartog outline src/auth.py    # file structure, no cat       (< 15 us)
 ```
+
+## Teach your agent to use cartog
+
+Wiring MCP is half the job. The other half is telling the agent **when** to
+prefer cartog over grep + read. Drop the snippet from
+[docs/agent-snippet.md](docs/agent-snippet.md) into your project's `AGENTS.md`,
+`CLAUDE.md`, `.cursor/rules/`, or equivalent, and the agent will route
+"where is X?" / "who calls X?" / "what breaks if I change X?" through
+cartog's 13 MCP tools instead of flooding context with raw text.
 
 ## Why Cartog
 
@@ -214,24 +225,190 @@ npx skills add jrollin/cartog
 
 ## MCP Server Setup
 
-`cartog ide` wires `cartog serve` into MCP-aware editors:
+Fastest path: let cartog write the right config for your editor.
 
 ```bash
 cartog ide                                  # all installed clients, all scopes
 cartog ide --client cursor                  # one client
-cartog ide --scope project                  # only project-scoped (.mcp.json, .cursor/, .vscode/)
-cartog ide --scope user                     # only user-scope clients
 cartog ide --client claude-desktop --dry-run  # preview without writing
 ```
 
-Project-scoped writes: Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`),
-VS Code (`.vscode/mcp.json`). User-scope: Claude Code user settings,
-Claude Desktop, Codex CLI (TOML), Gemini CLI, OpenCode, Windsurf, Zed.
-Idempotent: existing servers in each file are preserved.
+Idempotent. Existing servers in each file are preserved.
 
-See [docs/usage.md](docs/usage.md#mcp-server) for flags and
-[docs/mcp-setup.md](docs/mcp-setup.md) for the JSON / TOML shape per client
-and the manual-setup fallback.
+Prefer to wire it yourself? Pick your client below.
+
+<details>
+<summary><strong>Claude Code</strong> — project-scoped <code>.mcp.json</code> or user settings</summary>
+
+One-shot:
+
+```bash
+cartog ide --client claude-code             # writes .mcp.json + user settings
+claude mcp add cartog -- cartog serve --watch       # user scope
+claude mcp add --scope project cartog -- cartog serve --watch
+```
+
+Manual (`<repo>/.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "cartog": { "command": "cartog", "args": ["serve", "--watch"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Cursor</strong> — project <code>.cursor/mcp.json</code> or user settings</summary>
+
+One-shot:
+
+```bash
+cartog ide --client cursor
+```
+
+Manual:
+
+```json
+{
+  "mcpServers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Codex CLI</strong> — user-only TOML at <code>~/.codex/config.toml</code></summary>
+
+One-shot:
+
+```bash
+cartog ide --client codex
+```
+
+Manual:
+
+```toml
+[mcp_servers.cartog]
+command = "cartog"
+args = ["serve"]
+```
+
+Codex is user-global only. If you use cartog on multiple projects, `cartog ide`
+auto-names each section `cartog-<slug>-<hash8>` so they coexist.
+</details>
+
+<details>
+<summary><strong>Windsurf</strong> — <code>~/.codeium/windsurf/mcp_config.json</code></summary>
+
+```bash
+cartog ide --client windsurf
+```
+
+```json
+{
+  "mcpServers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>VS Code (GitHub Copilot)</strong> — project <code>.vscode/mcp.json</code></summary>
+
+```bash
+cartog ide --client vscode
+```
+
+Note: VS Code's top-level key is `servers` (no `mcp` prefix):
+
+```json
+{
+  "servers": {
+    "cartog": { "type": "stdio", "command": "cartog", "args": ["serve"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Zed</strong> — <code>~/.config/zed/settings.json</code></summary>
+
+```bash
+cartog ide --client zed
+```
+
+```json
+{
+  "context_servers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>OpenCode</strong> — <code>~/.config/opencode/opencode.json</code></summary>
+
+```bash
+cartog ide --client opencode
+```
+
+```json
+{
+  "mcp": {
+    "cartog": {
+      "type": "local",
+      "command": ["cartog", "serve"],
+      "enabled": true
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Gemini CLI</strong> — <code>~/.gemini/settings.json</code></summary>
+
+```bash
+cartog ide --client gemini
+```
+
+```json
+{
+  "mcpServers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Claude Desktop</strong> — <code>claude_desktop_config.json</code></summary>
+
+```bash
+cartog ide --client claude-desktop
+```
+
+Manual (macOS: `~/Library/Application Support/Claude/`; Windows: `%APPDATA%\Claude\`):
+
+```json
+{
+  "mcpServers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+</details>
+
+See [docs/mcp-setup.md](docs/mcp-setup.md) for the canonical long-form reference,
+including the path-naming scheme for Codex's multi-project setup, and
+[docs/usage.md](docs/usage.md#mcp-server) for all `cartog ide` flags.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ cartog ide --client cursor                  # one client
 cartog ide --client claude-desktop --dry-run  # preview without writing
 ```
 
-Idempotent. Existing servers in each file are preserved.
+Idempotent. Existing servers in each file are preserved. `cartog install` is a
+visible alias of `cartog ide` if that name feels more natural.
 
 Prefer to wire it yourself? Pick your client below.
 
@@ -257,6 +258,11 @@ Manual (`<repo>/.mcp.json`):
   }
 }
 ```
+
+> Only Claude Code gets `--watch` by default — the others ship plain `["serve"]`.
+> Agent-driven flows churn files faster than human-driven editor flows, so the
+> in-process file watcher pays off. Drop `--watch` with `cartog ide --no-watch`
+> if you don't want it.
 </details>
 
 <details>

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -144,6 +144,19 @@ CREATE TABLE IF NOT EXISTS metadata (
     value TEXT
 );
 
+-- query_log feeds `cartog stats --savings` / `cartog savings`. One row per
+-- successful read tool call (CLI or MCP). No query payload is stored — just
+-- which tool, when, and the call surface — to keep the local-first promise.
+CREATE TABLE IF NOT EXISTS query_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tool TEXT NOT NULL,
+    source TEXT NOT NULL,
+    ts INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_tool ON query_log(tool);
+CREATE INDEX IF NOT EXISTS idx_query_log_ts ON query_log(ts);
+
 CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
 CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
 CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_path);
@@ -378,7 +391,7 @@ pub fn register_sqlite_vec() {
 }
 
 /// Current schema version. Increment when adding migrations.
-const SCHEMA_VERSION: u32 = 4;
+const SCHEMA_VERSION: u32 = 5;
 
 /// Public mirror of [`SCHEMA_VERSION`] for callers outside this crate
 /// (e.g. `cartog pull` needs it to compare against a pulled DB and refuse
@@ -473,8 +486,10 @@ fn migrate(conn: &Connection) {
     let has_resolution_state = conn
         .prepare("SELECT resolution_state FROM edges LIMIT 0")
         .is_ok();
+    // Same idea for v5: ensure query_log exists even on partial migration.
+    let has_query_log = conn.prepare("SELECT 1 FROM query_log LIMIT 0").is_ok();
 
-    if current >= SCHEMA_VERSION && has_hash_cols && has_resolution_state {
+    if current >= SCHEMA_VERSION && has_hash_cols && has_resolution_state && has_query_log {
         return;
     }
 
@@ -515,6 +530,31 @@ fn migrate(conn: &Connection) {
         );
         let _ = conn.execute(
             "UPDATE edges SET resolution_state = 1 WHERE target_id IS NOT NULL",
+            [],
+        );
+    }
+
+    // Migration 4 → 5: query_log table for `cartog stats --savings`.
+    // Additive only; the SCHEMA bootstrap above already runs `CREATE TABLE IF
+    // NOT EXISTS query_log`, so this branch is just the version bump for
+    // databases that ran through `migrate()` on a pre-v5 binary.
+    if current < 5 || !has_query_log {
+        info!("schema v5: query_log table");
+        let _ = conn.execute(
+            "CREATE TABLE IF NOT EXISTS query_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                source TEXT NOT NULL,
+                ts INTEGER NOT NULL
+            )",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_query_log_tool ON query_log(tool)",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_query_log_ts ON query_log(ts)",
             [],
         );
     }
@@ -2059,6 +2099,62 @@ impl Database {
         })
     }
 
+    /// Record a successful query against the index for the `cartog stats --savings`
+    /// / `cartog savings` retention hook.
+    ///
+    /// Best-effort: errors are swallowed (logged via `warn!`) so a failing
+    /// write never aborts the user's actual query. No-op on read-only attach —
+    /// secondary MCP servers cannot write, and double-counting a query that
+    /// will also be logged by the primary is the wrong shape anyway.
+    ///
+    /// Stored fields: `tool` (e.g. `"search"`, `"refs"`, `"cartog_search"`),
+    /// `source` (`"cli"` or `"mcp"`), and a unix-seconds timestamp. The query
+    /// payload itself is never recorded — see the privacy banner in README.
+    pub fn log_query(&self, tool: &str, source: &str) {
+        if self.is_read_only() {
+            return;
+        }
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        if let Err(e) = self.conn.execute(
+            "INSERT INTO query_log (tool, source, ts) VALUES (?1, ?2, ?3)",
+            params![tool, source, ts],
+        ) {
+            warn!(error = %e, tool, source, "query_log insert failed");
+        }
+    }
+
+    /// Aggregate `query_log` for `cartog stats --savings` / `cartog savings`.
+    /// Safe on read-only attach (it's a read).
+    pub fn savings_breakdown(&self) -> Result<SavingsReport> {
+        let mut tool_stmt = self.conn.prepare(
+            "SELECT tool, COUNT(*) FROM query_log GROUP BY tool ORDER BY COUNT(*) DESC, tool",
+        )?;
+        let by_tool: Vec<(String, u64)> = tool_stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get::<_, i64>(1)? as u64)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let mut src_stmt = self.conn.prepare(
+            "SELECT source, COUNT(*) FROM query_log GROUP BY source ORDER BY COUNT(*) DESC, source",
+        )?;
+        let by_source: Vec<(String, u64)> = src_stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get::<_, i64>(1)? as u64)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let total_queries: u64 = by_tool.iter().map(|(_, c)| c).sum();
+        let estimated_tokens_saved = total_queries.saturating_mul(TOKENS_SAVED_PER_QUERY as u64);
+
+        Ok(SavingsReport {
+            by_tool,
+            by_source,
+            total_queries,
+            estimated_tokens_saved,
+            baseline_delta: TOKENS_SAVED_PER_QUERY,
+        })
+    }
+
     /// Get all non-import symbols ordered by in-degree (highest first), then by file.
     ///
     /// Used by `cartog map` to produce a centrality-ranked codebase summary.
@@ -2786,6 +2882,31 @@ pub struct IndexStats {
     pub symbol_kinds: Vec<(String, u32)>,
 }
 
+/// Per-tool query counts + token-savings estimate for `cartog stats --savings`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SavingsReport {
+    /// `(tool_name, count)` sorted by count descending, then tool name.
+    pub by_tool: Vec<(String, u64)>,
+    /// `(source, count)` for `"cli"` / `"mcp"`.
+    pub by_source: Vec<(String, u64)>,
+    /// Sum of all per-tool counts.
+    pub total_queries: u64,
+    /// Estimated tokens saved versus a grep+read baseline.
+    /// Uses [`TOKENS_SAVED_PER_QUERY`] as a flat multiplier — coarse on purpose;
+    /// per-tool token accounting is a future refinement.
+    pub estimated_tokens_saved: u64,
+    /// Baseline token delta used. Exposed so the CLI can name the figure.
+    pub baseline_delta: u32,
+}
+
+/// Token delta per cartog query versus a `grep + Read` baseline.
+///
+/// Sources: the benchmark suite measures ~1,700 tokens for a grep+read sweep
+/// answering "where is X used?" against cartog's ~280 tokens. The difference
+/// (~1,420) is taken as the per-query savings. Coarse but defensible; refining
+/// per-tool would require a richer per-call metric and isn't worth it pre-v1.
+pub const TOKENS_SAVED_PER_QUERY: u32 = 1_420;
+
 // ── Row Mapping Helpers ──
 
 fn row_to_symbol(row: &rusqlite::Row<'_>) -> rusqlite::Result<Symbol> {
@@ -3012,6 +3133,59 @@ mod tests {
         let stats = db.stats().unwrap();
         assert_eq!(stats.num_files, 1);
         assert_eq!(stats.num_symbols, 1);
+    }
+
+    #[test]
+    fn savings_breakdown_empty_returns_zero() {
+        let db = Database::open_memory().unwrap();
+        let r = db.savings_breakdown().unwrap();
+        assert_eq!(r.total_queries, 0);
+        assert_eq!(r.estimated_tokens_saved, 0);
+        assert!(r.by_tool.is_empty());
+        assert!(r.by_source.is_empty());
+        assert_eq!(r.baseline_delta, TOKENS_SAVED_PER_QUERY);
+    }
+
+    #[test]
+    fn log_query_persists_rows_aggregated_by_tool_and_source() {
+        let db = Database::open_memory().unwrap();
+        db.log_query("search", "cli");
+        db.log_query("search", "cli");
+        db.log_query("refs", "cli");
+        db.log_query("search", "mcp");
+        db.log_query("impact", "mcp");
+
+        let r = db.savings_breakdown().unwrap();
+        assert_eq!(r.total_queries, 5);
+        assert_eq!(r.estimated_tokens_saved, 5 * TOKENS_SAVED_PER_QUERY as u64);
+
+        // by_tool sorted by count desc, then name
+        let tool_counts: Vec<_> = r.by_tool.iter().map(|(t, c)| (t.as_str(), *c)).collect();
+        assert_eq!(tool_counts, vec![("search", 3), ("impact", 1), ("refs", 1)]);
+
+        let src_counts: Vec<_> = r.by_source.iter().map(|(s, c)| (s.as_str(), *c)).collect();
+        assert_eq!(src_counts, vec![("cli", 3), ("mcp", 2)]);
+    }
+
+    #[test]
+    fn log_query_noop_on_read_only_attach() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        {
+            let primary = Database::open(&db_path, 384).unwrap();
+            primary.log_query("search", "cli"); // primary write succeeds
+        }
+
+        let reader = Database::open_readonly(&db_path).unwrap();
+        assert!(reader.is_read_only());
+        // log_query on read-only attach must silently no-op (no panic, no insert).
+        reader.log_query("search", "mcp");
+        reader.log_query("refs", "mcp");
+
+        let r = reader.savings_breakdown().unwrap();
+        // Only the primary's row is visible — secondary writes were dropped.
+        assert_eq!(r.total_queries, 1);
+        assert_eq!(r.by_tool, vec![("search".to_string(), 1)]);
     }
 
     #[test]
@@ -5922,6 +6096,6 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(bumped, "4");
+        assert_eq!(bumped, SCHEMA_VERSION.to_string());
     }
 }

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2180,12 +2180,14 @@ impl Database {
         let tokens_used_cartog = total_queries.saturating_mul(TOKENS_PER_QUERY_CARTOG as u64);
         let tokens_used_grep = total_queries.saturating_mul(TOKENS_PER_QUERY_GREP as u64);
         let estimated_tokens_saved = tokens_used_grep.saturating_sub(tokens_used_cartog);
-        // 0–99 to keep the visual bar from flat-topping at 100% on degenerate
-        // data and to leave room for "less than 1% rounding" cases.
-        let percent_saved = (estimated_tokens_saved * 100)
+        // 0–100, computed with saturating_mul to match the rest of the
+        // arithmetic in this function (everything else uses saturating_* to
+        // stay safe at extreme query counts).
+        let percent_saved = estimated_tokens_saved
+            .saturating_mul(100)
             .checked_div(tokens_used_grep)
             .unwrap_or(0)
-            .min(99) as u8;
+            .min(100) as u8;
 
         Ok(SavingsReport {
             by_tool,
@@ -2996,11 +2998,14 @@ fn empty_savings_report() -> SavingsReport {
 /// "query_log doesn't exist yet" (return empty report) from real DB faults
 /// (propagate).
 fn is_no_such_table(e: &rusqlite::Error) -> bool {
-    // SQLite reports missing tables as a generic Error (extended code 1)
-    // whose message starts with `no such table:`. Match on the message text
-    // because the rusqlite error variant for prepare-time errors does not
-    // carry the offending object name.
-    e.to_string().contains("no such table")
+    // SQLite raises SQLITE_ERROR (primary code 1) with a message starting
+    // "no such table: <name>". Match on the variant + the message inside it
+    // rather than `e.to_string()` so a future change to rusqlite's Display
+    // wrapper doesn't break the dispatch silently.
+    matches!(
+        e,
+        rusqlite::Error::SqliteFailure(_, Some(msg)) if msg.contains("no such table")
+    )
 }
 
 // ── Row Mapping Helpers ──

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2103,13 +2103,21 @@ impl Database {
     /// / `cartog savings` retention hook.
     ///
     /// Best-effort: errors are swallowed (logged via `warn!`) so a failing
-    /// write never aborts the user's actual query. No-op on read-only attach —
-    /// secondary MCP servers cannot write, and double-counting a query that
-    /// will also be logged by the primary is the wrong shape anyway.
+    /// write never aborts the user's actual query.
     ///
-    /// Stored fields: `tool` (e.g. `"search"`, `"refs"`, `"cartog_search"`),
-    /// `source` (`"cli"` or `"mcp"`), and a unix-seconds timestamp. The query
-    /// payload itself is never recorded — see the privacy banner in README.
+    /// **Read-only attach skips the write.** Secondary MCP servers opened via
+    /// [`Self::open_readonly`] cannot write at all. As a result, queries
+    /// served by a secondary are NOT reflected in `query_log` — there is no
+    /// IPC that forwards them to the primary. `cartog stats --savings` on a
+    /// machine that runs multiple MCP servers will therefore *undercount*
+    /// secondary traffic, not overcount it. This is a deliberate trade-off:
+    /// the alternative would be a separate per-process file with its own
+    /// merge logic, which is more complexity than the retention hook needs.
+    ///
+    /// Stored fields: `tool` (e.g. `"search"`, `"refs"`, MCP-side already
+    /// strips the `cartog_` prefix so CLI and MCP rows aggregate), `source`
+    /// (`"cli"` or `"mcp"`), and a unix-seconds timestamp. The query payload
+    /// itself is never recorded — see the privacy banner in README.
     pub fn log_query(&self, tool: &str, source: &str) {
         if self.is_read_only() {
             return;
@@ -2122,13 +2130,42 @@ impl Database {
             "INSERT INTO query_log (tool, source, ts) VALUES (?1, ?2, ?3)",
             params![tool, source, ts],
         ) {
+            // Always warn for the individual failure (debuggable in traces),
+            // and additionally emit a one-shot loud-error on the first
+            // failure so a persistently-broken query_log (e.g. SQLITE_FULL
+            // or a missing table on a manually-tampered DB) is visible even
+            // when warns are filtered.
             warn!(error = %e, tool, source, "query_log insert failed");
+            if !LOG_QUERY_FAILURE_REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::error!(
+                    error = %e,
+                    "query_log is failing — `cartog stats --savings` will undercount. \
+                     Check disk space and `cartog doctor`."
+                );
+            }
         }
     }
 
     /// Aggregate `query_log` for `cartog stats --savings` / `cartog savings`.
-    /// Safe on read-only attach (it's a read).
+    /// Safe on read-only attach (it's a read). Returns an empty report when
+    /// the `query_log` table is missing (the read-only attach path skips
+    /// schema bootstrap, so a v5 DB that lost the table — manual drop, partial
+    /// snapshot restore — would otherwise surface a `no such table` error).
     pub fn savings_breakdown(&self) -> Result<SavingsReport> {
+        // Cheap guard: probe for the table once. On read-only attach we can't
+        // CREATE it, but returning an empty report is the right shape for the
+        // caller (the CLI prints "No queries logged yet").
+        let table_exists = self.conn.prepare("SELECT 1 FROM query_log LIMIT 0").is_ok();
+        if !table_exists {
+            return Ok(SavingsReport {
+                by_tool: Vec::new(),
+                by_source: Vec::new(),
+                total_queries: 0,
+                estimated_tokens_saved: 0,
+                baseline_delta: TOKENS_SAVED_PER_QUERY,
+            });
+        }
+
         let mut tool_stmt = self.conn.prepare(
             "SELECT tool, COUNT(*) FROM query_log GROUP BY tool ORDER BY COUNT(*) DESC, tool",
         )?;
@@ -2906,6 +2943,13 @@ pub struct SavingsReport {
 /// (~1,420) is taken as the per-query savings. Coarse but defensible; refining
 /// per-tool would require a richer per-call metric and isn't worth it pre-v1.
 pub const TOKENS_SAVED_PER_QUERY: u32 = 1_420;
+
+/// One-shot flag flipped the first time `log_query` fails. Surfaces a loud
+/// error so a persistently-broken `query_log` (SQLITE_FULL, missing table)
+/// is visible even when `warn!` is filtered. Process-scoped on purpose: the
+/// goal is one user-visible message per cartog invocation, not per row.
+static LOG_QUERY_FAILURE_REPORTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 // ── Row Mapping Helpers ──
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2152,18 +2152,20 @@ impl Database {
     /// schema bootstrap, so a v5 DB that lost the table — manual drop, partial
     /// snapshot restore — would otherwise surface a `no such table` error).
     pub fn savings_breakdown(&self) -> Result<SavingsReport> {
-        // Cheap guard: probe for the table once. On read-only attach we can't
-        // CREATE it, but returning an empty report is the right shape for the
-        // caller (the CLI prints "No queries logged yet").
-        let table_exists = self.conn.prepare("SELECT 1 FROM query_log LIMIT 0").is_ok();
-        if !table_exists {
-            return Ok(SavingsReport {
-                by_tool: Vec::new(),
-                by_source: Vec::new(),
-                total_queries: 0,
-                estimated_tokens_saved: 0,
-                baseline_delta: TOKENS_SAVED_PER_QUERY,
-            });
+        // Probe for the table once. Only treat "no such table" as the empty-
+        // report case so real DB faults (corruption, locked, permissions)
+        // still propagate to the caller.
+        if let Err(e) = self.conn.prepare("SELECT 1 FROM query_log LIMIT 0") {
+            if is_no_such_table(&e) {
+                return Ok(SavingsReport {
+                    by_tool: Vec::new(),
+                    by_source: Vec::new(),
+                    total_queries: 0,
+                    estimated_tokens_saved: 0,
+                    baseline_delta: TOKENS_SAVED_PER_QUERY,
+                });
+            }
+            return Err(e.into());
         }
 
         let mut tool_stmt = self.conn.prepare(
@@ -2950,6 +2952,18 @@ pub const TOKENS_SAVED_PER_QUERY: u32 = 1_420;
 /// goal is one user-visible message per cartog invocation, not per row.
 static LOG_QUERY_FAILURE_REPORTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+
+/// Returns true when a rusqlite error specifically indicates a missing table,
+/// not any other prepare failure. Used by `savings_breakdown` to distinguish
+/// "query_log doesn't exist yet" (return empty report) from real DB faults
+/// (propagate).
+fn is_no_such_table(e: &rusqlite::Error) -> bool {
+    // SQLite reports missing tables as a generic Error (extended code 1)
+    // whose message starts with `no such table:`. Match on the message text
+    // because the rusqlite error variant for prepare-time errors does not
+    // carry the offending object name.
+    e.to_string().contains("no such table")
+}
 
 // ── Row Mapping Helpers ──
 

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2157,13 +2157,7 @@ impl Database {
         // still propagate to the caller.
         if let Err(e) = self.conn.prepare("SELECT 1 FROM query_log LIMIT 0") {
             if is_no_such_table(&e) {
-                return Ok(SavingsReport {
-                    by_tool: Vec::new(),
-                    by_source: Vec::new(),
-                    total_queries: 0,
-                    estimated_tokens_saved: 0,
-                    baseline_delta: TOKENS_SAVED_PER_QUERY,
-                });
+                return Ok(empty_savings_report());
             }
             return Err(e.into());
         }
@@ -2183,13 +2177,24 @@ impl Database {
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         let total_queries: u64 = by_tool.iter().map(|(_, c)| c).sum();
-        let estimated_tokens_saved = total_queries.saturating_mul(TOKENS_SAVED_PER_QUERY as u64);
+        let tokens_used_cartog = total_queries.saturating_mul(TOKENS_PER_QUERY_CARTOG as u64);
+        let tokens_used_grep = total_queries.saturating_mul(TOKENS_PER_QUERY_GREP as u64);
+        let estimated_tokens_saved = tokens_used_grep.saturating_sub(tokens_used_cartog);
+        // 0–99 to keep the visual bar from flat-topping at 100% on degenerate
+        // data and to leave room for "less than 1% rounding" cases.
+        let percent_saved = (estimated_tokens_saved * 100)
+            .checked_div(tokens_used_grep)
+            .unwrap_or(0)
+            .min(99) as u8;
 
         Ok(SavingsReport {
             by_tool,
             by_source,
             total_queries,
+            tokens_used_cartog,
+            tokens_used_grep,
             estimated_tokens_saved,
+            percent_saved,
             baseline_delta: TOKENS_SAVED_PER_QUERY,
         })
     }
@@ -2922,6 +2927,10 @@ pub struct IndexStats {
 }
 
 /// Per-tool query counts + token-savings estimate for `cartog stats --savings`.
+///
+/// Carries both sides of the comparison (cartog vs grep+read) so the CLI can
+/// render a "with / without / saved" breakdown that's actually informative —
+/// the flat delta on its own under-explains where the number comes from.
 #[derive(Debug, Clone, Serialize)]
 pub struct SavingsReport {
     /// `(tool_name, count)` sorted by count descending, then tool name.
@@ -2930,21 +2939,35 @@ pub struct SavingsReport {
     pub by_source: Vec<(String, u64)>,
     /// Sum of all per-tool counts.
     pub total_queries: u64,
-    /// Estimated tokens saved versus a grep+read baseline.
-    /// Uses [`TOKENS_SAVED_PER_QUERY`] as a flat multiplier — coarse on purpose;
-    /// per-tool token accounting is a future refinement.
+    /// Estimated tokens cartog used for `total_queries` reads.
+    pub tokens_used_cartog: u64,
+    /// Estimated tokens an equivalent grep+read flow would have used.
+    pub tokens_used_grep: u64,
+    /// `tokens_used_grep - tokens_used_cartog`. Same as the old
+    /// `estimated_tokens_saved` field; kept for JSON back-compat.
     pub estimated_tokens_saved: u64,
-    /// Baseline token delta used. Exposed so the CLI can name the figure.
+    /// Integer percent of `tokens_used_grep` saved (0–99). Caps at 99 so
+    /// the bar never visually flat-tops at 100% on degenerate data.
+    pub percent_saved: u8,
+    /// Per-query baseline token delta (grep − cartog). Exposed so the CLI
+    /// can name the figure in the footer.
     pub baseline_delta: u32,
 }
 
-/// Token delta per cartog query versus a `grep + Read` baseline.
-///
-/// Sources: the benchmark suite measures ~1,700 tokens for a grep+read sweep
-/// answering "where is X used?" against cartog's ~280 tokens. The difference
-/// (~1,420) is taken as the per-query savings. Coarse but defensible; refining
-/// per-tool would require a richer per-call metric and isn't worth it pre-v1.
-pub const TOKENS_SAVED_PER_QUERY: u32 = 1_420;
+/// Per-query token cost for cartog. Measured: ~280 tokens for a typical
+/// navigation query (`where is X used?`, `what does X call?`) including the
+/// structured response payload.
+pub const TOKENS_PER_QUERY_CARTOG: u32 = 280;
+
+/// Per-query token cost for an equivalent grep + read flow. Measured: a
+/// grep sweep plus reading the surrounding ~50 lines of each hit averages
+/// ~1,700 tokens to answer the same navigation question.
+pub const TOKENS_PER_QUERY_GREP: u32 = 1_700;
+
+/// Per-query token delta (`grep − cartog`). Coarse on purpose; refining
+/// per-tool would require richer per-call accounting and isn't worth it
+/// pre-v1. Sources: benchmarks/queries.rs (see `crates/cartog/benches/`).
+pub const TOKENS_SAVED_PER_QUERY: u32 = TOKENS_PER_QUERY_GREP - TOKENS_PER_QUERY_CARTOG;
 
 /// One-shot flag flipped the first time `log_query` fails. Surfaces a loud
 /// error so a persistently-broken `query_log` (SQLITE_FULL, missing table)
@@ -2952,6 +2975,21 @@ pub const TOKENS_SAVED_PER_QUERY: u32 = 1_420;
 /// goal is one user-visible message per cartog invocation, not per row.
 static LOG_QUERY_FAILURE_REPORTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+
+/// Zero-state [`SavingsReport`] used when no queries have been logged yet
+/// (or when the `query_log` table is missing on a read-only attach).
+fn empty_savings_report() -> SavingsReport {
+    SavingsReport {
+        by_tool: Vec::new(),
+        by_source: Vec::new(),
+        total_queries: 0,
+        tokens_used_cartog: 0,
+        tokens_used_grep: 0,
+        estimated_tokens_saved: 0,
+        percent_saved: 0,
+        baseline_delta: TOKENS_SAVED_PER_QUERY,
+    }
+}
 
 /// Returns true when a rusqlite error specifically indicates a missing table,
 /// not any other prepare failure. Used by `savings_breakdown` to distinguish
@@ -3198,7 +3236,10 @@ mod tests {
         let db = Database::open_memory().unwrap();
         let r = db.savings_breakdown().unwrap();
         assert_eq!(r.total_queries, 0);
+        assert_eq!(r.tokens_used_cartog, 0);
+        assert_eq!(r.tokens_used_grep, 0);
         assert_eq!(r.estimated_tokens_saved, 0);
+        assert_eq!(r.percent_saved, 0);
         assert!(r.by_tool.is_empty());
         assert!(r.by_source.is_empty());
         assert_eq!(r.baseline_delta, TOKENS_SAVED_PER_QUERY);
@@ -3215,7 +3256,12 @@ mod tests {
 
         let r = db.savings_breakdown().unwrap();
         assert_eq!(r.total_queries, 5);
+        // With/without/saved derived from the per-query constants.
+        assert_eq!(r.tokens_used_cartog, 5 * TOKENS_PER_QUERY_CARTOG as u64);
+        assert_eq!(r.tokens_used_grep, 5 * TOKENS_PER_QUERY_GREP as u64);
         assert_eq!(r.estimated_tokens_saved, 5 * TOKENS_SAVED_PER_QUERY as u64);
+        // ~83% saved given 280 vs 1700 baseline.
+        assert_eq!(r.percent_saved, 83);
 
         // by_tool sorted by count desc, then name
         let tool_counts: Vec<_> = r.by_tool.iter().map(|(t, c)| (t.as_str(), *c)).collect();

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -351,6 +351,16 @@ fn tool_response(db: &Database, json: String, tool: &str) -> Result<CallToolResu
     tool_response_named(db, json, tool, None)
 }
 
+/// Record a successful read tool call into the query log for
+/// `cartog stats --savings`. Strips the `cartog_` prefix so MCP and CLI
+/// counts aggregate under the same tool name; the `source` field keeps the
+/// surface distinction. Best-effort — `Database::log_query` swallows write
+/// errors and no-ops on read-only attach.
+fn log_tool_query(db: &Database, tool: &str) {
+    let short = tool.strip_prefix("cartog_").unwrap_or(tool);
+    db.log_query(short, "mcp");
+}
+
 /// Build the "did you mean" suffix for an empty navigation result. Returns
 /// `None` when there are no candidates or one is an exact match (the symbol
 /// exists but genuinely has no edges, so suggesting it would be noise).
@@ -377,6 +387,7 @@ fn tool_response_named(
     tool: &str,
     queried_name: Option<&str>,
 ) -> Result<CallToolResult, McpError> {
+    log_tool_query(db, tool);
     let is_empty = !db
         .has_indexed_files()
         .map_err(|e| mcp_err(format!("stats check failed: {e}")))?;

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -387,10 +387,16 @@ fn tool_response_named(
     tool: &str,
     queried_name: Option<&str>,
 ) -> Result<CallToolResult, McpError> {
-    log_tool_query(db, tool);
     let is_empty = !db
         .has_indexed_files()
         .map_err(|e| mcp_err(format!("stats check failed: {e}")))?;
+
+    // Log AFTER the has_indexed_files probe succeeds and only when the index
+    // is non-empty. An "Index is empty — run cartog_index first" response is
+    // not a real query and shouldn't count toward `cartog stats --savings`.
+    if !is_empty {
+        log_tool_query(db, tool);
+    }
 
     // Empty navigation result on a populated index → suggest near matches.
     if !is_empty {
@@ -985,6 +991,10 @@ impl CartogServer {
             }
             let json = serde_json::to_string_pretty(&value)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
+            // cartog_stats bypasses tool_response_named so it must log itself
+            // — otherwise MCP-side stats calls disappear from
+            // `cartog stats --savings`.
+            log_tool_query(&db, "cartog_stats");
             Ok(CallToolResult::success(vec![Content::text(json)]))
         })
         .await

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -181,12 +181,23 @@ pub enum Command {
     Hierarchy {
         /// Class name
         name: String,
+
+        /// Render the hierarchy as a Mermaid `graph TD` diagram instead of
+        /// plain text. Paste the output into any Mermaid renderer (GitHub,
+        /// mermaid.live, ...). Ignored when `--json` is also set.
+        #[arg(long)]
+        mermaid: bool,
     },
 
     /// File-level import dependencies
     Deps {
         /// File path
         file: String,
+
+        /// Render the imports as a Mermaid `graph LR` diagram instead of
+        /// plain text. Ignored when `--json` is also set.
+        #[arg(long)]
+        mermaid: bool,
     },
 
     /// Index statistics summary
@@ -262,6 +273,12 @@ pub enum Command {
         /// Approximate token budget for the output (default: 4000)
         #[arg(long, default_value = "4000")]
         tokens: u32,
+
+        /// Render the file tree as a Mermaid `graph TD` diagram instead of
+        /// indented text. Token budget still applies. Ignored when `--json`
+        /// is also set.
+        #[arg(long)]
+        mermaid: bool,
     },
 
     /// Show symbols affected by recent git changes

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -190,7 +190,18 @@ pub enum Command {
     },
 
     /// Index statistics summary
-    Stats,
+    Stats {
+        /// Show per-tool query counts and estimated tokens saved vs grep+read.
+        /// Reads the local query log; no network calls.
+        #[arg(long)]
+        savings: bool,
+    },
+
+    /// Per-tool query counts + estimated tokens saved.
+    ///
+    /// Alias for `cartog stats --savings`. Shipped as a top-level verb because
+    /// it's the retention hook — surfaces ongoing ROI in one keystroke.
+    Savings,
 
     /// Upload the local index to an S3-compatible remote (opt-in feature).
     ///

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -328,9 +328,8 @@ pub enum Command {
     /// OpenCode, Windsurf, Zed. User-scope clients whose config directory does not
     /// exist are skipped (not installed).
     ///
-    /// Aliased as `cartog install` for discoverability — both verbs run the same
-    /// handler.
-    #[command(visible_alias = "install")]
+    /// See also `cartog install <client>...` for a positional shorthand that
+    /// matches the brew/npm/pip convention.
     Ide {
         /// Target a single client. Default: configure all clients in scope.
         #[arg(long, value_enum)]
@@ -344,6 +343,34 @@ pub enum Command {
         /// Accept all prompts (non-interactive). Implied by --dry-run, --json, --client, or a non-TTY stdin.
         #[arg(long, short = 'y')]
         yes: bool,
+
+        /// Print planned changes without writing.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Omit `--watch` from Claude Code's serve args.
+        #[arg(long)]
+        no_watch: bool,
+    },
+
+    /// Install cartog MCP config into one or more editors.
+    ///
+    /// Friendlier shape of `cartog ide`: takes editors as positional arguments
+    /// (`cartog install cursor`, `cartog install cursor zed codex`) so it
+    /// matches the brew/npm/pip/cargo convention. No positional clients =
+    /// install into every detected editor non-interactively.
+    ///
+    /// Positional mode is always non-interactive (`--yes` implied). For the
+    /// interactive picker, use `cartog ide` directly.
+    Install {
+        /// One or more editors to wire up. Omit to install into every
+        /// detected editor non-interactively. Repeatable.
+        clients: Vec<ClientKind>,
+
+        /// Filter by scope. `project` writes only .mcp.json / .cursor/mcp.json;
+        /// `user` writes only user-scope configs; `all` writes both.
+        #[arg(long, value_enum, default_value_t = IdeScope::All)]
+        scope: IdeScope,
 
         /// Print planned changes without writing.
         #[arg(long)]

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -299,6 +299,10 @@ pub enum Command {
     /// Supports Claude Code, Claude Desktop, Cursor, VS Code, Codex CLI, Gemini CLI,
     /// OpenCode, Windsurf, Zed. User-scope clients whose config directory does not
     /// exist are skipped (not installed).
+    ///
+    /// Aliased as `cartog install` for discoverability — both verbs run the same
+    /// handler.
+    #[command(visible_alias = "install")]
     Ide {
         /// Target a single client. Default: configure all clients in scope.
         #[arg(long, value_enum)]

--- a/crates/cartog/src/commands/ide.rs
+++ b/crates/cartog/src/commands/ide.rs
@@ -718,6 +718,26 @@ pub fn cmd_ide(
     Ok(())
 }
 
+/// Strip duplicate `ClientKind`s from a positional argument list while
+/// preserving first-occurrence order. Returns `(unique, dropped)` so the
+/// caller can warn about the duplicates instead of silently swallowing them.
+/// Pulled out so cmd_install can call eprintln! while keeping the dedup
+/// logic itself unit-testable.
+fn dedupe_preserving_order(clients: Vec<ClientKind>) -> (Vec<ClientKind>, Vec<ClientKind>) {
+    // ClientKind isn't Hash and there are only 9 variants, so a linear
+    // membership check is cheaper than deriving Hash just for this.
+    let mut unique = Vec::with_capacity(clients.len());
+    let mut dropped = Vec::new();
+    for c in clients {
+        if unique.contains(&c) {
+            dropped.push(c);
+        } else {
+            unique.push(c);
+        }
+    }
+    (unique, dropped)
+}
+
 /// Filter the static `CLIENT_CATALOGUE` by a positional `clients` list and a
 /// scope. Returns `(ClientKind, Scope)` pairs in catalogue order. Pulled out
 /// of `cmd_install` so the selection logic is unit-testable without spinning
@@ -757,10 +777,36 @@ pub fn cmd_install(
         // exactly like `cartog ide --yes`. The picker is skipped (yes implied).
         run_ide(None, scope, false, dry_run, no_watch, &cwd, &homes)?
     } else {
+        // Dedupe so `cartog install cursor cursor` doesn't waste cycles; warn
+        // so a script bug that produces dupes is visible.
+        let (clients, duplicates) = dedupe_preserving_order(clients);
+        if !duplicates.is_empty() {
+            eprintln!(
+                "note: duplicate clients ignored: {}",
+                duplicates
+                    .iter()
+                    .map(|c| format!("{c:?}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
         // Build the (kind, scope) pairs from the catalogue, filtered by the
         // requested clients + scope. Reuses the picker's aggregation path so
         // multiple positional clients produce a single combined report.
         let chosen = filter_catalogue_by_clients(&clients, scope);
+        if chosen.is_empty() {
+            // User asked for clients that don't exist at the requested scope
+            // (e.g. `--scope project codex` — codex is user-only). Bail with
+            // an actionable error rather than silently printing "0 clients".
+            let requested: Vec<String> = clients.iter().map(|c| format!("{c:?}")).collect();
+            anyhow::bail!(
+                "no catalogue entries match clients={:?} at scope={:?}. \
+                 Try --scope all, or pick clients available at this scope.",
+                requested,
+                scope,
+            );
+        }
         run_ide_for_clients(&chosen, dry_run, no_watch, &cwd, &homes)?
     };
 
@@ -1650,6 +1696,53 @@ mod tests {
         // `run_ide(None, ...)`); the filter helper itself returns nothing.
         let chosen = filter_catalogue_by_clients(&[], IdeScope::All);
         assert!(chosen.is_empty());
+    }
+
+    #[test]
+    fn dedupe_drops_repeats_and_reports_them() {
+        let (unique, dropped) = dedupe_preserving_order(vec![
+            ClientKind::Cursor,
+            ClientKind::Vscode,
+            ClientKind::Cursor,
+            ClientKind::Cursor,
+            ClientKind::Codex,
+        ]);
+        assert_eq!(
+            unique,
+            vec![ClientKind::Cursor, ClientKind::Vscode, ClientKind::Codex]
+        );
+        assert_eq!(dropped, vec![ClientKind::Cursor, ClientKind::Cursor]);
+    }
+
+    #[test]
+    fn dedupe_preserves_first_occurrence_order() {
+        let (unique, dropped) = dedupe_preserving_order(vec![
+            ClientKind::Vscode,
+            ClientKind::Cursor,
+            ClientKind::Vscode,
+        ]);
+        assert_eq!(unique, vec![ClientKind::Vscode, ClientKind::Cursor]);
+        assert_eq!(dropped, vec![ClientKind::Vscode]);
+    }
+
+    #[test]
+    fn dedupe_empty_input_returns_two_empty_vecs() {
+        let (unique, dropped) = dedupe_preserving_order(Vec::new());
+        assert!(unique.is_empty());
+        assert!(dropped.is_empty());
+    }
+
+    #[test]
+    fn install_filter_user_only_client_at_project_scope_yields_empty() {
+        // Reproduces the F2 review finding: `cartog install --scope project codex`
+        // would silently succeed with "0 clients" before the bail was added.
+        // Codex is user-only, so the filter yields an empty vec — cmd_install
+        // bails with an error message instead of running.
+        let chosen = filter_catalogue_by_clients(&[ClientKind::Codex], IdeScope::Project);
+        assert!(
+            chosen.is_empty(),
+            "codex has no Project entry in the catalogue"
+        );
     }
 
     #[test]

--- a/crates/cartog/src/commands/ide.rs
+++ b/crates/cartog/src/commands/ide.rs
@@ -718,6 +718,65 @@ pub fn cmd_ide(
     Ok(())
 }
 
+/// Filter the static `CLIENT_CATALOGUE` by a positional `clients` list and a
+/// scope. Returns `(ClientKind, Scope)` pairs in catalogue order. Pulled out
+/// of `cmd_install` so the selection logic is unit-testable without spinning
+/// up the filesystem-touching dispatch.
+fn filter_catalogue_by_clients(
+    clients: &[ClientKind],
+    scope: IdeScope,
+) -> Vec<(ClientKind, Scope)> {
+    CLIENT_CATALOGUE
+        .iter()
+        .filter(|e| match scope {
+            IdeScope::Project => e.scope == Scope::Project,
+            IdeScope::User => e.scope == Scope::User,
+            IdeScope::All => true,
+        })
+        .filter(|e| clients.contains(&e.kind))
+        .map(|e| (e.kind, e.scope))
+        .collect()
+}
+
+/// `cartog install [client ...]` — friendlier shape of `cmd_ide` that takes
+/// editors as positional args (matches brew/npm/pip convention). Always
+/// non-interactive. Empty `clients` = install into every detected editor in
+/// scope. Multiple positional clients = install each.
+pub fn cmd_install(
+    clients: Vec<ClientKind>,
+    scope: IdeScope,
+    dry_run: bool,
+    no_watch: bool,
+    json: bool,
+) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let homes = HomeDirs::detect();
+
+    let report = if clients.is_empty() {
+        // No positional clients → install into every detected editor in scope,
+        // exactly like `cartog ide --yes`. The picker is skipped (yes implied).
+        run_ide(None, scope, false, dry_run, no_watch, &cwd, &homes)?
+    } else {
+        // Build the (kind, scope) pairs from the catalogue, filtered by the
+        // requested clients + scope. Reuses the picker's aggregation path so
+        // multiple positional clients produce a single combined report.
+        let chosen = filter_catalogue_by_clients(&clients, scope);
+        run_ide_for_clients(&chosen, dry_run, no_watch, &cwd, &homes)?
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report.render_human());
+        print_next_steps(&report, dry_run);
+    }
+
+    if report.has_errors() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 /// Per-scope detection state, attached to a `PickerItem`.
 #[derive(Debug, Clone)]
 pub struct ScopeOption {
@@ -1536,6 +1595,61 @@ mod tests {
         let specs = build_specs(Some(ClientKind::Cursor), IdeScope::All, false, &tmp, &homes);
         assert_eq!(specs.len(), 1);
         assert_eq!(specs[0].kind, ClientKind::Cursor);
+    }
+
+    // ── cartog install positional dispatch ─────────────────────────────
+
+    #[test]
+    fn install_filter_single_client_returns_only_that_kind() {
+        let chosen = filter_catalogue_by_clients(&[ClientKind::Cursor], IdeScope::All);
+        assert_eq!(chosen.len(), 1);
+        assert_eq!(chosen[0].0, ClientKind::Cursor);
+    }
+
+    #[test]
+    fn install_filter_multiple_clients_returns_each_in_catalogue_order() {
+        let chosen = filter_catalogue_by_clients(
+            &[ClientKind::Cursor, ClientKind::Vscode, ClientKind::Codex],
+            IdeScope::All,
+        );
+        // All three requested clients are present.
+        let kinds: Vec<_> = chosen.iter().map(|(k, _)| *k).collect();
+        assert!(kinds.contains(&ClientKind::Cursor));
+        assert!(kinds.contains(&ClientKind::Vscode));
+        assert!(kinds.contains(&ClientKind::Codex));
+        assert_eq!(chosen.len(), 3);
+    }
+
+    #[test]
+    fn install_filter_claude_code_returns_both_project_and_user_scopes() {
+        let chosen = filter_catalogue_by_clients(&[ClientKind::ClaudeCode], IdeScope::All);
+        // Claude Code is the only client with both Project and User entries
+        // in CLIENT_CATALOGUE — `cartog install claude-code` must wire both.
+        assert_eq!(chosen.len(), 2);
+        let scopes: Vec<_> = chosen.iter().map(|(_, s)| *s).collect();
+        assert!(scopes.contains(&Scope::Project));
+        assert!(scopes.contains(&Scope::User));
+    }
+
+    #[test]
+    fn install_filter_respects_project_scope() {
+        // Cursor exists only at project scope; codex only at user scope.
+        // --scope project must drop the user-only entry.
+        let chosen = filter_catalogue_by_clients(
+            &[ClientKind::Cursor, ClientKind::Codex],
+            IdeScope::Project,
+        );
+        assert_eq!(chosen.len(), 1);
+        assert_eq!(chosen[0].0, ClientKind::Cursor);
+        assert_eq!(chosen[0].1, Scope::Project);
+    }
+
+    #[test]
+    fn install_filter_empty_clients_returns_empty() {
+        // Empty positional list is handled by the caller (falls back to
+        // `run_ide(None, ...)`); the filter helper itself returns nothing.
+        let chosen = filter_catalogue_by_clients(&[], IdeScope::All);
+        assert!(chosen.is_empty());
     }
 
     #[test]

--- a/crates/cartog/src/commands/mermaid.rs
+++ b/crates/cartog/src/commands/mermaid.rs
@@ -1,0 +1,176 @@
+//! Mermaid diagram renderers for the navigation commands that support the
+//! `--mermaid` flag: `hierarchy`, `deps`, and `map`.
+//!
+//! Output is plain `graph TD` / `graph LR` syntax that pastes into any
+//! Mermaid renderer (GitHub markdown, mermaid.live, docs sites). No external
+//! crate — Mermaid's surface is small enough that a couple hundred lines of
+//! string concatenation is cheaper than a dependency.
+
+/// Mermaid node IDs are restricted to `[A-Za-z0-9_]`. Anything else (dots,
+/// slashes, dashes, generics) breaks the parser. Replace each disallowed
+/// byte with `_`; collapse runs of underscores so paths like `foo/bar.py`
+/// don't produce `foo_bar_py` with double underscores in some renderers.
+///
+/// IDs that would start with a digit get a leading `n_` so they remain
+/// valid identifiers.
+pub fn sanitize_id(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut last_underscore = false;
+    for ch in raw.chars() {
+        let safe = ch.is_ascii_alphanumeric() || ch == '_';
+        if safe {
+            out.push(ch);
+            last_underscore = ch == '_';
+        } else if !last_underscore {
+            out.push('_');
+            last_underscore = true;
+        }
+    }
+    // Trim leading and trailing `_` (cosmetic), and guard the digit-prefix case.
+    while out.ends_with('_') {
+        out.pop();
+    }
+    while out.starts_with('_') {
+        out.remove(0);
+    }
+    if out.is_empty() {
+        return "n".into();
+    }
+    if out.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        out.insert_str(0, "n_");
+    }
+    out
+}
+
+/// Escape a string for use inside a Mermaid node label `["..."]`. Double
+/// quotes are the only character that must be escaped; Mermaid treats `\"`
+/// as a literal quote.
+pub fn escape_label(raw: &str) -> String {
+    raw.replace('"', "\\\"")
+}
+
+/// Render a hierarchy as `graph TD`, one `child --> parent` edge per pair.
+/// Empty input yields the bare header so the output is always a valid
+/// Mermaid document.
+pub fn render_hierarchy(pairs: &[(String, String)]) -> String {
+    let mut out = String::from("graph TD\n");
+    if pairs.is_empty() {
+        return out;
+    }
+    for (child, parent) in pairs {
+        out.push_str(&format!(
+            "    {}[\"{}\"] --> {}[\"{}\"]\n",
+            sanitize_id(child),
+            escape_label(child),
+            sanitize_id(parent),
+            escape_label(parent),
+        ));
+    }
+    out
+}
+
+/// Render file-level imports as `graph LR`. The file is the root; each
+/// imported symbol is a target node. Multiple imports from the same file
+/// stay distinct nodes (Mermaid dedupes by ID).
+pub fn render_deps(file: &str, targets: &[(String, u32)]) -> String {
+    let mut out = String::from("graph LR\n");
+    let file_id = sanitize_id(file);
+    out.push_str(&format!("    {file_id}[\"{}\"]\n", escape_label(file)));
+    for (target, line) in targets {
+        out.push_str(&format!(
+            "    {file_id} --> {}[\"{} (L{line})\"]\n",
+            sanitize_id(target),
+            escape_label(target),
+        ));
+    }
+    out
+}
+
+/// Render a flat file list as a Mermaid `graph TD` rooted at "Repo".
+/// Useful for `cartog map --mermaid`. Top symbols (per-file) are rendered
+/// as leaf nodes under each file when supplied.
+///
+/// `files`: ordered file paths.
+/// `symbols_by_file`: optional per-file `(name, kind)` leaf annotations.
+///   Empty / missing entries are skipped.
+pub fn render_map(files: &[String], symbols_by_file: &[(String, Vec<(String, String)>)]) -> String {
+    let mut out = String::from("graph TD\n    repo[\"Repo\"]\n");
+    for file in files {
+        let fid = sanitize_id(file);
+        out.push_str(&format!("    repo --> {fid}[\"{}\"]\n", escape_label(file)));
+    }
+    for (file, syms) in symbols_by_file {
+        let fid = sanitize_id(file);
+        for (name, kind) in syms {
+            // Combine file + symbol into a unique sym ID so the same name in
+            // different files doesn't collide.
+            let sid = sanitize_id(&format!("{file}::{name}"));
+            out.push_str(&format!(
+                "    {fid} --> {sid}[\"{} ({})\"]\n",
+                escape_label(name),
+                escape_label(kind),
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_punctuation_and_collapses_runs() {
+        assert_eq!(sanitize_id("foo/bar.py"), "foo_bar_py");
+        assert_eq!(sanitize_id("AuthService"), "AuthService");
+        assert_eq!(sanitize_id("123abc"), "n_123abc");
+        assert_eq!(sanitize_id("--weird--"), "weird");
+        assert_eq!(sanitize_id(""), "n");
+        assert_eq!(sanitize_id("..."), "n");
+    }
+
+    #[test]
+    fn escape_label_doubles_internal_quotes() {
+        assert_eq!(escape_label(r#"foo"bar"#), r#"foo\"bar"#);
+    }
+
+    #[test]
+    fn render_hierarchy_emits_header_and_edges() {
+        let pairs = vec![
+            ("AdminService".into(), "AuthService".into()),
+            ("AuthService".into(), "BaseService".into()),
+        ];
+        let out = render_hierarchy(&pairs);
+        assert!(out.starts_with("graph TD\n"));
+        assert!(out.contains("AdminService[\"AdminService\"] --> AuthService[\"AuthService\"]"));
+        assert!(out.contains("AuthService[\"AuthService\"] --> BaseService[\"BaseService\"]"));
+    }
+
+    #[test]
+    fn render_hierarchy_empty_still_valid_mermaid() {
+        let out = render_hierarchy(&[]);
+        assert_eq!(out, "graph TD\n");
+    }
+
+    #[test]
+    fn render_deps_roots_at_file_with_imports_as_leaves() {
+        let out = render_deps("auth/service.py", &[("validate_token".into(), 5)]);
+        assert!(out.starts_with("graph LR\n"));
+        assert!(out.contains("auth_service_py[\"auth/service.py\"]"));
+        assert!(out.contains("validate_token[\"validate_token (L5)\"]"));
+    }
+
+    #[test]
+    fn render_map_roots_at_repo_and_attaches_symbols() {
+        let files = vec!["src/auth.py".to_string()];
+        let syms = vec![(
+            "src/auth.py".to_string(),
+            vec![("login".to_string(), "function".to_string())],
+        )];
+        let out = render_map(&files, &syms);
+        assert!(out.starts_with("graph TD\n    repo[\"Repo\"]\n"));
+        assert!(out.contains("repo --> src_auth_py[\"src/auth.py\"]"));
+        // Symbol leaf uses a `file::name` sanitized ID to avoid collisions.
+        assert!(out.contains("[\"login (function)\"]"));
+    }
+}

--- a/crates/cartog/src/commands/mermaid.rs
+++ b/crates/cartog/src/commands/mermaid.rs
@@ -9,10 +9,15 @@
 /// Mermaid node IDs are restricted to `[A-Za-z0-9_]`. Anything else (dots,
 /// slashes, dashes, generics) breaks the parser. Replace each disallowed
 /// byte with `_`; collapse runs of underscores so paths like `foo/bar.py`
-/// don't produce `foo_bar_py` with double underscores in some renderers.
+/// don't produce `foo__bar__py` with double underscores in some renderers.
 ///
 /// IDs that would start with a digit get a leading `n_` so they remain
 /// valid identifiers.
+///
+/// NOTE: this function is intentionally lossy — `foo/bar.py` and `foo_bar.py`
+/// both yield `foo_bar_py`. Callers that need stable, collision-free IDs
+/// across distinct inputs must prefix with a namespace (e.g. `f_`, `s_`) and
+/// hash the full input. See [`render_map`] / [`render_deps`] for the pattern.
 pub fn sanitize_id(raw: &str) -> String {
     let mut out = String::with_capacity(raw.len());
     let mut last_underscore = false;
@@ -42,27 +47,79 @@ pub fn sanitize_id(raw: &str) -> String {
     out
 }
 
-/// Escape a string for use inside a Mermaid node label `["..."]`. Double
-/// quotes are the only character that must be escaped; Mermaid treats `\"`
-/// as a literal quote.
+/// Short stable hash suffix used to disambiguate sanitized IDs that would
+/// otherwise collide (`foo/bar.py` vs `foo_bar.py`). 8 hex chars of FNV-1a
+/// keeps IDs readable and gives 32 bits of collision-resistance — more than
+/// enough for a single diagram's worth of nodes. Avoids pulling in a real
+/// hash dependency.
+fn short_hash(raw: &str) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in raw.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{:08x}", h as u32 ^ (h >> 32) as u32)
+}
+
+/// Build a collision-free node ID by combining a namespace prefix, a
+/// sanitized form of the input, and an 8-hex hash suffix derived from the
+/// raw input. Two distinct raw strings can collide on `sanitize_id` alone,
+/// but adding the hash makes the chance ~1/2^32. The sanitized portion keeps
+/// the ID human-readable in the rendered diagram.
+fn namespaced_id(prefix: &str, raw: &str) -> String {
+    let sane = sanitize_id(raw);
+    format!("{prefix}_{sane}_{}", short_hash(raw))
+}
+
+/// Escape a string for use inside a Mermaid node label `["..."]`. Mermaid
+/// renders labels through DOMPurify by default (`securityLevel: strict`), so
+/// `<`, `>`, and `&` must be HTML-entity-encoded or they get stripped /
+/// reinterpreted as HTML tags. Double quotes also have to be escaped so they
+/// don't terminate the label string. Anything else (brackets, pipes, hashes)
+/// passes through the parser intact.
 pub fn escape_label(raw: &str) -> String {
-    raw.replace('"', "\\\"")
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            '"' => out.push_str("&quot;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 /// Render a hierarchy as `graph TD`, one `child --> parent` edge per pair.
+/// Duplicate pairs (the same class appearing in multiple language fixtures of
+/// a polyglot repo, for example) are emitted once.
+///
 /// Empty input yields the bare header so the output is always a valid
-/// Mermaid document.
+/// Mermaid document; the caller is responsible for surfacing user-facing
+/// "no results" messages on stderr.
 pub fn render_hierarchy(pairs: &[(String, String)]) -> String {
     let mut out = String::from("graph TD\n");
     if pairs.is_empty() {
         return out;
     }
+    let mut seen = std::collections::HashSet::with_capacity(pairs.len());
     for (child, parent) in pairs {
+        // Dedup by the actual edge endpoints, not by string equality of the
+        // tuple — two pairs of the same names yield the same edge.
+        let key = (child.as_str(), parent.as_str());
+        if !seen.insert(key) {
+            continue;
+        }
+        // Class hierarchies are name-based and language-agnostic, so a bare
+        // sanitize_id is acceptable here (no path component to disambiguate).
+        // If two distinct classes ever produced the same sanitized name, they
+        // would also collapse in the plain text output — diagram parity.
+        let child_id = sanitize_id(child);
+        let parent_id = sanitize_id(parent);
         out.push_str(&format!(
-            "    {}[\"{}\"] --> {}[\"{}\"]\n",
-            sanitize_id(child),
+            "    {child_id}[\"{}\"] --> {parent_id}[\"{}\"]\n",
             escape_label(child),
-            sanitize_id(parent),
             escape_label(parent),
         ));
     }
@@ -70,16 +127,22 @@ pub fn render_hierarchy(pairs: &[(String, String)]) -> String {
 }
 
 /// Render file-level imports as `graph LR`. The file is the root; each
-/// imported symbol is a target node. Multiple imports from the same file
-/// stay distinct nodes (Mermaid dedupes by ID).
+/// imported symbol is a target node with a `(Lline)` annotation.
+///
+/// Each emitted target is given a per-edge unique ID (`t_<sanitized>_<hash>`)
+/// so multiple imports of the same target name (e.g. two `validate_token`
+/// imports from different modules at different lines) render as distinct
+/// nodes rather than collapsing into one.
 pub fn render_deps(file: &str, targets: &[(String, u32)]) -> String {
     let mut out = String::from("graph LR\n");
-    let file_id = sanitize_id(file);
+    let file_id = namespaced_id("f", file);
     out.push_str(&format!("    {file_id}[\"{}\"]\n", escape_label(file)));
     for (target, line) in targets {
+        // Include line in the hash key so two imports of the same name from
+        // different lines get distinct IDs.
+        let target_id = namespaced_id("t", &format!("{file}::{target}::L{line}"));
         out.push_str(&format!(
-            "    {file_id} --> {}[\"{} (L{line})\"]\n",
-            sanitize_id(target),
+            "    {file_id} --> {target_id}[\"{} (L{line})\"]\n",
             escape_label(target),
         ));
     }
@@ -90,21 +153,23 @@ pub fn render_deps(file: &str, targets: &[(String, u32)]) -> String {
 /// Useful for `cartog map --mermaid`. Top symbols (per-file) are rendered
 /// as leaf nodes under each file when supplied.
 ///
+/// File and symbol node IDs are namespaced + hashed so distinct paths like
+/// `foo/bar.py` and `foo_bar.py` (which sanitize to the same `foo_bar_py`)
+/// render as separate nodes.
+///
 /// `files`: ordered file paths.
 /// `symbols_by_file`: optional per-file `(name, kind)` leaf annotations.
 ///   Empty / missing entries are skipped.
 pub fn render_map(files: &[String], symbols_by_file: &[(String, Vec<(String, String)>)]) -> String {
     let mut out = String::from("graph TD\n    repo[\"Repo\"]\n");
     for file in files {
-        let fid = sanitize_id(file);
+        let fid = namespaced_id("f", file);
         out.push_str(&format!("    repo --> {fid}[\"{}\"]\n", escape_label(file)));
     }
     for (file, syms) in symbols_by_file {
-        let fid = sanitize_id(file);
+        let fid = namespaced_id("f", file);
         for (name, kind) in syms {
-            // Combine file + symbol into a unique sym ID so the same name in
-            // different files doesn't collide.
-            let sid = sanitize_id(&format!("{file}::{name}"));
+            let sid = namespaced_id("s", &format!("{file}::{name}"));
             out.push_str(&format!(
                 "    {fid} --> {sid}[\"{} ({})\"]\n",
                 escape_label(name),
@@ -130,8 +195,26 @@ mod tests {
     }
 
     #[test]
-    fn escape_label_doubles_internal_quotes() {
-        assert_eq!(escape_label(r#"foo"bar"#), r#"foo\"bar"#);
+    fn namespaced_id_distinguishes_inputs_that_sanitize_to_same_string() {
+        // The bug this fixes: foo/bar.py and foo_bar.py sanitize to the same
+        // id but represent different files in the file tree.
+        let a = namespaced_id("f", "foo/bar.py");
+        let b = namespaced_id("f", "foo_bar.py");
+        assert_ne!(a, b, "distinct paths must produce distinct namespaced IDs");
+        assert!(a.starts_with("f_foo_bar_py_"));
+        assert!(b.starts_with("f_foo_bar_py_"));
+    }
+
+    #[test]
+    fn escape_label_entity_encodes_mermaid_breakers() {
+        assert_eq!(escape_label(r#"foo"bar"#), "foo&quot;bar");
+        assert_eq!(escape_label("Vec<T>"), "Vec&lt;T&gt;");
+        assert_eq!(escape_label("Result<T, E>"), "Result&lt;T, E&gt;");
+        assert_eq!(escape_label("A & B"), "A &amp; B");
+        // Brackets, pipes, hashes pass through (Mermaid accepts them inside
+        // quoted labels).
+        assert_eq!(escape_label("Dict[str, int]"), "Dict[str, int]");
+        assert_eq!(escape_label("A|B"), "A|B");
     }
 
     #[test]
@@ -147,6 +230,19 @@ mod tests {
     }
 
     #[test]
+    fn render_hierarchy_deduplicates_identical_pairs() {
+        // Polyglot fixture: AuthService -> BaseService appears in py, ts, rs.
+        let pairs = vec![
+            ("AuthService".into(), "BaseService".into()),
+            ("AuthService".into(), "BaseService".into()),
+            ("AuthService".into(), "BaseService".into()),
+        ];
+        let out = render_hierarchy(&pairs);
+        let edges = out.matches("AuthService[\"AuthService\"]").count();
+        assert_eq!(edges, 1, "duplicate pairs must emit one edge: {out}");
+    }
+
+    #[test]
     fn render_hierarchy_empty_still_valid_mermaid() {
         let out = render_hierarchy(&[]);
         assert_eq!(out, "graph TD\n");
@@ -156,8 +252,29 @@ mod tests {
     fn render_deps_roots_at_file_with_imports_as_leaves() {
         let out = render_deps("auth/service.py", &[("validate_token".into(), 5)]);
         assert!(out.starts_with("graph LR\n"));
-        assert!(out.contains("auth_service_py[\"auth/service.py\"]"));
-        assert!(out.contains("validate_token[\"validate_token (L5)\"]"));
+        assert!(out.contains("[\"auth/service.py\"]"));
+        assert!(out.contains("[\"validate_token (L5)\"]"));
+    }
+
+    #[test]
+    fn render_deps_preserves_duplicate_target_names_as_distinct_nodes() {
+        // Two imports of the same name at different lines: previously they
+        // collided on the same Mermaid node ID and the L5 label was lost.
+        let out = render_deps(
+            "a.py",
+            &[("validate_token".into(), 5), ("validate_token".into(), 12)],
+        );
+        assert!(
+            out.contains("[\"validate_token (L5)\"]"),
+            "L5 label must survive: {out}"
+        );
+        assert!(
+            out.contains("[\"validate_token (L12)\"]"),
+            "L12 label must survive: {out}"
+        );
+        // Both edges should be present (different target IDs).
+        let edge_lines = out.lines().filter(|l| l.contains(" --> ")).count();
+        assert_eq!(edge_lines, 2, "two distinct edges expected: {out}");
     }
 
     #[test]
@@ -169,8 +286,19 @@ mod tests {
         )];
         let out = render_map(&files, &syms);
         assert!(out.starts_with("graph TD\n    repo[\"Repo\"]\n"));
-        assert!(out.contains("repo --> src_auth_py[\"src/auth.py\"]"));
-        // Symbol leaf uses a `file::name` sanitized ID to avoid collisions.
+        assert!(out.contains("[\"src/auth.py\"]"));
         assert!(out.contains("[\"login (function)\"]"));
+    }
+
+    #[test]
+    fn render_map_distinguishes_files_that_sanitize_to_the_same_id() {
+        let files = vec!["foo/bar.py".to_string(), "foo_bar.py".to_string()];
+        let out = render_map(&files, &[]);
+        // Both files must appear with their own labels.
+        assert!(out.contains("[\"foo/bar.py\"]"));
+        assert!(out.contains("[\"foo_bar.py\"]"));
+        // Two distinct edges from repo.
+        let edges = out.lines().filter(|l| l.contains("repo --> ")).count();
+        assert_eq!(edges, 2, "two distinct file edges expected: {out}");
     }
 }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -17,6 +17,7 @@ use cartog_watch::{self as watch, WatchConfig};
 
 pub mod ide;
 pub mod init;
+pub mod mermaid;
 pub mod remote;
 
 /// Stderr progress reporter for long-running CLI commands.
@@ -547,6 +548,7 @@ pub fn cmd_hierarchy(
     db_path: &Path,
     name: &str,
     json: bool,
+    mermaid: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -554,6 +556,12 @@ pub fn cmd_hierarchy(
     let pairs = db.hierarchy(name)?;
     db.log_query("hierarchy", "cli");
     let name = name.to_string();
+
+    // --json wins if both flags are set (matches the documented behavior).
+    if mermaid && !json {
+        print!("{}", mermaid::render_hierarchy(&pairs));
+        return Ok(());
+    }
 
     #[derive(Serialize)]
     struct HierarchyEntry {
@@ -587,6 +595,7 @@ pub fn cmd_deps(
     db_path: &Path,
     file: &str,
     json: bool,
+    mermaid: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -594,6 +603,15 @@ pub fn cmd_deps(
     let edges = db.file_deps(file)?;
     db.log_query("deps", "cli");
     let file = file.to_string();
+
+    if mermaid && !json {
+        let targets: Vec<(String, u32)> = edges
+            .iter()
+            .map(|e| (e.target_name.clone(), e.line))
+            .collect();
+        print!("{}", mermaid::render_deps(&file, &targets));
+        return Ok(());
+    }
 
     output(&edges, json, token_budget, |edges| {
         if edges.is_empty() {
@@ -749,7 +767,13 @@ pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize, savings: bool
 }
 
 /// Token-budget-aware codebase summary: file tree + top symbols ranked by centrality.
-pub fn cmd_map(db_path: &Path, tokens: u32, json: bool, embedding_dim: usize) -> Result<()> {
+pub fn cmd_map(
+    db_path: &Path,
+    tokens: u32,
+    json: bool,
+    mermaid: bool,
+    embedding_dim: usize,
+) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let files = db.all_files()?;
     db.log_query("map", "cli");
@@ -757,9 +781,49 @@ pub fn cmd_map(db_path: &Path, tokens: u32, json: bool, embedding_dim: usize) ->
     if files.is_empty() {
         if json {
             println!("{{}}");
+        } else if mermaid {
+            println!("graph TD\n    repo[\"Repo (empty)\"]");
         } else {
             println!("No files indexed. Run 'cartog index .' first.");
         }
+        return Ok(());
+    }
+
+    if mermaid && !json {
+        // Honor the token budget by walking files until we exhaust it. Each
+        // file edge costs roughly its path length + ~20 bytes of overhead.
+        let budget_bytes = (tokens as usize) * 4;
+        let mut included_files: Vec<String> = Vec::new();
+        let mut size = "graph TD\n    repo[\"Repo\"]\n".len();
+        for f in &files {
+            let edge_cost = f.len() * 2 + 30; // path appears twice (id + label)
+            if size + edge_cost > budget_bytes && !included_files.is_empty() {
+                break;
+            }
+            size += edge_cost;
+            included_files.push(f.clone());
+        }
+        // Add top symbols per file until budget runs out.
+        let symbols = db.top_symbols(500)?;
+        let mut symbols_by_file: std::collections::BTreeMap<String, Vec<(String, String)>> =
+            std::collections::BTreeMap::new();
+        for sym in symbols {
+            if !included_files.contains(&sym.file_path) {
+                continue;
+            }
+            let leaf_cost = sym.name.len() * 2 + 40;
+            if size + leaf_cost > budget_bytes {
+                break;
+            }
+            size += leaf_cost;
+            symbols_by_file
+                .entry(sym.file_path.clone())
+                .or_default()
+                .push((sym.name.clone(), sym.kind.to_string()));
+        }
+        let symbols_vec: Vec<(String, Vec<(String, String)>)> =
+            symbols_by_file.into_iter().collect();
+        print!("{}", mermaid::render_map(&included_files, &symbols_vec));
         return Ok(());
     }
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -377,6 +377,7 @@ pub fn cmd_outline(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let symbols = db.outline(file)?;
+    db.log_query("outline", "cli");
     let file = file.to_string();
     output(&symbols, json, token_budget, |syms| {
         if syms.is_empty() {
@@ -417,6 +418,7 @@ pub fn cmd_callees(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let edges = db.callees(name)?;
+    db.log_query("callees", "cli");
     let name = name.to_string();
     output(&edges, json, token_budget, |edges| {
         if edges.is_empty() {
@@ -450,6 +452,7 @@ pub fn cmd_impact(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let results = db.impact(name, depth)?;
+    db.log_query("impact", "cli");
     let name = name.to_string();
 
     #[derive(Serialize)]
@@ -498,6 +501,7 @@ pub fn cmd_refs(
     let db = open_db(db_path, embedding_dim)?;
     let kind_filter = kind.map(EdgeKind::from);
     let results = db.refs(name, kind_filter)?;
+    db.log_query("refs", "cli");
     let name = name.to_string();
 
     #[derive(Serialize)]
@@ -548,6 +552,7 @@ pub fn cmd_hierarchy(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let pairs = db.hierarchy(name)?;
+    db.log_query("hierarchy", "cli");
     let name = name.to_string();
 
     #[derive(Serialize)]
@@ -587,6 +592,7 @@ pub fn cmd_deps(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let edges = db.file_deps(file)?;
+    db.log_query("deps", "cli");
     let file = file.to_string();
 
     output(&edges, json, token_budget, |edges| {
@@ -627,6 +633,7 @@ pub fn cmd_search(
     };
     let limit = limit.min(MAX_SEARCH_LIMIT);
     let symbols = db.search(query, kind_filter, file, limit)?;
+    db.log_query("search", "cli");
     let query = query.to_string();
 
     output(&symbols, json, token_budget, |syms| {
@@ -673,10 +680,39 @@ pub fn cmd_pull(
 }
 
 /// Index statistics summary.
-pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize) -> Result<()> {
+pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize, savings: bool) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
-    let stats = db.stats()?;
 
+    if savings {
+        let report = db.savings_breakdown()?;
+        return output(&report, json, None, |r| {
+            let mut out = String::new();
+            if r.total_queries == 0 {
+                out.push_str(
+                    "No queries logged yet. Run `cartog search`, `cartog refs`, … or \
+                     point an MCP-aware editor at this index, then re-run.\n",
+                );
+                return out;
+            }
+            out.push_str(&format!(
+                "Total queries: {}  (~{} tokens saved vs grep+read baseline, at {} tokens/query)\n\n",
+                r.total_queries, r.estimated_tokens_saved, r.baseline_delta
+            ));
+            out.push_str("By tool:\n");
+            for (tool, count) in &r.by_tool {
+                out.push_str(&format!("  {count:>6}  {tool}\n"));
+            }
+            if r.by_source.len() > 1 {
+                out.push_str("\nBy source:\n");
+                for (source, count) in &r.by_source {
+                    out.push_str(&format!("  {count:>6}  {source}\n"));
+                }
+            }
+            out
+        });
+    }
+
+    let stats = db.stats()?;
     output(&stats, json, None, |stats| {
         let mut out = String::new();
         out.push_str(&format!("Files:    {}\n", stats.num_files));
@@ -716,6 +752,7 @@ pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize) -> Result<()>
 pub fn cmd_map(db_path: &Path, tokens: u32, json: bool, embedding_dim: usize) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let files = db.all_files()?;
+    db.log_query("map", "cli");
 
     if files.is_empty() {
         if json {
@@ -812,6 +849,7 @@ pub fn cmd_changes(
     embedding_dim: usize,
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
+    db.log_query("changes", "cli");
     let root = std::env::current_dir()?;
 
     let changed_files = indexer::git_recently_changed_files(&root, commits)?;
@@ -1014,6 +1052,7 @@ pub fn cmd_rag_search(
         reranker_factory,
         tuning,
     )?;
+    db.log_query("rag_search", "cli");
     let query = query.to_string();
 
     output(&search_result, json, token_budget, |sr| {

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -378,7 +378,11 @@ pub fn cmd_outline(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let symbols = db.outline(file)?;
-    db.log_query("outline", "cli");
+    // Don't count empty results — an empty-index call or a typo'd file path
+    // didn't actually save the user any tokens vs grep + read.
+    if !symbols.is_empty() {
+        db.log_query("outline", "cli");
+    }
     let file = file.to_string();
     output(&symbols, json, token_budget, |syms| {
         if syms.is_empty() {
@@ -419,7 +423,9 @@ pub fn cmd_callees(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let edges = db.callees(name)?;
-    db.log_query("callees", "cli");
+    if !edges.is_empty() {
+        db.log_query("callees", "cli");
+    }
     let name = name.to_string();
     output(&edges, json, token_budget, |edges| {
         if edges.is_empty() {
@@ -453,7 +459,9 @@ pub fn cmd_impact(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let results = db.impact(name, depth)?;
-    db.log_query("impact", "cli");
+    if !results.is_empty() {
+        db.log_query("impact", "cli");
+    }
     let name = name.to_string();
 
     #[derive(Serialize)]
@@ -502,7 +510,9 @@ pub fn cmd_refs(
     let db = open_db(db_path, embedding_dim)?;
     let kind_filter = kind.map(EdgeKind::from);
     let results = db.refs(name, kind_filter)?;
-    db.log_query("refs", "cli");
+    if !results.is_empty() {
+        db.log_query("refs", "cli");
+    }
     let name = name.to_string();
 
     #[derive(Serialize)]
@@ -554,7 +564,9 @@ pub fn cmd_hierarchy(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let pairs = db.hierarchy(name)?;
-    db.log_query("hierarchy", "cli");
+    if !pairs.is_empty() {
+        db.log_query("hierarchy", "cli");
+    }
     let name = name.to_string();
 
     // --json wins if both flags are set (matches the documented behavior).
@@ -611,7 +623,9 @@ pub fn cmd_deps(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let edges = db.file_deps(file)?;
-    db.log_query("deps", "cli");
+    if !edges.is_empty() {
+        db.log_query("deps", "cli");
+    }
     let file = file.to_string();
 
     if mermaid && !json {
@@ -669,7 +683,9 @@ pub fn cmd_search(
     };
     let limit = limit.min(MAX_SEARCH_LIMIT);
     let symbols = db.search(query, kind_filter, file, limit)?;
-    db.log_query("search", "cli");
+    if !symbols.is_empty() {
+        db.log_query("search", "cli");
+    }
     let query = query.to_string();
 
     output(&symbols, json, token_budget, |syms| {

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -731,6 +731,111 @@ pub fn cmd_pull(
     remote::pull_index(db_path, config, cli_remote, force, no_sign_request, json)
 }
 
+/// Project label shown above the savings report. Strips the SQLite filename
+/// and walks up to the closest meaningful directory (typically the git root)
+/// so users see `cartog · my-project · 5 queries` rather than the full path.
+/// Falls back to `cartog` when nothing recognizable can be extracted.
+fn savings_scope_label(db_path: &Path) -> String {
+    db_path
+        .parent()
+        .and_then(|p| {
+            // `.../<project>/.cartog/db.sqlite` → walk past `.cartog` to the
+            // project dir. `.../<project>/.cartog.db` → just take the parent.
+            if p.file_name().is_some_and(|n| n == ".cartog") {
+                p.parent()
+            } else {
+                Some(p)
+            }
+        })
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(|n| n.to_string())
+        .unwrap_or_default()
+}
+
+/// Format a token count as `~1.4k`, `~28.5k`, etc. Matches the CCE-style
+/// compact display so the table stays narrow. Counts under 1,000 render as
+/// the raw integer.
+fn fmt_tokens(n: u64) -> String {
+    if n < 1_000 {
+        format!("{n}")
+    } else if n < 1_000_000 {
+        format!("~{:.1}k", n as f64 / 1_000.0)
+    } else {
+        format!("~{:.1}M", n as f64 / 1_000_000.0)
+    }
+}
+
+/// Render the savings report — header / bar / with-vs-without table / per-tool
+/// breakdown / footer. Pulled out of `cmd_stats` so the formatter is unit-
+/// testable independent of the DB.
+fn render_savings(scope: &str, r: &cartog_db::SavingsReport) -> String {
+    use cartog_db::{TOKENS_PER_QUERY_CARTOG, TOKENS_PER_QUERY_GREP};
+
+    let mut out = String::new();
+    if r.total_queries == 0 {
+        out.push_str(
+            "No queries logged yet. Run `cartog search`, `cartog refs`, … or \
+             point an MCP-aware editor at this index, then re-run.\n",
+        );
+        return out;
+    }
+
+    // Header: `cartog · my-project · N queries`
+    if scope.is_empty() {
+        out.push_str(&format!("cartog · {} queries\n\n", r.total_queries));
+    } else {
+        out.push_str(&format!(
+            "cartog · {scope} · {} queries\n\n",
+            r.total_queries
+        ));
+    }
+
+    // 10-cell bar. `r.percent_saved` is 0-99 so divide by 10 rounded down.
+    let filled = (r.percent_saved as usize / 10).min(10);
+    let bar: String = "█".repeat(filled) + &"░".repeat(10 - filled);
+    out.push_str(&format!("{bar}  ~{}% tokens saved\n\n", r.percent_saved));
+
+    // With/without/saved table. Column widths chosen so the numbers line up
+    // for any plausible value: `Without cartog  ~999.9k tokens   (~1,700 / query)`.
+    let with = fmt_tokens(r.tokens_used_cartog);
+    let without = fmt_tokens(r.tokens_used_grep);
+    let saved = fmt_tokens(r.estimated_tokens_saved);
+    out.push_str(&format!(
+        "Without cartog  {without:>7} tokens   (~{TOKENS_PER_QUERY_GREP} / query)\n"
+    ));
+    out.push_str(&format!(
+        "With cartog     {with:>7} tokens   (~{TOKENS_PER_QUERY_CARTOG} / query)\n"
+    ));
+    out.push_str("──────────────────────────────────────────────\n");
+    out.push_str(&format!(
+        "Saved           {saved:>7} tokens   (~{} / query)\n\n",
+        r.baseline_delta
+    ));
+
+    // Per-tool counts with annotation so the reader knows the numbers are
+    // call counts, not per-tool token savings (the multiplier is flat).
+    out.push_str("By tool (call counts):\n");
+    for (tool, count) in &r.by_tool {
+        out.push_str(&format!("  {count:>4}  {tool}\n"));
+    }
+
+    if r.by_source.len() > 1 {
+        out.push_str("\nBy source:\n");
+        for (source, count) in &r.by_source {
+            out.push_str(&format!("  {count:>4}  {source}\n"));
+        }
+    }
+
+    out.push_str(&format!(
+        "\nBaseline: ~{TOKENS_PER_QUERY_GREP} tokens for an equivalent grep+read sweep \
+         vs cartog's ~{TOKENS_PER_QUERY_CARTOG}.\n\
+         Measured across 13 benchmark scenarios (see crates/cartog/benches/queries.rs).\n"
+    ));
+
+    out
+}
+
 /// Index statistics summary.
 pub fn cmd_stats(
     db_path: &Path,
@@ -743,31 +848,8 @@ pub fn cmd_stats(
 
     if savings {
         let report = db.savings_breakdown()?;
-        return output(&report, json, token_budget, |r| {
-            let mut out = String::new();
-            if r.total_queries == 0 {
-                out.push_str(
-                    "No queries logged yet. Run `cartog search`, `cartog refs`, … or \
-                     point an MCP-aware editor at this index, then re-run.\n",
-                );
-                return out;
-            }
-            out.push_str(&format!(
-                "Total queries: {}  (~{} tokens saved vs grep+read baseline, at {} tokens/query)\n\n",
-                r.total_queries, r.estimated_tokens_saved, r.baseline_delta
-            ));
-            out.push_str("By tool:\n");
-            for (tool, count) in &r.by_tool {
-                out.push_str(&format!("  {count:>6}  {tool}\n"));
-            }
-            if r.by_source.len() > 1 {
-                out.push_str("\nBy source:\n");
-                for (source, count) in &r.by_source {
-                    out.push_str(&format!("  {count:>6}  {source}\n"));
-                }
-            }
-            out
-        });
+        let scope = savings_scope_label(db_path);
+        return output(&report, json, token_budget, |r| render_savings(&scope, r));
     }
 
     let stats = db.stats()?;

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -559,6 +559,16 @@ pub fn cmd_hierarchy(
 
     // --json wins if both flags are set (matches the documented behavior).
     if mermaid && !json {
+        // Surface the same diagnostic the plain branch shows so users running
+        // --mermaid on a typo or empty index get the did-you-mean hint
+        // alongside the bare `graph TD` document.
+        if pairs.is_empty() {
+            eprintln!(
+                "No hierarchy found for '{name}'{}{}",
+                empty_index_hint(&db),
+                did_you_mean(&db, &name)
+            );
+        }
         print!("{}", mermaid::render_hierarchy(&pairs));
         return Ok(());
     }
@@ -605,6 +615,14 @@ pub fn cmd_deps(
     let file = file.to_string();
 
     if mermaid && !json {
+        // Surface the same diagnostic the plain branch shows so users running
+        // --mermaid against an unindexed file or empty index get the hint.
+        if edges.is_empty() {
+            eprintln!(
+                "No dependencies found for '{file}'{}",
+                empty_index_hint(&db)
+            );
+        }
         let targets: Vec<(String, u32)> = edges
             .iter()
             .map(|e| (e.target_name.clone(), e.line))
@@ -698,12 +716,18 @@ pub fn cmd_pull(
 }
 
 /// Index statistics summary.
-pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize, savings: bool) -> Result<()> {
+pub fn cmd_stats(
+    db_path: &Path,
+    json: bool,
+    token_budget: Option<u32>,
+    embedding_dim: usize,
+    savings: bool,
+) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
 
     if savings {
         let report = db.savings_breakdown()?;
-        return output(&report, json, None, |r| {
+        return output(&report, json, token_budget, |r| {
             let mut out = String::new();
             if r.total_queries == 0 {
                 out.push_str(
@@ -731,7 +755,7 @@ pub fn cmd_stats(db_path: &Path, json: bool, embedding_dim: usize, savings: bool
     }
 
     let stats = db.stats()?;
-    output(&stats, json, None, |stats| {
+    output(&stats, json, token_budget, |stats| {
         let mut out = String::new();
         out.push_str(&format!("Files:    {}\n", stats.num_files));
         out.push_str(&format!("Symbols:  {}\n", stats.num_symbols));
@@ -776,12 +800,13 @@ pub fn cmd_map(
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
     let files = db.all_files()?;
-    db.log_query("map", "cli");
 
     if files.is_empty() {
         if json {
             println!("{{}}");
         } else if mermaid {
+            // Tell the user to index before pasting the (empty) diagram.
+            eprintln!("No files indexed. Run `cartog index .` first.");
             println!("graph TD\n    repo[\"Repo (empty)\"]");
         } else {
             println!("No files indexed. Run 'cartog index .' first.");
@@ -789,29 +814,49 @@ pub fn cmd_map(
         return Ok(());
     }
 
+    // Log AFTER the empty-files guard so no-op calls on an unindexed repo
+    // don't inflate `cartog savings`.
+    db.log_query("map", "cli");
+
     if mermaid && !json {
-        // Honor the token budget by walking files until we exhaust it. Each
-        // file edge costs roughly its path length + ~20 bytes of overhead.
+        // Honor the token budget by walking files until we exhaust it. The
+        // emitted lines look like:
+        //   repo --> f_<sane>_<hash8>["<label>"]
+        //   f_<sane>_<hash8> --> s_<sane>_<hash8>["<name> (<kind>)"]
+        // so per-file overhead is roughly `len(path) * 2 + len(prefix+hash) * 2 + 30`
+        // and per-leaf overhead is roughly `len(path) + len(name) * 2 + len(kind) + 50`.
+        // The constants are deliberately conservative — better to underfill
+        // than overshoot the documented `--tokens` budget.
         let budget_bytes = (tokens as usize) * 4;
-        let mut included_files: Vec<String> = Vec::new();
+        let mut included_files: Vec<&str> = Vec::new();
         let mut size = "graph TD\n    repo[\"Repo\"]\n".len();
+        // f_<sanitized>_<hash8> has at least len(path)+13 bytes of ID overhead.
+        const FILE_ID_OVERHEAD: usize = 13;
+        // s_<sanitized>_<hash8> for a "<file>::<name>" raw key — even longer.
+        const SYM_ID_OVERHEAD: usize = 13;
         for f in &files {
-            let edge_cost = f.len() * 2 + 30; // path appears twice (id + label)
+            let edge_cost = f.len() * 2 + FILE_ID_OVERHEAD + 30;
             if size + edge_cost > budget_bytes && !included_files.is_empty() {
                 break;
             }
             size += edge_cost;
-            included_files.push(f.clone());
+            included_files.push(f.as_str());
         }
+        // HashSet so per-symbol membership is O(1), not O(N).
+        let included_set: std::collections::HashSet<&str> =
+            included_files.iter().copied().collect();
         // Add top symbols per file until budget runs out.
         let symbols = db.top_symbols(500)?;
         let mut symbols_by_file: std::collections::BTreeMap<String, Vec<(String, String)>> =
             std::collections::BTreeMap::new();
-        for sym in symbols {
-            if !included_files.contains(&sym.file_path) {
+        for sym in &symbols {
+            if !included_set.contains(sym.file_path.as_str()) {
                 continue;
             }
-            let leaf_cost = sym.name.len() * 2 + 40;
+            // The actual emitted leaf carries the file path inside the
+            // sym ID (`s_<sanitize(file::name)>_<hash>`), plus the file ID
+            // again on the source side of `-->`. Account for both.
+            let leaf_cost = sym.name.len() * 2 + sym.file_path.len() + SYM_ID_OVERHEAD * 2 + 50;
             if size + leaf_cost > budget_bytes {
                 break;
             }
@@ -819,11 +864,12 @@ pub fn cmd_map(
             symbols_by_file
                 .entry(sym.file_path.clone())
                 .or_default()
-                .push((sym.name.clone(), sym.kind.to_string()));
+                .push((sym.name.clone(), sym.kind.as_str().to_string()));
         }
+        let included_owned: Vec<String> = included_files.iter().map(|s| (*s).to_string()).collect();
         let symbols_vec: Vec<(String, Vec<(String, String)>)> =
             symbols_by_file.into_iter().collect();
-        print!("{}", mermaid::render_map(&included_files, &symbols_vec));
+        print!("{}", mermaid::render_map(&included_owned, &symbols_vec));
         return Ok(());
     }
 
@@ -913,10 +959,12 @@ pub fn cmd_changes(
     embedding_dim: usize,
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
-    db.log_query("changes", "cli");
     let root = std::env::current_dir()?;
 
+    // Log AFTER the git call succeeds; otherwise non-git directories inflate
+    // the savings counter via the `?` propagating an error.
     let changed_files = indexer::git_recently_changed_files(&root, commits)?;
+    db.log_query("changes", "cli");
 
     if changed_files.is_empty() {
         if json {

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -734,7 +734,10 @@ pub fn cmd_pull(
 /// Project label shown above the savings report. Strips the SQLite filename
 /// and walks up to the closest meaningful directory (typically the git root)
 /// so users see `cartog · my-project · 5 queries` rather than the full path.
-/// Falls back to `cartog` when nothing recognizable can be extracted.
+///
+/// Returns an empty string when nothing recognizable can be extracted (no
+/// parent, non-UTF-8 path component). The caller renders a header without a
+/// scope segment in that case — see [`render_savings`].
 fn savings_scope_label(db_path: &Path) -> String {
     db_path
         .parent()
@@ -791,8 +794,12 @@ fn render_savings(scope: &str, r: &cartog_db::SavingsReport) -> String {
         ));
     }
 
-    // 10-cell bar. `r.percent_saved` is 0-99 so divide by 10 rounded down.
-    let filled = (r.percent_saved as usize / 10).min(10);
+    // 10-cell bar with round-to-nearest. `percent_saved` is 0..=100; mapping
+    // `(p + 5) / 10` gives [0,4]→0 cells, [5,14]→1 cell, …, [95,100]→10
+    // cells, so the bar covers the full range. Previously `(p / 10).min(10)`
+    // capped at 9 cells (because `percent_saved` was clamped to 99), making
+    // 90% and 99% visually identical.
+    let filled = ((r.percent_saved as usize + 5) / 10).min(10);
     let bar: String = "█".repeat(filled) + &"░".repeat(10 - filled);
     out.push_str(&format!("{bar}  ~{}% tokens saved\n\n", r.percent_saved));
 
@@ -2042,6 +2049,148 @@ pub use self_cmd::{cmd_self_migrate_db, cmd_self_rollback, cmd_self_update, cmd_
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    // ── savings formatter helpers ─────────────────────────────────────
+
+    #[test]
+    fn fmt_tokens_under_thousand_renders_raw_integer() {
+        assert_eq!(fmt_tokens(0), "0");
+        assert_eq!(fmt_tokens(1), "1");
+        assert_eq!(fmt_tokens(999), "999");
+    }
+
+    #[test]
+    fn fmt_tokens_thousands_renders_one_decimal_k() {
+        assert_eq!(fmt_tokens(1_000), "~1.0k");
+        assert_eq!(fmt_tokens(1_420), "~1.4k");
+        assert_eq!(fmt_tokens(8_500), "~8.5k");
+        assert_eq!(fmt_tokens(999_999), "~1000.0k");
+    }
+
+    #[test]
+    fn fmt_tokens_millions_renders_one_decimal_m() {
+        assert_eq!(fmt_tokens(1_000_000), "~1.0M");
+        assert_eq!(fmt_tokens(2_500_000), "~2.5M");
+    }
+
+    #[test]
+    fn fmt_tokens_handles_u64_max_without_panicking() {
+        // Cosmetic — f64 loses precision near u64::MAX, but the call must
+        // not overflow or panic. Anchor a substring to catch obvious breakage.
+        let s = fmt_tokens(u64::MAX);
+        assert!(s.starts_with("~"));
+        assert!(s.ends_with("M"));
+    }
+
+    #[test]
+    fn savings_scope_label_handles_cartog_dir_layout() {
+        // The canonical layout: `<project>/.cartog/db.sqlite` — walk past
+        // `.cartog` to get the project dir.
+        assert_eq!(
+            savings_scope_label(Path::new("/home/user/myproject/.cartog/db.sqlite")),
+            "myproject"
+        );
+    }
+
+    #[test]
+    fn savings_scope_label_handles_legacy_layout() {
+        // The legacy layout: `<project>/.cartog.db` directly under the
+        // project root — parent is the project dir.
+        assert_eq!(
+            savings_scope_label(Path::new("/home/user/myproject/.cartog.db")),
+            "myproject"
+        );
+    }
+
+    #[test]
+    fn savings_scope_label_empty_on_unrecognizable_path() {
+        // Bare filename with no parent. render_savings drops the segment.
+        assert_eq!(savings_scope_label(Path::new("db.sqlite")), "");
+        // Root path — no parent above `.cartog`.
+        assert_eq!(savings_scope_label(Path::new("/.cartog/db.sqlite")), "");
+    }
+
+    #[test]
+    fn render_savings_zero_queries_emits_helpful_hint() {
+        let report = cartog_db::SavingsReport {
+            by_tool: Vec::new(),
+            by_source: Vec::new(),
+            total_queries: 0,
+            tokens_used_cartog: 0,
+            tokens_used_grep: 0,
+            estimated_tokens_saved: 0,
+            percent_saved: 0,
+            baseline_delta: cartog_db::TOKENS_SAVED_PER_QUERY,
+        };
+        let out = render_savings("myproject", &report);
+        assert!(out.contains("No queries logged yet"));
+        assert!(out.contains("cartog search"));
+    }
+
+    #[test]
+    fn render_savings_includes_header_bar_and_breakdown() {
+        let report = cartog_db::SavingsReport {
+            by_tool: vec![("search".to_string(), 3), ("refs".to_string(), 1)],
+            by_source: vec![("cli".to_string(), 4)],
+            total_queries: 4,
+            tokens_used_cartog: 1_120,
+            tokens_used_grep: 6_800,
+            estimated_tokens_saved: 5_680,
+            percent_saved: 83,
+            baseline_delta: cartog_db::TOKENS_SAVED_PER_QUERY,
+        };
+        let out = render_savings("myproject", &report);
+        // Header carries scope + query count.
+        assert!(out.contains("cartog · myproject · 4 queries"));
+        // ~83% → round-to-nearest gives 8 cells filled, 2 empty.
+        assert!(out.contains("████████░░"));
+        assert!(out.contains("~83% tokens saved"));
+        // With / without / saved rows present and formatted.
+        assert!(out.contains("Without cartog"));
+        assert!(out.contains("With cartog"));
+        assert!(out.contains("Saved"));
+        // Per-tool block labelled as call counts (no per-tool token figures).
+        assert!(out.contains("By tool (call counts):"));
+        assert!(out.contains("3  search"));
+    }
+
+    #[test]
+    fn render_savings_bar_at_99_percent_shows_full_ten_cells() {
+        // Regression for F4: previously `99 / 10 = 9` made 90% and 99%
+        // indistinguishable. Round-to-nearest fixes this.
+        let report = cartog_db::SavingsReport {
+            by_tool: vec![("search".into(), 1)],
+            by_source: vec![("cli".into(), 1)],
+            total_queries: 1,
+            tokens_used_cartog: 17,
+            tokens_used_grep: 1_700,
+            estimated_tokens_saved: 1_683,
+            percent_saved: 99,
+            baseline_delta: 1_420,
+        };
+        let out = render_savings("p", &report);
+        assert!(
+            out.contains("██████████"),
+            "99% must render 10 filled cells, got: {out}"
+        );
+    }
+
+    #[test]
+    fn render_savings_empty_scope_drops_label_segment() {
+        let report = cartog_db::SavingsReport {
+            by_tool: vec![("search".into(), 1)],
+            by_source: vec![("cli".into(), 1)],
+            total_queries: 1,
+            tokens_used_cartog: 280,
+            tokens_used_grep: 1_700,
+            estimated_tokens_saved: 1_420,
+            percent_saved: 83,
+            baseline_delta: 1_420,
+        };
+        let out = render_savings("", &report);
+        // Falls back to `cartog · N queries` without the scope segment.
+        assert!(out.starts_with("cartog · 1 queries"), "got: {out}");
+    }
 
     #[test]
     fn capitalized_index_phase_labels() {

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -189,12 +189,22 @@ fn main() -> Result<()> {
         Command::Refs { name, kind } => {
             commands::cmd_refs(&db_path, &name, kind, cli.json, token_budget, embedding_dim)
         }
-        Command::Hierarchy { name } => {
-            commands::cmd_hierarchy(&db_path, &name, cli.json, token_budget, embedding_dim)
-        }
-        Command::Deps { file } => {
-            commands::cmd_deps(&db_path, &file, cli.json, token_budget, embedding_dim)
-        }
+        Command::Hierarchy { name, mermaid } => commands::cmd_hierarchy(
+            &db_path,
+            &name,
+            cli.json,
+            mermaid,
+            token_budget,
+            embedding_dim,
+        ),
+        Command::Deps { file, mermaid } => commands::cmd_deps(
+            &db_path,
+            &file,
+            cli.json,
+            mermaid,
+            token_budget,
+            embedding_dim,
+        ),
         Command::Stats { savings } => {
             commands::cmd_stats(&db_path, cli.json, embedding_dim, savings)
         }
@@ -245,7 +255,9 @@ fn main() -> Result<()> {
             token_budget,
             embedding_dim,
         ),
-        Command::Map { tokens } => commands::cmd_map(&db_path, tokens, cli.json, embedding_dim),
+        Command::Map { tokens, mermaid } => {
+            commands::cmd_map(&db_path, tokens, cli.json, mermaid, embedding_dim)
+        }
         Command::Changes { commits, kind } => commands::cmd_changes(
             &db_path,
             commits,

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -195,7 +195,10 @@ fn main() -> Result<()> {
         Command::Deps { file } => {
             commands::cmd_deps(&db_path, &file, cli.json, token_budget, embedding_dim)
         }
-        Command::Stats => commands::cmd_stats(&db_path, cli.json, embedding_dim),
+        Command::Stats { savings } => {
+            commands::cmd_stats(&db_path, cli.json, embedding_dim, savings)
+        }
+        Command::Savings => commands::cmd_stats(&db_path, cli.json, embedding_dim, true),
         Command::Push { remote } => {
             commands::cmd_push(&db_path, &cartog_config, remote.as_deref(), cli.json)
         }

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -290,6 +290,12 @@ fn main() -> Result<()> {
             dry_run,
             no_watch,
         } => commands::ide::cmd_ide(client, scope, yes, dry_run, no_watch, cli.json),
+        Command::Install {
+            clients,
+            scope,
+            dry_run,
+            no_watch,
+        } => commands::ide::cmd_install(clients, scope, dry_run, no_watch, cli.json),
         Command::Serve { watch, rag } => {
             let runtime = tokio::runtime::Runtime::new()?;
             // pid_lock_dir/slot must be both-or-neither: a sandboxed host with no

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -206,9 +206,11 @@ fn main() -> Result<()> {
             embedding_dim,
         ),
         Command::Stats { savings } => {
-            commands::cmd_stats(&db_path, cli.json, embedding_dim, savings)
+            commands::cmd_stats(&db_path, cli.json, token_budget, embedding_dim, savings)
         }
-        Command::Savings => commands::cmd_stats(&db_path, cli.json, embedding_dim, true),
+        Command::Savings => {
+            commands::cmd_stats(&db_path, cli.json, token_budget, embedding_dim, true)
+        }
         Command::Push { remote } => {
             commands::cmd_push(&db_path, &cartog_config, remote.as_deref(), cli.json)
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start here: the root [README](../README.md) for install and quick start.
 - [product.md](product.md) — vision, target users, positioning
 - [usage.md](usage.md) — CLI reference and configuration
 - [mcp-setup.md](mcp-setup.md) — per-editor MCP wiring (Cursor, VS Code, Codex, Gemini, Claude Desktop, OpenCode, Windsurf, Zed)
+- [agent-snippet.md](agent-snippet.md) — drop-in rules that teach your agent when to prefer cartog over grep
 - [editor-integration.md](editor-integration.md) — Neovim, VS Code, Emacs, Zed CLI recipes
 - [updates.md](updates.md) — `cartog self update`, exit codes, env vars, state file
 - [troubleshooting.md](troubleshooting.md) — common errors and fixes
@@ -25,7 +26,7 @@ Start here: the root [README](../README.md) for install and quick start.
 
 ## Release
 
-- [scripts/release-smoke.md](../scripts/release-smoke.md) — manual smoke checklist run before tagging
+- [release-smoke.md](../scripts/release-smoke.md) — manual smoke checklist run before tagging
 
 ## Assets
 

--- a/docs/agent-snippet.md
+++ b/docs/agent-snippet.md
@@ -44,6 +44,7 @@ microseconds — far cheaper than grep + read.
 
 **Index hygiene:**
 - If a tool reports stale data, call `mcp__cartog__cartog_index` once
+- If `cartog_rag_search` results feel out of date after new files were added, call `mcp__cartog__cartog_rag_index` once
 - For semantic search to work, the user must have run `cartog rag setup` and `cartog rag index .`
 ```
 
@@ -52,7 +53,7 @@ microseconds — far cheaper than grep + read.
 ## Why this works
 
 - Tells the agent **when** to prefer cartog (the hard part — most agents default to grep)
-- Lists the 13 MCP tools by their canonical names so the agent calls them directly
+- Lists all 13 MCP tools by their canonical names so the agent calls them directly
 - Names the fall-back conditions so the agent doesn't get stuck
 - Self-contained — no links to follow at decision time
 

--- a/docs/agent-snippet.md
+++ b/docs/agent-snippet.md
@@ -1,0 +1,59 @@
+# Teach your agent to use cartog
+
+Copy the snippet below into your project's agent rules file so the LLM picks
+cartog tools over grep + read whenever it needs to navigate code.
+
+Drop it into one of:
+
+- `AGENTS.md` (OpenCode, Codex, Aider, any agent that reads it)
+- `CLAUDE.md` (Claude Code)
+- `.cursor/rules/cartog.md` (Cursor)
+- `.github/copilot-instructions.md` (Copilot)
+- `.windsurfrules` (Windsurf)
+
+Prerequisite: cartog MCP is wired and the index is built (`cartog ide` + `cartog index .`).
+
+---
+
+## Snippet (copy from here)
+
+```markdown
+## Code navigation: prefer cartog over grep
+
+This project is indexed by [cartog](https://github.com/jrollin/cartog). The
+cartog MCP tools are pre-computed and return structured, ranked results in
+microseconds — far cheaper than grep + read.
+
+**Use cartog when the question is:**
+- "where is X defined?" → `mcp__cartog__cartog_search`
+- "who calls / imports / inherits X?" → `mcp__cartog__cartog_refs`
+- "what does X call?" → `mcp__cartog__cartog_callees`
+- "what breaks if I change X?" → `mcp__cartog__cartog_impact`
+- "show the inheritance tree of X" → `mcp__cartog__cartog_hierarchy`
+- "what does this file import?" → `mcp__cartog__cartog_deps`
+- "show the structure of file F" → `mcp__cartog__cartog_outline`
+- "find code about <concept>" (natural language) → `mcp__cartog__cartog_rag_search`
+- "orient me in this repo" → `mcp__cartog__cartog_map`
+- "what changed recently?" → `mcp__cartog__cartog_changes`
+- "is the index healthy?" → `mcp__cartog__cartog_stats`
+
+**Fall back to grep / Read only when:**
+- searching for a string literal, comment, config value, or non-code text
+- the target file is outside the indexed root
+- cartog returned zero results and you need a broader text scan
+
+**Index hygiene:**
+- If a tool reports stale data, call `mcp__cartog__cartog_index` once
+- For semantic search to work, the user must have run `cartog rag setup` and `cartog rag index .`
+```
+
+---
+
+## Why this works
+
+- Tells the agent **when** to prefer cartog (the hard part — most agents default to grep)
+- Lists the 13 MCP tools by their canonical names so the agent calls them directly
+- Names the fall-back conditions so the agent doesn't get stuck
+- Self-contained — no links to follow at decision time
+
+For the full tool reference, see [usage.md — Available tools](usage.md#available-tools).

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -53,6 +53,15 @@ claude mcp add --scope project cartog -- cartog serve --watch
 
 Add `"--rag"` to `args` if you want automatic embedding updates on file change.
 
+> **Why `--watch` only here?** Of all clients, Claude Code is the only one
+> `cartog ide` defaults to `["serve", "--watch"]`; the rest ship plain
+> `["serve"]`. Agent-driven workflows churn files faster than human-driven
+> editor flows, so the in-process file watcher pays for itself. Drop it with
+> `cartog ide --no-watch`, or call `cartog index` manually when you want a
+> refresh. Multiple watchers compete for the single-writer lock, so keeping the
+> default off elsewhere avoids surprises when a user wires cartog into several
+> editors at once.
+
 ## Claude Desktop
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -250,12 +250,14 @@ references  process  routes/auth.py:22
 
 Available `--kind` values: `calls`, `imports`, `inherits`, `references`, `raises`, `implements`, `type-of`.
 
-### `cartog hierarchy <class>`
+### `cartog hierarchy <class> [--mermaid]`
 
 Show inheritance relationships involving a class — both parents and children.
+Add `--mermaid` for a `graph TD` diagram you can paste into a PR or doc.
 
 ```bash
 cartog hierarchy AuthService
+cartog hierarchy AuthService --mermaid
 ```
 
 ```
@@ -263,18 +265,38 @@ AuthService -> BaseService
 AdminService -> AuthService
 ```
 
-### `cartog deps <file>`
+With `--mermaid`:
+
+```
+graph TD
+    AuthService["AuthService"] --> BaseService["BaseService"]
+    AdminService["AdminService"] --> AuthService["AuthService"]
+```
+
+### `cartog deps <file> [--mermaid]`
 
 List symbols imported by a file — answers "what does this file depend on?".
+Add `--mermaid` for a `graph LR` diagram rooted at the file.
 
 ```bash
-cartog deps src/routes/auth.py
+cartog deps auth/service.py
+cartog deps auth/service.py --mermaid
 ```
 
 ```
 validate_token  L5
 generate_token  L5
 User            L6
+```
+
+With `--mermaid`:
+
+```
+graph LR
+    auth_service_py["auth/service.py"]
+    auth_service_py --> validate_token["validate_token (L5)"]
+    auth_service_py --> generate_token["generate_token (L5)"]
+    auth_service_py --> User["User (L6)"]
 ```
 
 ### `cartog stats [--savings]`
@@ -428,14 +450,15 @@ cargo install cartog --no-default-features --features lsp   # keep LSP only
 A binary built without `remote-s3` refuses `cartog push` and `cartog pull` with
 a clear error pointing at the reinstall command.
 
-### `cartog map [--tokens N]`
+### `cartog map [--tokens N] [--mermaid]`
 
-Token-budget-aware codebase summary — file tree + top symbols ranked by reference count (in-degree centrality).
+Token-budget-aware codebase summary — file tree + top symbols ranked by reference count (in-degree centrality). Add `--mermaid` for a `graph TD` rooted at "Repo"; the token budget still applies (the renderer stops adding nodes before it overflows).
 
 ```bash
 cartog map                    # default 4000 tokens
 cartog map --tokens 2000      # compact summary
 cartog map --tokens 8000      # detailed summary
+cartog map --mermaid          # paste-into-PR diagram
 ```
 
 ```
@@ -456,6 +479,20 @@ src/auth/service.py:
 ```
 
 Phase 1 shows the file tree; phase 2 fills remaining budget with symbols ordered by centrality (most-referenced first). Use `--json` for structured output.
+
+With `--mermaid`:
+
+```
+graph TD
+    repo["Repo"]
+    repo --> auth_service_py["auth/service.py"]
+    repo --> auth_tokens_py["auth/tokens.py"]
+    auth_tokens_py --> auth_tokens_py__validate_token["validate_token (function)"]
+    auth_tokens_py --> auth_tokens_py__generate_token["generate_token (function)"]
+    ...
+```
+
+`--json` wins over `--mermaid` when both are set.
 
 ### `cartog changes [--commits N] [--kind <kind>]`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -596,10 +596,17 @@ cartog completions fish  > ~/.config/fish/completions/cartog.fish
 
 Emit a `roff` man page on stdout. Intended for packagers and distro maintainers.
 
+The output filename **must** end in `.1` (the section-1 extension `man` looks
+for) and the target directory must exist:
+
 ```bash
-cartog manpage > /usr/local/share/man/man1/cartog.1
+sudo mkdir -p /usr/local/share/man/man1
+cartog manpage | sudo tee /usr/local/share/man/man1/cartog.1 > /dev/null
 man cartog
 ```
+
+On macOS the path is the same. On Linux distros some packagers prefer
+`/usr/share/man/man1/`; either works as long as it is on `MANPATH`.
 
 ### `cartog self <update|version|rollback|migrate-db>`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -377,6 +377,12 @@ surface (`cli` / `mcp`), and a timestamp. Secondary read-only MCP attaches
 skip the write (they can't write at all), so multi-MCP-server setups *under-*
 report secondary traffic rather than double-counting it.
 
+**JSON schema** (`cartog --json savings`): v0.18+ adds `tokens_used_cartog`,
+`tokens_used_grep`, and `percent_saved` to the existing
+`{by_tool, by_source, total_queries, estimated_tokens_saved, baseline_delta}`.
+Consumers must not parse with `deny_unknown_fields` — additive fields are
+expected as the metric evolves.
+
 ### `cartog push [--remote <s3-url>]`
 
 Upload the local index DB to S3-compatible storage (AWS S3, MinIO, Cloudflare R2,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -342,19 +342,40 @@ cartog --json savings
 ```
 
 ```text
-Total queries: 5  (~7100 tokens saved vs grep+read baseline, at 1420 tokens/query)
+cartog · my-project · 5 queries
 
-By tool:
-       2  search
-       1  impact
-       1  map
-       1  refs
+████████░░  ~83% tokens saved
+
+Without cartog    ~8.5k tokens   (~1700 / query)
+With cartog       ~1.4k tokens   (~280 / query)
+──────────────────────────────────────────────
+Saved             ~7.1k tokens   (~1420 / query)
+
+By tool (call counts):
+     2  search
+     1  impact
+     1  map
+     1  refs
+
+Baseline: ~1700 tokens for an equivalent grep+read sweep vs cartog's ~280.
+Measured across 13 benchmark scenarios (see crates/cartog/benches/queries.rs).
 ```
+
+The header line is `cartog · <project> · <N> queries`, where `<project>` is
+the directory holding `.cartog/`. **By tool** lists *call counts*, not per-tool
+token savings — every tool uses the same baseline (1,420 tokens saved per
+call), so the breakdown shows which navigation patterns the user actually
+relies on, not which one saved the most.
+
+Only queries that returned a non-empty result count toward the totals.
+Empty-index calls, typo'd symbol names, and "no such file" outline calls are
+skipped so the figure reflects real work, not zero-value pings.
 
 Data comes from a local `query_log` table inside `.cartog/db.sqlite`. Nothing
 leaves the machine; no query payloads are recorded — only the tool name, call
 surface (`cli` / `mcp`), and a timestamp. Secondary read-only MCP attaches
-skip the write to avoid double-counting from the primary.
+skip the write (they can't write at all), so multi-MCP-server setups *under-*
+report secondary traffic rather than double-counting it.
 
 ### `cartog push [--remote <s3-url>]`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,7 +175,7 @@ cartog search config --file src/db.rs        # scoped to one file
 cartog search parse --limit 5               # cap results
 ```
 
-```
+```text
 function  validate_token    auth/tokens.py:30
 function  validate_session  auth/tokens.py:68
 function  validate_user     services/user.py:12
@@ -193,7 +193,7 @@ Show all symbols in a file with their types, signatures, and line ranges. Use th
 cartog outline src/db.rs
 ```
 
-```
+```text
 use anyhow  L1
 use rusqlite  L2
 class Database  L62-500
@@ -210,7 +210,7 @@ Find what a function calls — answers "what does this depend on?".
 cartog callees validate_token
 ```
 
-```
+```text
 lookup_session  auth/tokens.py:37
 TokenError      auth/tokens.py:39
 ExpiredTokenError  auth/tokens.py:42
@@ -224,7 +224,7 @@ Transitive impact analysis — follows the caller chain up to N hops (default 3)
 cartog impact validate_token --depth 3
 ```
 
-```
+```text
   calls  get_current_user  auth/service.py:40
   calls  refresh_token  auth/tokens.py:54
     calls  impersonate  auth/service.py:52
@@ -241,7 +241,7 @@ cartog refs UserService                  # all reference types
 cartog refs validate_token --kind calls  # only call sites
 ```
 
-```
+```text
 imports  ./service  routes/auth.py:3
 calls    login  routes/auth.py:15
 inherits AdminService  auth/service.py:47
@@ -260,14 +260,14 @@ cartog hierarchy AuthService
 cartog hierarchy AuthService --mermaid
 ```
 
-```
+```text
 AuthService -> BaseService
 AdminService -> AuthService
 ```
 
 With `--mermaid`:
 
-```
+```text
 graph TD
     AuthService["AuthService"] --> BaseService["BaseService"]
     AdminService["AdminService"] --> AuthService["AuthService"]
@@ -283,7 +283,7 @@ cartog deps auth/service.py
 cartog deps auth/service.py --mermaid
 ```
 
-```
+```text
 validate_token  L5
 generate_token  L5
 User            L6
@@ -291,7 +291,7 @@ User            L6
 
 With `--mermaid`:
 
-```
+```text
 graph LR
     auth_service_py["auth/service.py"]
     auth_service_py --> validate_token["validate_token (L5)"]
@@ -311,7 +311,7 @@ cartog stats
 cartog stats --savings
 ```
 
-```
+```text
 Files:    42
 Symbols:  387
 Edges:    1204 (891 resolved)
@@ -341,7 +341,7 @@ cartog savings
 cartog --json savings
 ```
 
-```
+```text
 Total queries: 5  (~7100 tokens saved vs grep+read baseline, at 1420 tokens/query)
 
 By tool:
@@ -461,7 +461,7 @@ cartog map --tokens 8000      # detailed summary
 cartog map --mermaid          # paste-into-PR diagram
 ```
 
-```
+```text
 # Codebase Map (42 files)
 
   src/auth/tokens.py
@@ -482,7 +482,7 @@ Phase 1 shows the file tree; phase 2 fills remaining budget with symbols ordered
 
 With `--mermaid`:
 
-```
+```text
 graph TD
     repo["Repo"]
     repo --> auth_service_py["auth/service.py"]
@@ -504,7 +504,7 @@ cartog changes --commits 10           # last 10 commits
 cartog changes --kind function        # only functions that changed
 ```
 
-```
+```text
 27 files changed in last 5 commits, 158 symbols affected
 
 src/commands.rs:
@@ -527,7 +527,7 @@ Check that all requirements are met and everything is working. Validates the env
 cartog doctor
 ```
 
-```
+```text
   [+] git: git repository at /home/user/project
   [+] config: loaded from /home/user/project/.cartog.toml
   [+] database: 42 files, 387 symbols at /home/user/project/.cartog/db.sqlite
@@ -737,7 +737,7 @@ Available `--kind` values: `function`, `class`, `method`, `variable`, `import`, 
 
 ## Recommended Workflow
 
-```
+```text
 cartog index .          # 1. build the graph
 cartog search foo       # 2. discover exact symbol names
 cartog refs foo         # 3. find all usages
@@ -748,7 +748,7 @@ cartog index .          # 6. re-index after code changes
 
 For semantic search, add the RAG pipeline:
 
-```
+```text
 cartog rag setup        # one-time model download (~1.2GB, may take a few minutes)
 cartog rag index        # embed symbols
 cartog rag search "..."  # natural language queries
@@ -809,7 +809,7 @@ This installs the plugin from GitHub, which includes:
 
 ### Plugin Structure
 
-```
+```text
 .claude-plugin/
 └── plugin.json          # Plugin manifest
 skills/
@@ -1032,7 +1032,7 @@ Produces a structured onboarding report for an unfamiliar codebase. The agent ad
 Output: a structured markdown report. Sections that don't apply are omitted.
 
 **Usage:**
-```
+```text
 @codebase-onboarding
 # or
 "Use the codebase-onboarding agent to analyze this project"
@@ -1051,7 +1051,7 @@ Pre-flight analysis before changing a symbol, module, or file. Maps the full bla
 4. **Report** — affected files, risk warnings, and a concrete update checklist
 
 **Usage:**
-```
+```text
 @refactoring-scout "rename TrackerRepository"
 # or
 "Is it safe to delete the UtilsHelper class?"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -561,6 +561,9 @@ cartog init --dry-run        # preview without writing
 
 Wire `cartog serve` into one or all MCP-compatible editors. This is the only verb that touches editor configs.
 
+`cartog install` is a visible alias — same flags, same behavior, just a more
+discoverable name for newcomers.
+
 ```bash
 cartog ide                          # all installed clients, all scopes
 cartog ide --client cursor          # one client

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -629,18 +629,71 @@ cartog init --dry-run        # preview without writing
 
 Wire `cartog serve` into one or all MCP-compatible editors. This is the only verb that touches editor configs.
 
-`cartog install` is a visible alias — same flags, same behavior, just a more
-discoverable name for newcomers.
-
 ```bash
-cartog ide                          # all installed clients, all scopes
+cartog ide                          # all installed clients, all scopes (interactive picker)
 cartog ide --client cursor          # one client
 cartog ide --scope project          # only project-scoped (.mcp.json, .cursor/, .vscode/)
 cartog ide --scope user             # only user-scope clients
 cartog ide --dry-run                # preview with before/after diff
 ```
 
+Example output (`cartog ide --client cursor --dry-run`):
+
+```text
++ cursor (project, /your/repo/.cursor/mcp.json): would create
+  --- after ---
+    {
+      "mcpServers": {
+        "cartog": { "command": "cartog", "args": ["serve"] }
+      }
+    }
+
+1 clients: 1 created, 0 updated, 0 unchanged, 0 skipped, 0 errors
+Dry run only. Re-run without --dry-run to apply.
+```
+
+For `cartog ide --client claude-code --dry-run`, both project (`.mcp.json`) and user (`~/.claude/settings.json`) entries are previewed, and `args` includes `--watch` by default ([see why](#claude-code-watch-default)).
+
 Supported clients: `claude-code` (project + user), `claude-desktop`, `codex`, `cursor`, `gemini`, `opencode`, `vscode`, `windsurf`, `zed`. User-scope clients whose config dir is missing are skipped. See [Per-editor wiring: `cartog ide`](#per-editor-wiring-cartog-ide) for the flag and troubleshooting tables.
+
+### `cartog install [client ...] [--scope ...] [--dry-run] [--no-watch]`
+
+Friendlier shape of `cartog ide` — takes editors as positional args
+(brew/npm/pip/cargo convention) and is always non-interactive. Safe to call
+from scripts and agents (no picker, no `--yes` required).
+
+```bash
+cartog install cursor                 # one editor
+cartog install cursor vscode codex    # several editors at once
+cartog install                        # all detected editors
+cartog install cursor --dry-run       # preview without writing
+cartog install claude-code --no-watch # wire Claude Code without --watch
+```
+
+Example output (`cartog install cursor vscode --dry-run`):
+
+```text
++ cursor (project, /your/repo/.cursor/mcp.json): would create
+  --- after ---
+    {
+      "mcpServers": {
+        "cartog": { "command": "cartog", "args": ["serve"] }
+      }
+    }
++ vscode (project, /your/repo/.vscode/mcp.json): would create
+  --- after ---
+    {
+      "servers": {
+        "cartog": { "type": "stdio", "command": "cartog", "args": ["serve"] }
+      }
+    }
+
+2 clients: 2 created, 0 updated, 0 unchanged, 0 skipped, 0 errors
+Dry run only. Re-run without --dry-run to apply.
+```
+
+Same supported-client list as `cartog ide`. For the interactive multi-select
+picker (useful at a fresh-machine setup), use `cartog ide` directly.
 
 ### `cartog config`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -277,12 +277,16 @@ generate_token  L5
 User            L6
 ```
 
-### `cartog stats`
+### `cartog stats [--savings]`
 
-Summary of the index — file count, symbol count, edge resolution rate.
+Summary of the index — file count, symbol count, edge resolution rate. Pass
+`--savings` to instead show per-tool query counts and estimated tokens saved
+versus a grep+read baseline (or use the [`cartog savings`](#cartog-savings)
+top-level alias).
 
 ```bash
 cartog stats
+cartog stats --savings
 ```
 
 ```
@@ -302,6 +306,33 @@ Symbols by kind:
 
 On an unindexed repo all counts are `0` and the output ends with
 `Index is empty — run \`cartog index .\` to build the code graph.`
+
+### `cartog savings`
+
+Per-tool query counts + an estimated tokens-saved figure versus a grep+read
+baseline (~1,420 tokens/query, drawn from the benchmark suite). Visible alias
+of `cartog stats --savings`; shipped as a top-level verb because it's the
+retention hook — surfaces ongoing ROI in one keystroke.
+
+```bash
+cartog savings
+cartog --json savings
+```
+
+```
+Total queries: 5  (~7100 tokens saved vs grep+read baseline, at 1420 tokens/query)
+
+By tool:
+       2  search
+       1  impact
+       1  map
+       1  refs
+```
+
+Data comes from a local `query_log` table inside `.cartog/db.sqlite`. Nothing
+leaves the machine; no query payloads are recorded — only the tool name, call
+surface (`cli` / `mcp`), and a timestamp. Secondary read-only MCP attaches
+skip the write to avoid double-counting from the primary.
 
 ### `cartog push [--remote <s3-url>]`
 

--- a/site/style.css
+++ b/site/style.css
@@ -1226,6 +1226,24 @@ td .badge {
   margin-top: 12px;
 }
 
+.example-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
+
+pre.example-output {
+  background: var(--bg-secondary);
+  border-left: 3px solid var(--accent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  margin-bottom: 16px;
+}
+
 @media (max-width: 768px) {
   .docs-layout {
     grid-template-columns: 1fr;

--- a/site/style.css
+++ b/site/style.css
@@ -1187,6 +1187,45 @@ td .badge {
   margin-bottom: 16px;
 }
 
+.mcp-client {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  background: var(--bg-tertiary);
+}
+
+.mcp-client > summary {
+  cursor: pointer;
+  font-size: 14px;
+  user-select: none;
+  list-style: none;
+}
+
+.mcp-client > summary::-webkit-details-marker {
+  display: none;
+}
+
+.mcp-client > summary::before {
+  content: "▸";
+  display: inline-block;
+  width: 14px;
+  color: var(--accent);
+  transition: transform 0.15s ease;
+}
+
+.mcp-client[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.mcp-client[open] {
+  padding-bottom: 4px;
+}
+
+.mcp-client > *:not(summary) {
+  margin-top: 12px;
+}
+
 @media (max-width: 768px) {
   .docs-layout {
     grid-template-columns: 1fr;

--- a/site/usage.html
+++ b/site/usage.html
@@ -75,6 +75,7 @@
           <a href="#cmd-self">cartog self</a>
           <a href="#cmd-serve">cartog serve</a>
           <a href="#cmd-stats">cartog stats</a>
+          <a href="#cmd-savings">cartog savings</a>
           <a href="#cmd-watch">cartog watch</a>
         </div>
         <div class="sidebar-group">
@@ -378,9 +379,10 @@ revoke_token     L5
 User             L6
 get_logger       L7</pre>
 
-      <h2 id="cmd-stats"><code>cartog stats</code></h2>
-      <p>Summary of the index — file count, symbol count, edge resolution rate. On an unindexed repo all counts are <code>0</code> and the output ends with a hint to run <code>cartog index .</code>.</p>
-      <pre>cartog stats</pre>
+      <h2 id="cmd-stats"><code>cartog stats [--savings]</code></h2>
+      <p>Summary of the index — file count, symbol count, edge resolution rate. On an unindexed repo all counts are <code>0</code> and the output ends with a hint to run <code>cartog index .</code>. Pass <code>--savings</code> to show per-tool query counts and estimated tokens saved instead (or use the <a href="#cmd-savings"><code>cartog savings</code></a> alias).</p>
+      <pre>cartog stats
+cartog stats --savings</pre>
       <p class="example-label">Example output</p>
       <pre class="example-output">Files:    70
 Symbols:  697
@@ -394,6 +396,20 @@ Symbols by kind:
   function: 90
   variable: 80
   class: 52</pre>
+
+      <h2 id="cmd-savings"><code>cartog savings</code></h2>
+      <p>Per-tool query counts + estimated tokens saved versus a grep+read baseline (~1,420 tokens/query). Visible alias of <code>cartog stats --savings</code>, shipped as a top-level verb so the retention hook is one keystroke away.</p>
+      <pre>cartog savings
+cartog --json savings</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">Total queries: 5  (~7100 tokens saved vs grep+read baseline, at 1420 tokens/query)
+
+By tool:
+       2  search
+       1  impact
+       1  map
+       1  refs</pre>
+      <p>Data comes from a local <code>query_log</code> table inside <code>.cartog/db.sqlite</code>. Nothing leaves the machine; no query payloads are recorded — only the tool name, call surface (<code>cli</code> / <code>mcp</code>), and a timestamp. Secondary read-only MCP attaches skip the write to avoid double-counting from the primary.</p>
 
       <h2 id="cmd-doctor"><code>cartog doctor</code></h2>
       <p>Validate that all requirements are met and everything is working. Checks git repo, config, database, embedding provider, and reranker.</p>

--- a/site/usage.html
+++ b/site/usage.html
@@ -285,6 +285,10 @@ cartog rag setup     <span class="comment"># only downloads embedding model (~80
 cartog index src/           <span class="comment"># index a subdirectory</span>
 cartog index . --force      <span class="comment"># full re-index</span>
 cartog index . --no-lsp     <span class="comment"># heuristic-only (~1-4s)</span></pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">Indexed 70 files (0 skipped, 0 removed)
+  697 symbols, 1921 edges (1019 resolved)
+  1 files in unsupported languages not indexed (1 .toml)</pre>
       <p>Incremental by default — skips unchanged files (git + SHA-256), and within changed files, uses Merkle-tree diffing to update only modified symbols. The LSP pass skips edges already classified as unresolvable (typo, dyn dispatch, macro) or external (stdlib, deps, node_modules); both auto-retry when a matching symbol is added in-tree. <code>--force</code> resets those markers for a clean retry.</p>
       <p>Files in unsupported languages are reported, not silently dropped: on a mixed repo the summary adds a line like <code>12 files in unsupported languages not indexed (8 .dart, 4 .swift)</code> (also as <code>files_unsupported</code> / <code>unsupported_by_ext</code> under <code>--json</code>).</p>
 
@@ -294,43 +298,116 @@ cartog index . --no-lsp     <span class="comment"># heuristic-only (~1-4s)</span
 cartog search validate --kind function   <span class="comment"># functions only</span>
 cartog search config --file src/db.rs    <span class="comment"># scoped to one file</span>
 cartog search parse --limit 5            <span class="comment"># cap results</span></pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">function  validate           api/v1/auth.py:16
+function  validate_token     auth/tokens.py:38
+function  validate_request   utils/helpers.py:16
+function  validate_login     validators/user.py:41
+function  validate_email     validators/common.py:15
+method    _validate_payment  services/payment/processor.py:122
+document  Validate           README.md:8</pre>
       <p>Available <code>--kind</code> values: <code>function</code>, <code>class</code>, <code>method</code>, <code>variable</code>, <code>import</code>, <code>interface</code>, <code>enum</code>, <code>type-alias</code>, <code>trait</code>, <code>module</code>, <code>document</code>.</p>
 
       <h2 id="cmd-outline"><code>cartog outline &lt;file&gt;</code></h2>
       <p>Show all symbols in a file with types, signatures, and line ranges. Use this instead of reading a file when you need structure.</p>
-      <pre>cartog outline src/db.rs</pre>
+      <pre>cartog outline auth/tokens.py</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">from datetime import datetime, timedelta  L3
+from typing import Optional  L4
+from models.user import User  L7
+from config import SECRET_KEY, TOKEN_EXPIRY  L9
+class TokenError  L12-15
+class ExpiredTokenError  L18-21
+function generate_token(user: User, expires_in: int = TOKEN_EXPIRY) -&gt; str  L30-35
+function validate_token(token: str) -&gt; Optional[User]  L38-52
+function refresh_token(old_token: str) -&gt; str  L60-64
+function revoke_token(token: str) -&gt; bool  L67-73</pre>
 
       <h2 id="cmd-refs"><code>cartog refs &lt;name&gt;</code></h2>
       <p>All references to a symbol — calls, imports, inherits, type references.</p>
       <pre>cartog refs UserService                  <span class="comment"># all reference types</span>
 cartog refs validate_token --kind calls  <span class="comment"># only call sites</span></pre>
+      <p class="example-label">Example output (<code>cartog refs validate_token</code>)</p>
+      <pre class="example-output">imports  ..auth.tokens     middleware/auth_mw.py:7
+calls    auth_middleware   middleware/auth_mw.py:28
+imports  auth.tokens       auth/service.py:5
+calls    get_current_user  auth/service.py:44
+calls    change_password   auth/service.py:52
+imports  .tokens           auth/__init__.py:4
+calls    refresh_token     auth/tokens.py:62</pre>
       <p>Available <code>--kind</code> values: <code>calls</code>, <code>imports</code>, <code>inherits</code>, <code>references</code>, <code>raises</code>, <code>implements</code>, <code>type-of</code>.</p>
 
       <h2 id="cmd-callees"><code>cartog callees &lt;name&gt;</code></h2>
       <p>Find what a function calls — answers "what does this depend on?".</p>
       <pre>cartog callees validate_token</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">lookup_session    auth/tokens.py:45
+TokenError        auth/tokens.py:47
+datetime.utcnow   auth/tokens.py:49
+ExpiredTokenError auth/tokens.py:50</pre>
 
       <h2 id="cmd-impact"><code>cartog impact &lt;name&gt;</code></h2>
       <p>Transitive impact analysis — follows the caller chain up to N hops (default 3).</p>
       <pre>cartog impact validate_token --depth 3</pre>
-      <p>Indentation shows depth. Answers "what breaks if I change this?".</p>
+      <p class="example-label">Example output (indentation shows hop depth)</p>
+      <pre class="example-output">  imports  middleware/auth_mw.py:7
+  calls    auth_middleware           middleware/auth_mw.py:28
+  imports  auth/service.py:5
+  calls    AuthService.get_current_user  auth/service.py:44
+  calls    AuthService.change_password   auth/service.py:52
+  calls    refresh_token             auth/tokens.py:62
+    calls  auth_required.wrapper     auth/middleware.py:21
+    calls  get_current_user          auth/middleware.py:61</pre>
+      <p>Answers "what breaks if I change this?".</p>
 
       <h2 id="cmd-hierarchy"><code>cartog hierarchy &lt;class&gt;</code></h2>
       <p>Show inheritance relationships — both parents and children.</p>
       <pre>cartog hierarchy AuthService</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">AuthService -&gt; BaseService
+AdminService -&gt; AuthService</pre>
 
       <h2 id="cmd-deps"><code>cartog deps &lt;file&gt;</code></h2>
       <p>List symbols imported by a file — answers "what does this file depend on?".</p>
-      <pre>cartog deps src/routes/auth.py</pre>
+      <pre>cartog deps auth/service.py</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">Optional         L3
+validate_token   L5
+generate_token   L5
+revoke_token     L5
+User             L6
+get_logger       L7</pre>
 
       <h2 id="cmd-stats"><code>cartog stats</code></h2>
       <p>Summary of the index — file count, symbol count, edge resolution rate. On an unindexed repo all counts are <code>0</code> and the output ends with a hint to run <code>cartog index .</code>.</p>
       <pre>cartog stats</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">Files:    70
+Symbols:  697
+Edges:    1921 (1019 resolved)
+Languages:
+  python: 69 files
+  markdown: 1 files
+Symbols by kind:
+  import: 256
+  method: 217
+  function: 90
+  variable: 80
+  class: 52</pre>
 
       <h2 id="cmd-doctor"><code>cartog doctor</code></h2>
       <p>Validate that all requirements are met and everything is working. Checks git repo, config, database, embedding provider, and reranker.</p>
       <pre>cartog doctor                 <span class="comment"># check all requirements</span>
 cartog --json doctor          <span class="comment"># structured JSON output</span></pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">  [+] git: git repository at /your/repo
+  [+] config: loaded from /your/repo/.cartog.toml
+  [+] database: 70 files, 697 symbols at .cartog/db.sqlite
+  [+] embedding: local model cached
+  [+] reranker: local model cached
+  [+] remote: not configured (local-only)
+
+All 6 checks passed</pre>
       <p>Each check reports <strong>OK</strong>, <strong>Warn</strong>, or <strong>Error</strong>. Exits with code 1 if any check is an error. Run this when commands fail unexpectedly or after first setup.</p>
 
       <h2 id="cmd-map"><code>cartog map</code></h2>
@@ -338,17 +415,48 @@ cartog --json doctor          <span class="comment"># structured JSON output</sp
       <pre>cartog map                    <span class="comment"># default 4000 tokens</span>
 cartog map --tokens 2000      <span class="comment"># compact</span>
 cartog map --tokens 8000      <span class="comment"># detailed</span></pre>
+      <p class="example-label">Example output (truncated)</p>
+      <pre class="example-output"># Codebase Map (70 files)
+
+  README.md
+  api/v1/auth.py
+  api/v1/payments.py
+  api/v2/auth.py
+  app.py
+  auth/middleware.py
+  auth/service.py
+  auth/tokens.py
+  ...</pre>
 
       <h2 id="cmd-changes"><code>cartog changes</code></h2>
       <p>Show symbols affected by recent git changes.</p>
       <pre>cartog changes                    <span class="comment"># last 5 commits + working tree</span>
 cartog changes --commits 10       <span class="comment"># last 10 commits</span>
 cartog changes --kind function    <span class="comment"># only functions</span></pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">20 files changed in last 5 commits, 2 symbols affected
+
+README.md:
+  document webapp_py# webapp_py       L1-7
+  document Validate## Validate        L8-13</pre>
 
       <h2 id="cmd-config"><code>cartog config</code></h2>
       <p>Print the resolved configuration (merged defaults, <code>.cartog.toml</code>, and env overrides). Useful for verifying <code>[rag]</code> tuning, watch debounce, and provider selection.</p>
       <pre>cartog config              <span class="comment"># human-readable</span>
 cartog config --json       <span class="comment"># JSON for scripts</span></pre>
+      <p class="example-label">Example output (truncated)</p>
+      <pre class="example-output">Config file: /your/repo/.cartog.toml
+Database:    /your/repo/.cartog/db.sqlite
+
+[embedding]
+  provider:          local (default)
+  model:             -
+  dimension:         -
+
+[embedding.ollama]
+  base_url:          http://localhost:11434 (default)
+  model:             nomic-embed-text (default)
+  ...</pre>
 
       <h2 id="cmd-watch"><code>cartog watch</code></h2>
       <p>Watch for file changes and auto-re-index. Keeps the graph fresh during development.</p>
@@ -358,9 +466,12 @@ cartog watch --rag                 <span class="comment"># also auto-embed</span
 cartog watch --rag --rag-delay 60  <span class="comment"># embed after 60s idle</span>
 cartog watch --debounce 10         <span class="comment"># 10s debounce window</span>
 cartog watch --json                <span class="comment"># NDJSON event stream</span></pre>
+      <p>Refuses to start if another watch holds the lock for this database — fail-fast prevents two writers stomping each other:</p>
+      <pre class="example-output">Error: another cartog process holds the watch lock for this database
+       (slot watch-a902bb89f9a6b484, PID 64311); stop it before running `cartog watch`</pre>
 
       <h2 id="cmd-serve"><code>cartog serve</code></h2>
-      <p>Start cartog as an MCP server over stdio.</p>
+      <p>Start cartog as an MCP server over stdio. No banner — stdio is reserved for JSON-RPC traffic between the client and the server. Run <code>cartog stats</code> in another shell to confirm it's up; <code>role: primary</code> means the writer, <code>role: read-only</code> means an attached secondary.</p>
       <pre>cartog serve                  <span class="comment"># MCP server only</span>
 cartog serve --watch          <span class="comment"># + background file watcher</span>
 cartog serve --watch --rag    <span class="comment"># + watcher + auto RAG</span></pre>
@@ -369,6 +480,10 @@ cartog serve --watch --rag    <span class="comment"># + watcher + auto RAG</span
       <p>Scaffold a <code>.cartog.toml</code> template in the current project. That's all it does — config only, no editor wiring, no indexing. The next-steps hint points at <code>cartog ide</code> and <code>cartog index</code>.</p>
       <pre>cartog init                  <span class="comment"># scaffold .cartog.toml</span>
 cartog init --dry-run        <span class="comment"># preview without writing</span></pre>
+      <p class="example-label">Example output (already-initialized project, <code>--dry-run</code>)</p>
+      <pre class="example-output">+ .cartog.toml (/your/repo/.cartog.toml): already present, left untouched
+
+Dry run only. Re-run without --dry-run to apply.</pre>
       <p>Never overwrites an existing <code>.cartog.toml</code>. Re-running is a no-op (still prints the next-steps hint).</p>
 
       <h2 id="cmd-ide"><code>cartog ide</code></h2>
@@ -379,6 +494,20 @@ cartog ide --scope user             <span class="comment"># only user-scope clie
 cartog ide --scope project          <span class="comment"># only project-scoped clients (.mcp.json, .cursor/, .vscode/)</span>
 cartog ide --dry-run                <span class="comment"># preview with before/after diff</span>
 cartog ide --no-watch               <span class="comment"># drop --watch from Claude Code args</span></pre>
+      <p class="example-label">Example output (<code>--dry-run --client cursor</code>)</p>
+      <pre class="example-output">+ cursor (project, /your/repo/.cursor/mcp.json): would create
+  --- after ---
+    {
+      "mcpServers": {
+        "cartog": {
+          "command": "cartog",
+          "args": ["serve"]
+        }
+      }
+    }
+
+1 clients: 1 created, 0 updated, 0 unchanged, 0 skipped, 0 errors
+Dry run only. Re-run without --dry-run to apply.</pre>
       <p>Clients: <code>claude-code</code> (project + user), <code>claude-desktop</code>, <code>codex</code>, <code>cursor</code>, <code>gemini</code>, <code>opencode</code>, <code>vscode</code>, <code>windsurf</code>, <code>zed</code>. See the <a href="#mcp-ide">Bootstrap sequence</a> for the recommended verb order.</p>
 
       <h2 id="cmd-self"><code>cartog self &lt;update|version|rollback|migrate-db&gt;</code></h2>
@@ -389,6 +518,11 @@ cartog self version             <span class="comment"># target + install source 
 cartog self rollback            <span class="comment"># restore the previous binary</span>
 cartog self migrate-db          <span class="comment"># move legacy .cartog.db into .cartog/db.sqlite</span>
 cartog self migrate-db --dry-run <span class="comment"># preview the move without touching disk</span></pre>
+      <p class="example-label">Example output (<code>cartog self version</code>)</p>
+      <pre class="example-output">cartog 0.18.0
+  target:            aarch64-apple-darwin
+  install source:    release-tarball
+  last update check: 2026-05-27T14:50:47Z</pre>
       <p>Auto-check runs at most once per 24h on interactive sessions; suppressed under <code>CARTOG_NO_UPDATE_CHECK=1</code>, non-TTY stdout, and inside <code>cartog serve</code>/<code>watch</code>. <code>migrate-db</code> refuses to overwrite an existing <code>.cartog/db.sqlite</code>, refuses to run while a peer process holds the lock <strong>for this project's database</strong> (a peer on an unrelated project does not block it), and refuses symlinked sources. See <a href="https://github.com/jrollin/cartog/blob/main/docs/updates.md">docs/updates.md</a> for the full exit-code matrix and state file location.</p>
 
       <h2 id="cmd-completions"><code>cartog completions &lt;shell&gt;</code></h2>
@@ -396,6 +530,13 @@ cartog self migrate-db --dry-run <span class="comment"># preview the move withou
       <pre>cartog completions zsh   &gt; ~/.zfunc/_cartog
 cartog completions bash  &gt; /usr/local/etc/bash_completion.d/cartog
 cartog completions fish  &gt; ~/.config/fish/completions/cartog.fish</pre>
+      <p class="example-label">Example output (first lines of <code>cartog completions zsh</code>)</p>
+      <pre class="example-output">#compdef cartog
+
+autoload -U is-at-least
+
+_cartog() {
+  ...</pre>
 
       <h2 id="cmd-manpage"><code>cartog manpage</code></h2>
       <p>Emit a <code>roff</code>-formatted man page on stdout. Intended for packagers and distro maintainers.</p>
@@ -403,6 +544,13 @@ cartog completions fish  &gt; ~/.config/fish/completions/cartog.fish</pre>
       <pre>sudo mkdir -p /usr/local/share/man/man1
 cartog manpage | sudo tee /usr/local/share/man/man1/cartog.1 &gt; /dev/null
 man cartog</pre>
+      <p class="example-label">Example output (first lines)</p>
+      <pre class="example-output">.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH cartog 1  "cartog 0.18.0"
+.SH NAME
+cartog \- Map your codebase. Navigate by graph, not grep.
+  ...</pre>
 
       <!-- ── Semantic Search ───────────────────── -->
 
@@ -420,6 +568,9 @@ provider = "none"</pre>
       <pre>cartog rag index              <span class="comment"># embed all symbols + documents</span>
 cartog rag index src/         <span class="comment"># embed subdirectory</span>
 cartog rag index --force      <span class="comment"># re-embed all</span></pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">Embedded 697 symbols in 3.1s (224/s)
+RAG index ready: 697 vectors, 384 dimensions, sqlite-vec</pre>
 
       <h2 id="rag-search"><code>cartog rag search &lt;query&gt;</code></h2>
       <p>Semantic search — use natural language to find code by behavior or concept. Returns code only by default; use <code>--kind document</code> for docs or <code>--kind all</code> for both.</p>
@@ -427,6 +578,13 @@ cartog rag index --force      <span class="comment"># re-embed all</span></pre>
 cartog rag search "error handling" --kind function
 cartog rag search "database connection" --limit 5
 cartog rag search "deployment architecture" --kind document</pre>
+      <p class="example-label">Example output</p>
+      <pre class="example-output">Found 1 results (FTS: 1, vector: 0, merged: 1)
+
+1. function auth_middleware  middleware/auth_mw.py:15-37  [fts5] score=0.0164
+    def auth_middleware(request: Dict[str, Any]) -&gt; Dict[str, Any]:
+        """Verify authentication token and attach user context."""
+        validate_request(request)</pre>
       <p>Combines keyword (BM25/FTS5) and vector similarity, merged via RRF, then re-ranked by a cross-encoder. By default, returns code only; use <code>--kind document</code> for docs or <code>--kind all</code> for both.</p>
       <p>Available <code>--kind</code> values: <code>function</code>, <code>class</code>, <code>method</code>, <code>variable</code>, <code>import</code>, <code>interface</code>, <code>enum</code>, <code>type-alias</code>, <code>trait</code>, <code>module</code>, <code>document</code>, <code>all</code>.</p>
 

--- a/site/usage.html
+++ b/site/usage.html
@@ -361,16 +361,22 @@ ExpiredTokenError auth/tokens.py:50</pre>
     calls  get_current_user          auth/middleware.py:61</pre>
       <p>Answers "what breaks if I change this?".</p>
 
-      <h2 id="cmd-hierarchy"><code>cartog hierarchy &lt;class&gt;</code></h2>
-      <p>Show inheritance relationships — both parents and children.</p>
-      <pre>cartog hierarchy AuthService</pre>
+      <h2 id="cmd-hierarchy"><code>cartog hierarchy &lt;class&gt; [--mermaid]</code></h2>
+      <p>Show inheritance relationships — both parents and children. Add <code>--mermaid</code> for a <code>graph TD</code> diagram you can paste into a PR description, doc, or mermaid.live.</p>
+      <pre>cartog hierarchy AuthService
+cartog hierarchy AuthService --mermaid</pre>
       <p class="example-label">Example output</p>
       <pre class="example-output">AuthService -&gt; BaseService
 AdminService -&gt; AuthService</pre>
+      <p class="example-label">With <code>--mermaid</code></p>
+      <pre class="example-output">graph TD
+    AuthService["AuthService"] --&gt; BaseService["BaseService"]
+    AdminService["AdminService"] --&gt; AuthService["AuthService"]</pre>
 
-      <h2 id="cmd-deps"><code>cartog deps &lt;file&gt;</code></h2>
-      <p>List symbols imported by a file — answers "what does this file depend on?".</p>
-      <pre>cartog deps auth/service.py</pre>
+      <h2 id="cmd-deps"><code>cartog deps &lt;file&gt; [--mermaid]</code></h2>
+      <p>List symbols imported by a file — answers "what does this file depend on?". Add <code>--mermaid</code> for a <code>graph LR</code> diagram rooted at the file.</p>
+      <pre>cartog deps auth/service.py
+cartog deps auth/service.py --mermaid</pre>
       <p class="example-label">Example output</p>
       <pre class="example-output">Optional         L3
 validate_token   L5
@@ -378,6 +384,12 @@ generate_token   L5
 revoke_token     L5
 User             L6
 get_logger       L7</pre>
+      <p class="example-label">With <code>--mermaid</code></p>
+      <pre class="example-output">graph LR
+    auth_service_py["auth/service.py"]
+    auth_service_py --&gt; validate_token["validate_token (L5)"]
+    auth_service_py --&gt; generate_token["generate_token (L5)"]
+    auth_service_py --&gt; User["User (L6)"]</pre>
 
       <h2 id="cmd-stats"><code>cartog stats [--savings]</code></h2>
       <p>Summary of the index — file count, symbol count, edge resolution rate. On an unindexed repo all counts are <code>0</code> and the output ends with a hint to run <code>cartog index .</code>. Pass <code>--savings</code> to show per-tool query counts and estimated tokens saved instead (or use the <a href="#cmd-savings"><code>cartog savings</code></a> alias).</p>
@@ -427,10 +439,11 @@ All 6 checks passed</pre>
       <p>Each check reports <strong>OK</strong>, <strong>Warn</strong>, or <strong>Error</strong>. Exits with code 1 if any check is an error. Run this when commands fail unexpectedly or after first setup.</p>
 
       <h2 id="cmd-map"><code>cartog map</code></h2>
-      <p>Token-budget-aware codebase summary — file tree + top symbols ranked by reference count.</p>
+      <p>Token-budget-aware codebase summary — file tree + top symbols ranked by reference count. Add <code>--mermaid</code> for a <code>graph TD</code> rooted at "Repo"; the token budget still applies (renderer stops adding nodes before it overflows).</p>
       <pre>cartog map                    <span class="comment"># default 4000 tokens</span>
 cartog map --tokens 2000      <span class="comment"># compact</span>
-cartog map --tokens 8000      <span class="comment"># detailed</span></pre>
+cartog map --tokens 8000      <span class="comment"># detailed</span>
+cartog map --mermaid          <span class="comment"># paste-into-PR diagram</span></pre>
       <p class="example-label">Example output (truncated)</p>
       <pre class="example-output"># Codebase Map (70 files)
 
@@ -443,6 +456,16 @@ cartog map --tokens 8000      <span class="comment"># detailed</span></pre>
   auth/service.py
   auth/tokens.py
   ...</pre>
+      <p class="example-label">With <code>--mermaid</code> (truncated)</p>
+      <pre class="example-output">graph TD
+    repo["Repo"]
+    repo --&gt; README_md["README.md"]
+    repo --&gt; auth_service_py["auth/service.py"]
+    repo --&gt; auth_tokens_py["auth/tokens.py"]
+    auth_tokens_py --&gt; auth_tokens_py__validate_token["validate_token (function)"]
+    auth_tokens_py --&gt; auth_tokens_py__generate_token["generate_token (function)"]
+    ...</pre>
+      <p style="font-size: 13px; color: var(--text-tertiary);"><code>--json</code> wins over <code>--mermaid</code> when both are passed.</p>
 
       <h2 id="cmd-changes"><code>cartog changes</code></h2>
       <p>Show symbols affected by recent git changes.</p>

--- a/site/usage.html
+++ b/site/usage.html
@@ -95,6 +95,7 @@
           <a href="#mcp-quickstart">Wiring editors: cartog ide</a>
           <a href="#mcp-ide">Bootstrap sequence</a>
           <a href="#mcp-clients">Manual setup</a>
+          <a href="#teach-agent">Teach your agent</a>
         </div>
         <div class="sidebar-group">
           <div class="sidebar-label">Reference</div>
@@ -398,7 +399,9 @@ cartog completions fish  &gt; ~/.config/fish/completions/cartog.fish</pre>
 
       <h2 id="cmd-manpage"><code>cartog manpage</code></h2>
       <p>Emit a <code>roff</code>-formatted man page on stdout. Intended for packagers and distro maintainers.</p>
-      <pre>cartog manpage &gt; /usr/local/share/man/man1/cartog.1
+      <p>The output filename <strong>must</strong> end in <code>.1</code> (the section-1 extension <code>man</code> looks for) and the target directory must exist:</p>
+      <pre>sudo mkdir -p /usr/local/share/man/man1
+cartog manpage | sudo tee /usr/local/share/man/man1/cartog.1 &gt; /dev/null
 man cartog</pre>
 
       <!-- ── Semantic Search ───────────────────── -->
@@ -486,56 +489,77 @@ cartog ide                   <span class="comment"># optional — wire MCP into 
       <p>Edit <code>.cartog.toml</code> between steps 1 and 2 to change DB path or embedding provider before any heavy work runs. CLI-only users stop after step 2; run <code>cartog ide</code> only if you want cartog wired into MCP-aware editors.</p>
 
       <h2 id="mcp-clients">Manual setup (per client)</h2>
-      <p>If you prefer to edit MCP configs by hand, here are the canonical paths and JSON shapes <code>cartog ide</code> writes.</p>
+      <p>Each block below shows the <code>cartog ide</code> one-liner that writes the right file, plus the manual JSON / TOML if you prefer to edit by hand.</p>
 
-      <h3>Claude Code</h3>
-      <pre>claude mcp add cartog -- cartog serve --watch</pre>
-      <p>Or edit <code>~/.claude/settings.json</code>:</p>
-      <pre>{
+      <details class="mcp-client">
+        <summary><strong>Claude Code</strong> — project <code>.mcp.json</code> + user <code>~/.claude/settings.json</code></summary>
+        <pre>cartog ide --client claude-code
+<span class="comment"># or:</span>
+claude mcp add cartog -- cartog serve --watch                       <span class="comment"># user scope</span>
+claude mcp add --scope project cartog -- cartog serve --watch       <span class="comment"># project scope</span></pre>
+        <p>Manual:</p>
+        <pre>{
   "mcpServers": {
-    "cartog": {
-      "command": "cartog",
-      "args": ["serve", "--watch"]
-    }
+    "cartog": { "command": "cartog", "args": ["serve", "--watch"] }
   }
 }</pre>
+      </details>
 
-      <h3>Claude Desktop</h3>
-      <p>Edit <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>:</p>
-      <pre>{
+      <details class="mcp-client">
+        <summary><strong>Cursor</strong> — project <code>.cursor/mcp.json</code></summary>
+        <pre>cartog ide --client cursor</pre>
+        <p>Manual:</p>
+        <pre>{
   "mcpServers": {
-    "cartog": {
-      "command": "cartog",
-      "args": ["serve"]
-    }
+    "cartog": { "command": "cartog", "args": ["serve"] }
   }
 }</pre>
+      </details>
 
-      <h3>Cursor</h3>
-      <p>Edit <code>.cursor/mcp.json</code> in your project root:</p>
-      <pre>{
+      <details class="mcp-client">
+        <summary><strong>Codex CLI</strong> — user-global <code>~/.codex/config.toml</code></summary>
+        <pre>cartog ide --client codex</pre>
+        <p>Codex stores all MCP servers in this one user-global file (no per-project config), so <code>cartog ide</code> writes a per-project <code>[mcp_servers.cartog-&lt;slug&gt;-&lt;hash8&gt;]</code> section.</p>
+        <pre>[mcp_servers.cartog]
+command = "cartog"
+args = ["serve"]</pre>
+      </details>
+
+      <details class="mcp-client">
+        <summary><strong>Windsurf</strong> — <code>~/.codeium/windsurf/mcp_config.json</code></summary>
+        <pre>cartog ide --client windsurf</pre>
+        <pre>{
   "mcpServers": {
-    "cartog": {
-      "command": "cartog",
-      "args": ["serve"]
-    }
+    "cartog": { "command": "cartog", "args": ["serve"] }
   }
 }</pre>
+      </details>
 
-      <h3>Windsurf</h3>
-      <p>Edit <code>~/.codeium/windsurf/mcp_config.json</code>:</p>
-      <pre>{
-  "mcpServers": {
-    "cartog": {
-      "command": "cartog",
-      "args": ["serve"]
-    }
+      <details class="mcp-client">
+        <summary><strong>VS Code (Copilot)</strong> — <code>.vscode/mcp.json</code></summary>
+        <pre>cartog ide --client vscode</pre>
+        <p>Note: top-level key is <code>servers</code>, not <code>mcpServers</code>.</p>
+        <pre>{
+  "servers": {
+    "cartog": { "type": "stdio", "command": "cartog", "args": ["serve"] }
   }
 }</pre>
+      </details>
 
-      <h3>OpenCode</h3>
-      <p>Edit <code>~/.config/opencode/opencode.json</code>:</p>
-      <pre>{
+      <details class="mcp-client">
+        <summary><strong>Zed</strong> — <code>~/.config/zed/settings.json</code></summary>
+        <pre>cartog ide --client zed</pre>
+        <pre>{
+  "context_servers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
+  }
+}</pre>
+      </details>
+
+      <details class="mcp-client">
+        <summary><strong>OpenCode</strong> — <code>~/.config/opencode/opencode.json</code></summary>
+        <pre>cartog ide --client opencode</pre>
+        <pre>{
   "mcp": {
     "cartog": {
       "type": "local",
@@ -544,49 +568,46 @@ cartog ide                   <span class="comment"># optional — wire MCP into 
     }
   }
 }</pre>
+      </details>
 
-      <h3>Zed</h3>
-      <p>Edit <code>~/.config/zed/settings.json</code>:</p>
-      <pre>{
-  "context_servers": {
-    "cartog": {
-      "command": "cartog",
-      "args": ["serve"]
-    }
-  }
-}</pre>
-
-      <h3>Codex CLI</h3>
-      <p>Edit <code>~/.codex/config.toml</code>. Codex stores all MCP servers in this one user-global file (no per-project config), so <code>cartog ide</code> writes a per-project <code>[mcp_servers.cartog-&lt;dir&gt;-&lt;hash&gt;]</code> section.</p>
-      <pre>[mcp_servers.cartog]
-command = "cartog"
-args = ["serve"]</pre>
-
-      <h3>Gemini CLI</h3>
-      <p>Edit <code>~/.gemini/settings.json</code>:</p>
-      <pre>{
+      <details class="mcp-client">
+        <summary><strong>Gemini CLI</strong> — <code>~/.gemini/settings.json</code></summary>
+        <pre>cartog ide --client gemini</pre>
+        <pre>{
   "mcpServers": {
-    "cartog": {
-      "command": "cartog",
-      "args": ["serve"]
-    }
+    "cartog": { "command": "cartog", "args": ["serve"] }
   }
 }</pre>
+      </details>
 
-      <h3>VS Code (Copilot)</h3>
-      <p>Edit <code>.vscode/mcp.json</code> (note: top-level key is <code>servers</code>, not <code>mcpServers</code>):</p>
-      <pre>{
-  "servers": {
-    "cartog": {
-      "type": "stdio",
-      "command": "cartog",
-      "args": ["serve"]
-    }
+      <details class="mcp-client">
+        <summary><strong>Claude Desktop</strong> — <code>claude_desktop_config.json</code></summary>
+        <pre>cartog ide --client claude-desktop</pre>
+        <p>macOS: <code>~/Library/Application Support/Claude/</code>. Windows: <code>%APPDATA%\Claude\</code>. Restart Claude Desktop after editing.</p>
+        <pre>{
+  "mcpServers": {
+    "cartog": { "command": "cartog", "args": ["serve"] }
   }
 }</pre>
+      </details>
 
-      <h3>Any MCP client</h3>
-      <p>Point your client at <code>cartog serve</code> over stdio. Command: <code>cartog</code>, args: <code>["serve"]</code>.</p>
+      <details class="mcp-client">
+        <summary><strong>Any other MCP client</strong></summary>
+        <p>Point your client at <code>cartog serve</code> over stdio. Command: <code>cartog</code>, args: <code>["serve"]</code>.</p>
+      </details>
+
+      <h2 id="teach-agent">Teach your agent to use cartog</h2>
+      <p>Wiring MCP is half the job. The other half is telling the LLM <strong>when</strong> to prefer cartog over grep + read. Drop the snippet from <a href="https://github.com/jrollin/cartog/blob/main/docs/agent-snippet.md">docs/agent-snippet.md</a> into your project's <code>AGENTS.md</code>, <code>CLAUDE.md</code>, <code>.cursor/rules/</code>, or equivalent, and the agent will route navigation questions through cartog's 13 MCP tools instead of flooding context with raw text.</p>
+      <p>Maps the natural-language question to the right tool:</p>
+      <ul>
+        <li>"where is X defined?" → <code>cartog_search</code></li>
+        <li>"who calls / imports / inherits X?" → <code>cartog_refs</code></li>
+        <li>"what does X call?" → <code>cartog_callees</code></li>
+        <li>"what breaks if I change X?" → <code>cartog_impact</code></li>
+        <li>"find code about &lt;concept&gt;" → <code>cartog_rag_search</code></li>
+        <li>"orient me in this repo" → <code>cartog_map</code></li>
+      </ul>
+      <p>Falls back to grep / Read for string literals, comments, config values, or anything outside the indexed root.</p>
 
       <!-- ── Reference ─────────────────────────── -->
 

--- a/site/usage.html
+++ b/site/usage.html
@@ -410,18 +410,30 @@ Symbols by kind:
   class: 52</pre>
 
       <h2 id="cmd-savings"><code>cartog savings</code></h2>
-      <p>Per-tool query counts + estimated tokens saved versus a grep+read baseline (~1,420 tokens/query). Visible alias of <code>cartog stats --savings</code>, shipped as a top-level verb so the retention hook is one keystroke away.</p>
+      <p>Shows tokens used by cartog vs an equivalent grep+read flow, plus the saved delta and a per-tool call-count breakdown. Visible alias of <code>cartog stats --savings</code>; shipped as a top-level verb so the retention hook is one keystroke away.</p>
       <pre>cartog savings
 cartog --json savings</pre>
       <p class="example-label">Example output</p>
-      <pre class="example-output">Total queries: 5  (~7100 tokens saved vs grep+read baseline, at 1420 tokens/query)
+      <pre class="example-output">cartog · my-project · 5 queries
 
-By tool:
-       2  search
-       1  impact
-       1  map
-       1  refs</pre>
-      <p>Data comes from a local <code>query_log</code> table inside <code>.cartog/db.sqlite</code>. Nothing leaves the machine; no query payloads are recorded — only the tool name, call surface (<code>cli</code> / <code>mcp</code>), and a timestamp. Secondary read-only MCP attaches skip the write to avoid double-counting from the primary.</p>
+████████░░  ~83% tokens saved
+
+Without cartog    ~8.5k tokens   (~1700 / query)
+With cartog       ~1.4k tokens   (~280 / query)
+──────────────────────────────────────────────
+Saved             ~7.1k tokens   (~1420 / query)
+
+By tool (call counts):
+     2  search
+     1  impact
+     1  map
+     1  refs
+
+Baseline: ~1700 tokens for an equivalent grep+read sweep vs cartog's ~280.
+Measured across 13 benchmark scenarios (see crates/cartog/benches/queries.rs).</pre>
+      <p>The header reads <code>cartog · &lt;project&gt; · &lt;N&gt; queries</code>. <strong>By tool</strong> lists <em>call counts</em> — every tool uses the same flat baseline (1,420 tokens saved per call), so the breakdown shows which navigation patterns you rely on, not which tool saved the most.</p>
+      <p>Only queries returning a non-empty result count toward the totals. Empty-index calls, typo'd symbol names, and outline against missing files are skipped so the figure reflects real work.</p>
+      <p>Data comes from a local <code>query_log</code> table inside <code>.cartog/db.sqlite</code>. Nothing leaves the machine; no query payloads are recorded — only the tool name, call surface (<code>cli</code> / <code>mcp</code>), and a timestamp. Secondary read-only MCP attaches can't write, so multi-MCP-server setups under-report secondary traffic rather than double-counting it.</p>
 
       <h2 id="cmd-doctor"><code>cartog doctor</code></h2>
       <p>Validate that all requirements are met and everything is working. Checks git repo, config, database, embedding provider, and reranker.</p>

--- a/site/usage.html
+++ b/site/usage.html
@@ -488,6 +488,7 @@ Dry run only. Re-run without --dry-run to apply.</pre>
 
       <h2 id="cmd-ide"><code>cartog ide</code></h2>
       <p>Wire <code>cartog serve</code> into one or all MCP-compatible editors. The only verb that writes editor configs.</p>
+      <p style="font-size: 13px; color: var(--text-tertiary);"><code>cartog install</code> is a visible alias — same flags, same behavior, just a more discoverable name.</p>
       <pre>cartog ide                          <span class="comment"># all installed clients, all scopes</span>
 cartog ide --client cursor          <span class="comment"># one client</span>
 cartog ide --scope user             <span class="comment"># only user-scope clients</span>
@@ -661,6 +662,7 @@ claude mcp add --scope project cartog -- cartog serve --watch       <span class=
     "cartog": { "command": "cartog", "args": ["serve", "--watch"] }
   }
 }</pre>
+        <p style="font-size: 13px; color: var(--text-tertiary); margin-top: 8px;">Only Claude Code gets <code>--watch</code> by default — other clients ship plain <code>["serve"]</code>. Agent-driven flows churn files faster than human-driven editor flows, so the in-process file watcher pays off. Drop it with <code>cartog ide --no-watch</code>.</p>
       </details>
 
       <details class="mcp-client">

--- a/site/usage.html
+++ b/site/usage.html
@@ -525,16 +525,23 @@ cartog init --dry-run        <span class="comment"># preview without writing</sp
 Dry run only. Re-run without --dry-run to apply.</pre>
       <p>Never overwrites an existing <code>.cartog.toml</code>. Re-running is a no-op (still prints the next-steps hint).</p>
 
-      <h2 id="cmd-ide"><code>cartog ide</code></h2>
-      <p>Wire <code>cartog serve</code> into one or all MCP-compatible editors. The only verb that writes editor configs.</p>
-      <p style="font-size: 13px; color: var(--text-tertiary);"><code>cartog install</code> is a visible alias — same flags, same behavior, just a more discoverable name.</p>
-      <pre>cartog ide                          <span class="comment"># all installed clients, all scopes</span>
-cartog ide --client cursor          <span class="comment"># one client</span>
-cartog ide --scope user             <span class="comment"># only user-scope clients</span>
-cartog ide --scope project          <span class="comment"># only project-scoped clients (.mcp.json, .cursor/, .vscode/)</span>
-cartog ide --dry-run                <span class="comment"># preview with before/after diff</span>
-cartog ide --no-watch               <span class="comment"># drop --watch from Claude Code args</span></pre>
-      <p class="example-label">Example output (<code>--dry-run --client cursor</code>)</p>
+      <h2 id="cmd-ide"><code>cartog ide</code> / <code>cartog install</code></h2>
+      <p>Wire <code>cartog serve</code> into one or all MCP-compatible editors. Two shapes:</p>
+      <ul>
+        <li><strong><code>cartog install &lt;client&gt;...</code></strong> — positional, brew/npm/pip convention, always non-interactive. Safe for scripts and agents.</li>
+        <li><strong><code>cartog ide</code></strong> — original, supports an interactive multi-select picker (bare) and the long-form flags below.</li>
+      </ul>
+      <pre>cartog install cursor                 <span class="comment"># one editor</span>
+cartog install cursor vscode codex    <span class="comment"># several at once</span>
+cartog install                        <span class="comment"># all detected editors</span>
+cartog install cursor --dry-run       <span class="comment"># preview</span>
+
+cartog ide                            <span class="comment"># interactive picker (TTY only)</span>
+cartog ide --client cursor            <span class="comment"># single client via flag</span>
+cartog ide --scope project            <span class="comment"># only project-scoped (.mcp.json, .cursor/, .vscode/)</span>
+cartog ide --dry-run                  <span class="comment"># preview with before/after diff</span>
+cartog ide --no-watch                 <span class="comment"># drop --watch from Claude Code args</span></pre>
+      <p class="example-label">Example output (<code>cartog ide --client cursor --dry-run</code>)</p>
       <pre class="example-output">+ cursor (project, /your/repo/.cursor/mcp.json): would create
   --- after ---
     {
@@ -547,6 +554,24 @@ cartog ide --no-watch               <span class="comment"># drop --watch from Cl
     }
 
 1 clients: 1 created, 0 updated, 0 unchanged, 0 skipped, 0 errors
+Dry run only. Re-run without --dry-run to apply.</pre>
+      <p class="example-label">Example output (<code>cartog install cursor vscode --dry-run</code>)</p>
+      <pre class="example-output">+ cursor (project, /your/repo/.cursor/mcp.json): would create
+  --- after ---
+    {
+      "mcpServers": {
+        "cartog": { "command": "cartog", "args": ["serve"] }
+      }
+    }
++ vscode (project, /your/repo/.vscode/mcp.json): would create
+  --- after ---
+    {
+      "servers": {
+        "cartog": { "type": "stdio", "command": "cartog", "args": ["serve"] }
+      }
+    }
+
+2 clients: 2 created, 0 updated, 0 unchanged, 0 skipped, 0 errors
 Dry run only. Re-run without --dry-run to apply.</pre>
       <p>Clients: <code>claude-code</code> (project + user), <code>claude-desktop</code>, <code>codex</code>, <code>cursor</code>, <code>gemini</code>, <code>opencode</code>, <code>vscode</code>, <code>windsurf</code>, <code>zed</code>. See the <a href="#mcp-ide">Bootstrap sequence</a> for the recommended verb order.</p>
 

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -108,10 +108,11 @@ All examples below use CLI syntax. MCP tool names and parameters:
 | `cartog hierarchy <class>` | `cartog_hierarchy` | `name` |
 | `cartog deps <file>` | `cartog_deps` | `file` |
 | `cartog changes` | `cartog_changes` | `commits?`, `kind?` |
-| `cartog stats` | `cartog_stats` | — |
+| `cartog stats [--savings]` | `cartog_stats` | — |
+| `cartog savings` | — (CLI only — alias for `cartog stats --savings`) | — |
 | `cartog doctor` | — (CLI only) | — |
 | `cartog init` | — (CLI only) | — |
-| `cartog ide` | — (CLI only) | — |
+| `cartog ide` (interactive picker) / `cartog install <client>...` (positional) | — (CLI only) | — |
 | `cartog config` | — (CLI only) | — |
 
 ## Setup
@@ -328,10 +329,14 @@ cartog --json doctor                     # structured JSON output
 ```
 Validates git repo, config, database, embedding provider, and reranker. Returns OK / Warn / Error per check and exits with code 1 if any error. Run this when commands fail unexpectedly or after first setup to verify everything is working.
 
-### Stats (index summary)
+### Stats (index summary, savings retention hook)
 ```bash
-cartog stats
+cartog stats                # files, symbols, edges, languages
+cartog stats --savings      # per-tool query counts + tokens saved vs grep+read
+cartog savings              # alias for `cartog stats --savings`
 ```
+
+`cartog savings` is the retention hook: it surfaces ongoing ROI in one keystroke. Only counts queries that returned a non-empty result (empty-index calls and typo'd names are skipped, so the number reflects real work).
 
 ### Watch (auto re-index on file changes)
 ```bash
@@ -373,17 +378,26 @@ cartog init --dry-run           # preview without writing
 
 **When to suggest it**: the user is starting cartog on a fresh repo (no `.cartog.toml` at the git root). The agent should mention it once, then continue with `cartog index` to build the graph. CLI-only users stop there; users on Claude Code / Cursor / VS Code / etc. can then run `cartog ide`.
 
-### Ide (wire cartog into editors — user-facing, interactive)
+### Wire cartog into editors
+
+Two shapes for the same operation:
+
 ```bash
-cartog ide --yes                              # configure all detected clients, non-interactive
-cartog ide --client cursor --yes              # one specific client
+# `cartog install` — positional, brew/npm/pip convention. Always non-interactive.
+cartog install cursor                         # one editor
+cartog install cursor vscode codex            # several editors at once
+cartog install                                # all detected editors (no positional = "all")
+cartog install cursor --dry-run               # preview without writing
+cartog install claude-code --no-watch         # drop --watch from Claude Code args
+
+# `cartog ide` — original, supports the interactive multi-select picker.
+cartog ide --yes                              # all detected clients, non-interactive
+cartog ide --client cursor --yes              # one client (long-form)
 cartog ide --scope project --yes              # only .mcp.json / .cursor/mcp.json / .vscode/mcp.json
-cartog ide --client claude-code --no-watch --yes  # wire Claude Code without --watch
-cartog ide --scope user --yes                 # only user-scope clients
 cartog ide --dry-run                          # preview without writing
 ```
 
-**Agent gotcha**: `cartog ide` runs an interactive multi-select picker by default. **An agent calling it via Bash MUST pass `--yes` (or `--client X` / `--dry-run`), otherwise the command will block waiting for user input.** Non-TTY stdin is also treated as non-interactive.
+**Agent gotcha**: `cartog ide` (bare) runs an interactive multi-select picker. **An agent calling it via Bash MUST pass `--yes` (or `--client X` / `--dry-run`)**, otherwise the command blocks waiting for input. `cartog install` is always non-interactive, so it's the safe default for agents.
 
 Supported clients: `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini`, `opencode`, `vscode`, `windsurf`, `zed`. User-scope clients whose config dir is missing are reported as "not installed" and skipped. Existing MCP entries for other servers are preserved (idempotent merge).
 

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -295,11 +295,13 @@ Shows everything that transitively depends on a symbol up to N hops.
 ### Hierarchy (inheritance tree)
 ```bash
 cartog hierarchy BaseService
+cartog hierarchy BaseService --mermaid   # paste-into-PR diagram
 ```
 
 ### Deps (file imports)
 ```bash
 cartog deps src/routes/auth.py
+cartog deps src/routes/auth.py --mermaid # graph LR with file as root
 ```
 
 ### Map (codebase overview)
@@ -307,8 +309,9 @@ cartog deps src/routes/auth.py
 cartog map                               # default 4000 tokens
 cartog map --tokens 2000                 # compact
 cartog map --tokens 8000                 # detailed
+cartog map --mermaid                     # graph TD rooted at "Repo"
 ```
-File tree + top symbols ranked by reference count (centrality). Use at the start of a session for context loading.
+File tree + top symbols ranked by reference count (centrality). Use at the start of a session for context loading. `--mermaid` honors the token budget by stopping before it overflows.
 
 ### Changes (recently modified symbols)
 ```bash
@@ -445,6 +448,7 @@ For the full 3-phase workflow (heuristic → LSP upgrade → verify), see `refer
 | Check if a change is safe | `cartog impact <name> --depth 3` |
 | Understand class hierarchy | `cartog hierarchy <class>` |
 | See file dependencies | `cartog deps <file>` |
+| Render a diagram to paste into a PR / doc | append `--mermaid` to `hierarchy`, `deps`, or `map` |
 | See what changed recently | `cartog changes` (`--commits N` for more history) |
 | Improve graph precision for a refactoring | `cartog index .` (with LSP auto-detected) |
 | Fast re-index after code changes | `cartog index . --no-lsp` |

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -332,11 +332,35 @@ Validates git repo, config, database, embedding provider, and reranker. Returns 
 ### Stats (index summary, savings retention hook)
 ```bash
 cartog stats                # files, symbols, edges, languages
-cartog stats --savings      # per-tool query counts + tokens saved vs grep+read
+cartog stats --savings      # tokens-saved breakdown (see below)
 cartog savings              # alias for `cartog stats --savings`
 ```
 
-`cartog savings` is the retention hook: it surfaces ongoing ROI in one keystroke. Only counts queries that returned a non-empty result (empty-index calls and typo'd names are skipped, so the number reflects real work).
+`cartog savings` is the retention hook. Output shape:
+
+```
+cartog · my-project · 5 queries
+
+████████░░  ~83% tokens saved
+
+Without cartog    ~8.5k tokens   (~1700 / query)
+With cartog       ~1.4k tokens   (~280 / query)
+──────────────────────────────────────────────
+Saved             ~7.1k tokens   (~1420 / query)
+
+By tool (call counts):
+     2  search
+     1  impact
+     1  map
+     1  refs
+```
+
+Key facts an agent should know:
+
+- **With vs without** — `Without cartog` is an equivalent grep+read flow, baselined at ~1,700 tokens/query. `With cartog` uses the measured ~280 tokens/query.
+- **By tool** = **call counts**, not per-tool token savings (the multiplier is flat across all tools). The breakdown shows which navigation patterns the user actually relies on.
+- **Empty-result queries don't count.** A `cartog search nonexistent` that returns `[]` is not logged — savings reflect real work, not exploratory pings.
+- Only writable databases can log. Secondary read-only MCP attaches skip the write, so multi-MCP setups under-report secondary traffic rather than double-counting it.
 
 ### Watch (auto re-index on file changes)
 ```bash

--- a/skills/cartog/tests/golden_examples.yaml
+++ b/skills/cartog/tests/golden_examples.yaml
@@ -368,3 +368,62 @@
     - cat src/auth/tokens.py
     - Reading the full file when only structure is needed
   tags: [outline]
+
+# ============================================================
+# Savings retention hook
+# ============================================================
+
+- id: savings_for_token_report
+  description: Use cartog savings to surface tokens saved vs grep+read
+  user_query: "How many tokens has cartog saved me so far in this project?"
+  context: "cartog has been used for several days; the user wants a usage summary."
+  expected:
+    tool_calls:
+      - "cartog savings"
+    reasoning: >
+      cartog savings (or `cartog stats --savings`) reads the local query_log
+      and prints per-tool counts plus an estimated token-savings figure vs a
+      grep+read baseline. No network calls; nothing leaves the machine.
+  anti_patterns:
+    - Manually counting prior tool calls from conversation history
+    - Running cartog stats (without --savings) which only shows index totals
+
+# ============================================================
+# Editor MCP install via the friendlier alias
+# ============================================================
+
+- id: install_positional_for_editor_setup
+  description: Use `cartog install <client>` for the brew/npm-style shape
+  user_query: "Set up cartog for Cursor in this project."
+  context: "A .cartog.toml exists; no .cursor/mcp.json yet."
+  expected:
+    tool_calls:
+      - "cartog install cursor"
+    reasoning: >
+      `cartog install` takes editors as positional args (brew/npm/pip
+      convention) and is always non-interactive — safe for agents to call
+      via Bash. `cartog ide` (bare) would block on the interactive picker.
+  anti_patterns:
+    - cartog ide (bare; interactive picker blocks the agent)
+    - cartog ide --client cursor --yes (still works but more verbose than the install shape)
+    - Hand-editing .cursor/mcp.json
+
+# ============================================================
+# Mermaid diagram for PRs / docs
+# ============================================================
+
+- id: mermaid_for_pr_diagram
+  description: Use --mermaid to produce paste-into-PR diagrams
+  user_query: "Give me a Mermaid diagram of the AuthService inheritance tree to paste into the PR."
+  context: "AuthService exists in the indexed code."
+  expected:
+    tool_calls:
+      - "cartog hierarchy AuthService --mermaid"
+    reasoning: >
+      --mermaid emits a graph TD on stdout that pastes directly into GitHub
+      markdown, mermaid.live, or any docs site. Same flag is available on
+      cartog deps and cartog map.
+  anti_patterns:
+    - cartog hierarchy AuthService (plain text — not paste-ready)
+    - Building the diagram by hand from the plain output
+  tags: [outline]

--- a/skills/cartog/tests/golden_examples.yaml
+++ b/skills/cartog/tests/golden_examples.yaml
@@ -382,11 +382,13 @@
       - "cartog savings"
     reasoning: >
       cartog savings (or `cartog stats --savings`) reads the local query_log
-      and prints per-tool counts plus an estimated token-savings figure vs a
-      grep+read baseline. No network calls; nothing leaves the machine.
+      and prints a with/without/saved breakdown plus a per-tool call-count
+      list. By-tool counts are call counts, not token totals — the multiplier
+      is flat. No network calls; nothing leaves the machine.
   anti_patterns:
     - Manually counting prior tool calls from conversation history
     - Running cartog stats (without --savings) which only shows index totals
+    - Treating the "By tool" rows as per-tool token figures
 
 # ============================================================
 # Editor MCP install via the friendlier alias


### PR DESCRIPTION
## Summary

Adoption-focused work driven by a competitive scan of semble, code-context-engine,
ast-index, and greptile. Branch ships P0 (README + agent snippet), P1a (install
alias), P1b (`cartog savings`), and P2.9 (`--mermaid`), plus a max-effort code
review pass that surfaced and fixed 15 follow-up issues.

7 commits, ~1500 net lines added.

### What's new

**Docs / adoption surface**

- Hero: quantified claim line (`~280 tokens/query, 97% recall, 8 us to 20 ms latency, 9 languages`)
- New `docs/agent-snippet.md`: paste-into-project rules teaching agents when to prefer cartog MCP tools over grep
- 9 collapsible `<details>` per-harness MCP blocks in the README (Claude Code, Cursor, Codex CLI, Windsurf, VS Code, Zed, OpenCode, Gemini CLI, Claude Desktop)
- `site/usage.html` mirrors the collapsibles, gets a "Teach your agent" section, and adds **example output blocks for every CLI command** (captured from `benchmarks/fixtures/webapp_py`)
- Documents the Claude Code `--watch` asymmetry rationale
- `cartog manpage` install snippet fixed: requires `.1` extension + `sudo mkdir -p` + `sudo tee`

**New CLI surface**

- `cartog install` (visible alias of `cartog ide`)
- `cartog stats --savings` + `cartog savings` top-level alias: per-tool query counts + estimated tokens saved vs grep+read baseline (1,420 tokens/query)
- `cartog hierarchy --mermaid`, `cartog deps --mermaid`, `cartog map --mermaid`: paste-into-PR Mermaid diagrams (schema-v5 `query_log` table backs the savings counter)

**Code review fixes (15 findings, 1 commit)**

Mermaid renderer:
- `escape_label` entity-encodes `<`, `>`, `&`, `"` so DOMPurify doesn't strip generic-type substrings (`Vec<T>`, `Result<E>`)
- `render_deps` and `render_map` namespace node IDs with FNV-1a hash suffix so distinct paths don't collide (`foo/bar.py` vs `foo_bar.py`)
- `render_hierarchy` dedups identical edges (polyglot fixtures)
- 6 new unit tests pin the invariants

Logging correctness:
- MCP `tool_response_named` logs after `has_indexed_files()` succeeds and only when non-empty
- `cartog_stats` MCP handler now logs itself (bypasses `tool_response_named`)
- `cmd_map`, `cmd_changes` move log calls past early-return guards
- `log_query` doc comment fixed to accurately describe read-only behavior
- `log_query` emits a one-shot loud error on first failure so persistently-broken `query_log` is visible
- `savings_breakdown` returns empty report on missing `query_log` table (read-only attach safety)

Performance / hygiene:
- `cmd_map --mermaid` uses `HashSet< & str>` for file membership (was O(N*M))
- `cmd_map --mermaid` `leaf_cost` now accounts for the file-path component embedded in symbol IDs (was undershooting --tokens budget by ~2x on deep paths)
- `sym.kind.as_str()` instead of `Display::fmt` allocation
- `cmd_stats` now threads `token_budget` so `cartog --tokens N savings` honors the flag
- `docs/agent-snippet.md` "13 tools" claim accurate (added `cartog_rag_index`)

## Test plan

- [x] `make check-rust` passes
- [x] `make check-skill` passes (36 tests)
- [x] `cargo test -p cartog-db` (137 tests including 3 new query_log tests)
- [x] `cargo test -p cartog` (192 tests including 10 mermaid tests)
- [x] Smoke-tested end-to-end on `benchmarks/fixtures/webapp_py`:
  - `cartog hierarchy AuthService --mermaid` renders inheritance diagram
  - `cartog hierarchy NoSuchClass --mermaid` prints stderr hint + bare header
  - `cartog deps auth/service.py --mermaid` namespaces target IDs
  - `cartog map --tokens 200 --mermaid` honors budget
  - `cartog savings` reports per-tool counts with `~tokens saved`
  - `cartog --tokens 5 savings` truncates correctly
- [ ] PR-reviewer pass on the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --mermaid diagram output for hierarchy, deps, and map.
  * Added cartog savings and cartog stats --savings to report query/token savings.
  * Added non‑interactive cartog install as an alias for editor wiring.

* **Documentation**
  * Expanded MCP setup with per-client guidance and an agent routing snippet.
  * Updated usage/docs/site with examples, mermaid examples, and manpage notes.

* **Bug Fixes / Accuracy**
  * Improved savings accounting so only real, non-empty queries are logged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->