### PR TITLE
refactor: Rust best-practices review fixes + CI/build tune-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # The default-feature suite is run (and gated) by the `coverage` job via
+    # `cargo llvm-cov`, so it is not repeated here. This job covers only the
+    # `--no-default-features` build, which `coverage` does not exercise.
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
       - run: cargo test --no-default-features
 
   test-remote:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,24 @@ Run `make check` before committing. Run `make eval-skill` after changing skill S
 
 ## Code Conventions
 
-- **Error handling**: `anyhow::Result` everywhere, no `unwrap()` in library code.
+- **Error handling**: `anyhow::Result` everywhere, no `unwrap()`/`expect()` in library code. Add `.context()`/`.with_context()` so failures name what/where/why.
 - **Output**: human-readable by default, `--json` flag for structured output.
 - **Visibility**: all public functions get `///` doc comments.
 - **Tests**: unit tests co-located in each module (`#[cfg(test)] mod tests`), integration fixtures in `tests/fixtures/`.
+
+### Rust standard
+
+Idiomatic-Rust expectations follow the `rust-skills` rubric (179 rules / 14 categories — own/err/mem/api/async/opt/name/type/test/doc/perf/proj/lint/anti). Don't restate it here; apply it. The points below are the ones that bind *this* codebase — keep them true on every change:
+
+- **Borrow, don't own in signatures**: take `&[T]` not `&Vec<T>`, `&str` not `&String`. Accept `impl Into<String>` for owned-string inputs (see `Symbol::new`, `Edge::new`).
+- **No panic on input**: parsing arbitrary source (`cartog-languages`) and indexing whole repos (`cartog-indexer`) must degrade — log + skip the file, never `unwrap()`/`expect()`/index-panic. Reserve `expect()` for true invariants and document why.
+- **SQL is always parameterized**: rusqlite `params!` / `?` placeholders. Only ever interpolate placeholder *counts* for `IN (...)` — never a value, never an identifier from untrusted input.
+- **Async (`cartog-mcp`)**: do blocking work (DB, embeddings, fs) inside `spawn_blocking`; never hold a `std::sync` lock across `.await`; use `tokio::sync` for locks that must span awaits.
+- **RAII for resources**: child processes (`cartog-lsp`) and PID locks (`cartog-process-lock`) release on `Drop`. Any new owned resource gets the same.
+- **`unsafe`**: only in `cartog-process-lock`; every `unsafe` fn/block carries a `# Safety` note and checks the libc/Win32 return.
+- **`#[must_use]`**: put it on builder methods returning `Self` and on functions whose ignored return is always a bug.
+- **Enums over stringly-typed**: prefer a `#[derive(Deserialize)]` enum to a free `String` for closed sets (config provider names, kinds) so typos fail at parse time.
+- **Before committing**: `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` must pass (clippy is currently warning-clean — keep it that way).
 
 ## Architecture
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,15 @@ criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"
 serial_test = "3"
 
+[workspace.lints.rust]
+# cartog-process-lock has unsafe libc/Win32 calls; require explicit unsafe
+# blocks inside unsafe fns so each call site documents its own invariant.
+unsafe_op_in_unsafe_fn = "warn"
+
+[workspace.lints.clippy]
+# Enforce the clippy default groups on every local build, not just in CI.
+all = "warn"
+
 [profile.release]
 lto = "thin"
 strip = "debuginfo"
@@ -74,3 +83,9 @@ strip = "debuginfo"
 # opt-level=1 because tree-sitter C grammars compile very slowly at the default level=0
 [profile.dev]
 opt-level = 1
+
+# Benchmarks run with release optimizations but keep debug symbols so
+# profilers (perf, flamegraph) can attribute samples to source lines.
+[profile.bench]
+inherits = "release"
+debug = true

--- a/crates/cartog-core/Cargo.toml
+++ b/crates/cartog-core/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -41,6 +41,7 @@ impl Symbol {
     /// `visibility` defaults to `Public`, and `is_async` defaults to `false`.
     /// Use the builder-style setters to override.
     #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn new(
         name: impl Into<String>,
         kind: SymbolKind,
@@ -74,30 +75,35 @@ impl Symbol {
     }
 
     /// Set the parent symbol ID.
+    #[must_use]
     pub fn with_parent(mut self, parent_id: Option<&str>) -> Self {
         self.parent_id = parent_id.map(str::to_string);
         self
     }
 
     /// Set the function/method signature.
+    #[must_use]
     pub fn with_signature(mut self, signature: Option<String>) -> Self {
         self.signature = signature;
         self
     }
 
     /// Set the visibility.
+    #[must_use]
     pub fn with_visibility(mut self, visibility: Visibility) -> Self {
         self.visibility = visibility;
         self
     }
 
     /// Mark as async.
+    #[must_use]
     pub fn with_async(mut self, is_async: bool) -> Self {
         self.is_async = is_async;
         self
     }
 
     /// Set the docstring.
+    #[must_use]
     pub fn with_docstring(mut self, docstring: Option<String>) -> Self {
         self.docstring = docstring;
         self
@@ -121,6 +127,7 @@ pub enum SymbolKind {
 }
 
 impl SymbolKind {
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Function => "function",
@@ -174,6 +181,7 @@ pub enum Visibility {
 }
 
 impl Visibility {
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Public => "public",
@@ -183,6 +191,7 @@ impl Visibility {
     }
 
     /// Parse a visibility string, defaulting to `Public` for unknown values.
+    #[must_use]
     pub fn from_str_lossy(s: &str) -> Self {
         match s {
             "private" => Self::Private,
@@ -210,6 +219,7 @@ pub struct Edge {
 
 impl Edge {
     /// Create a new edge with `target_id` set to `None` (resolved later by `db.resolve_edges()`).
+    #[must_use]
     pub fn new(
         source_id: impl Into<String>,
         target_name: impl Into<String>,
@@ -241,6 +251,7 @@ pub enum EdgeKind {
 }
 
 impl EdgeKind {
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Calls => "calls",
@@ -300,6 +311,7 @@ pub struct ChangesResult {
 /// - Nested class:       `src/auth.py:class:Outer.Inner`
 ///
 /// This ID is stable across line movements within a file.
+#[must_use]
 pub fn symbol_id(file_path: &str, kind: &str, name: &str, parent_name: Option<&str>) -> String {
     match parent_name {
         Some(pn) => format!("{file_path}:{kind}:{pn}.{name}"),
@@ -308,6 +320,7 @@ pub fn symbol_id(file_path: &str, kind: &str, name: &str, parent_name: Option<&s
 }
 
 /// Map file extension to language name.
+#[must_use]
 pub fn detect_language(path: &Path) -> Option<&'static str> {
     let ext = path.extension()?.to_str()?;
     match ext {

--- a/crates/cartog-db/Cargo.toml
+++ b/crates/cartog-db/Cargo.toml
@@ -18,3 +18,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -332,9 +332,9 @@ pub fn normalize_symbol_name(name: &str) -> String {
                 // SCREAMING to PascalCase boundary: `HTTPResponse` → split before R
                 words.push(std::mem::take(&mut current));
             }
-            current.push(c.to_lowercase().next().unwrap());
+            current.extend(c.to_lowercase());
         } else if c.is_alphanumeric() {
-            current.push(c.to_lowercase().next().unwrap());
+            current.extend(c.to_lowercase());
         } else {
             // Non-alphanumeric (other than _ and -): treat as separator
             if !current.is_empty() {

--- a/crates/cartog-indexer/Cargo.toml
+++ b/crates/cartog-indexer/Cargo.toml
@@ -29,3 +29,6 @@ lsp = ["dep:cartog-lsp"]
 [[bench]]
 name = "indexing"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -74,20 +74,16 @@ fn parse_one_file(
 
     let modified = file_modified(path);
 
-    // Extract symbols/edges using the per-thread extractor cache.
-    let extraction = THREAD_EXTRACTORS.with(|cell| {
-        let mut map = cell.borrow_mut();
-        let extractor = map
-            .entry(lang)
-            .or_insert_with(|| get_extractor(lang).expect("lang was validated by detect_language"))
-            .as_mut();
-        extractor.extract(&source, rel_path)
-    });
+    let extraction = extract_with_cached(lang, &source, rel_path);
 
     let mut extraction = match extraction {
-        Ok(e) => e,
-        Err(err) => {
+        Some(Ok(e)) => e,
+        Some(Err(err)) => {
             warn!(file = %rel_path, error = %err, "extraction failed");
+            return ParseOutput::Failed;
+        }
+        None => {
+            warn!(file = %rel_path, lang, "no extractor registered for language");
             return ParseOutput::Failed;
         }
     };
@@ -104,6 +100,27 @@ fn parse_one_file(
         symbols: extraction.symbols,
         edges: extraction.edges,
     }
+}
+
+/// Run the per-thread cached extractor for `lang` over `source`.
+///
+/// Returns `None` when no extractor is registered for `lang` — which means
+/// `detect_language` and `get_extractor` disagree (a bug introduced when adding
+/// a language). The caller skips the file rather than panicking inside the rayon
+/// worker, which would abort the whole index run.
+fn extract_with_cached(
+    lang: &'static str,
+    source: &str,
+    rel_path: &str,
+) -> Option<Result<cartog_languages::ExtractionResult>> {
+    THREAD_EXTRACTORS.with(|cell| {
+        let mut map = cell.borrow_mut();
+        if !map.contains_key(lang) {
+            map.insert(lang, get_extractor(lang)?);
+        }
+        let extractor = map.get_mut(lang).expect("just inserted").as_mut();
+        Some(extractor.extract(source, rel_path))
+    })
 }
 
 /// Summary of an indexing operation.
@@ -1050,6 +1067,22 @@ mod tests {
         let h1 = file_hash("def foo(): pass");
         let h2 = file_hash("def bar(): pass");
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn extract_with_cached_returns_none_for_unregistered_language() {
+        assert!(extract_with_cached("klingon", "irrelevant", "a.kl").is_none());
+    }
+
+    #[test]
+    fn extract_with_cached_extracts_for_known_language() {
+        let result = extract_with_cached("python", "def foo():\n    pass\n", "a.py")
+            .expect("python is registered")
+            .expect("valid source extracts");
+        assert!(
+            result.symbols.iter().any(|s| s.name == "foo"),
+            "expected `foo` among extracted symbols"
+        );
     }
 
     #[test]

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -5,6 +5,7 @@
 //! [`cartog_db`]. Uses Merkle tree hashing for surgical symbol-level updates.
 
 use std::cell::RefCell;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -115,10 +116,10 @@ fn extract_with_cached(
 ) -> Option<Result<cartog_languages::ExtractionResult>> {
     THREAD_EXTRACTORS.with(|cell| {
         let mut map = cell.borrow_mut();
-        if !map.contains_key(lang) {
-            map.insert(lang, get_extractor(lang)?);
-        }
-        let extractor = map.get_mut(lang).expect("just inserted").as_mut();
+        let extractor = match map.entry(lang) {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(e) => e.insert(get_extractor(lang)?),
+        };
         Some(extractor.extract(source, rel_path))
     })
 }

--- a/crates/cartog-languages/Cargo.toml
+++ b/crates/cartog-languages/Cargo.toml
@@ -22,3 +22,6 @@ tree-sitter-ruby = { workspace = true }
 tree-sitter-java = { workspace = true }
 tree-sitter-php = { workspace = true }
 tree-sitter-dart = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-languages/src/dart.rs
+++ b/crates/cartog-languages/src/dart.rs
@@ -3,7 +3,7 @@ use tree_sitter::{Language, Node, Parser};
 
 use cartog_core::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::{node_text, ExtractionResult, Extractor};
+use super::{last_segment, node_text, ExtractionResult, Extractor};
 
 /// Tree-sitter–based extractor for Dart source files.
 pub struct DartExtractor {
@@ -913,7 +913,7 @@ fn strip_quotes(raw: &str) -> String {
 
 /// Pick a short import target name (last path segment, without extension).
 fn uri_short_name(uri: &str) -> String {
-    let last = uri.rsplit('/').next().unwrap_or(uri);
+    let last = last_segment(uri, "/");
     let stem = last.strip_suffix(".dart").unwrap_or(last);
     if let Some(rest) = uri.strip_prefix("package:") {
         // For `package:foo/bar.dart`, prefer the package name `foo`.

--- a/crates/cartog-languages/src/go.rs
+++ b/crates/cartog-languages/src/go.rs
@@ -3,7 +3,7 @@ use tree_sitter::{Language, Node, Parser};
 
 use cartog_core::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::{node_text, ExtractionResult, Extractor};
+use super::{last_segment, node_text, ExtractionResult, Extractor};
 
 pub struct GoExtractor {
     parser: Parser,
@@ -429,7 +429,7 @@ fn extract_import_spec(
     }
 
     // Use the last segment of the path as the imported name
-    let pkg_name = path_str.rsplit('/').next().unwrap_or(&path_str);
+    let pkg_name = last_segment(&path_str, "/");
 
     let sym_id = symbol_id(file_path, "import", &path_str, parent_qname);
     symbols.push(

--- a/crates/cartog-languages/src/java.rs
+++ b/crates/cartog-languages/src/java.rs
@@ -3,7 +3,7 @@ use tree_sitter::{Language, Node, Parser};
 
 use cartog_core::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::{node_text, ExtractionResult, Extractor};
+use super::{last_segment, node_text, ExtractionResult, Extractor};
 
 pub struct JavaExtractor {
     parser: Parser,
@@ -570,7 +570,7 @@ fn extract_import(
     );
 
     // The imported name is the last segment of the dotted path
-    let target = import_text.rsplit('.').next().unwrap_or(&import_text);
+    let target = last_segment(&import_text, ".");
     if target != "*" {
         edges.push(Edge::new(
             sym_id,
@@ -929,7 +929,7 @@ fn extract_simple_type_name(node: Node, source: &str) -> String {
         "scoped_type_identifier" => {
             // com.example.Foo → "Foo"
             let text = node_text(node, source);
-            text.rsplit('.').next().unwrap_or(text).to_string()
+            last_segment(text, ".").to_string()
         }
         "generic_type" => {
             // List<String> → extract just the outer type name

--- a/crates/cartog-languages/src/lib.rs
+++ b/crates/cartog-languages/src/lib.rs
@@ -44,6 +44,13 @@ pub(crate) fn node_text<'a>(node: Node, source: &'a str) -> &'a str {
     source.get(node.start_byte()..node.end_byte()).unwrap_or("")
 }
 
+/// Last segment of `s` after the final `sep`, or all of `s` if `sep` is absent.
+/// Used to turn dotted/slashed import paths into a bare target name
+/// (`a.b.C` → `C`, `pkg/mod` → `mod`, `crate::path::Item` → `Item`).
+pub(crate) fn last_segment<'a>(s: &'a str, sep: &str) -> &'a str {
+    s.rsplit(sep).next().unwrap_or(s)
+}
+
 pub use cartog_core::detect_language;
 
 /// Get the extractor for a language name.

--- a/crates/cartog-languages/src/ruby.rs
+++ b/crates/cartog-languages/src/ruby.rs
@@ -3,7 +3,7 @@ use tree_sitter::{Language, Node, Parser};
 
 use cartog_core::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::{node_text, ExtractionResult, Extractor};
+use super::{last_segment, node_text, ExtractionResult, Extractor};
 
 /// Extracts symbols and edges from Ruby source files.
 pub struct RubyExtractor {
@@ -522,7 +522,7 @@ fn extract_require(
     );
 
     // Use the last segment of the path as the imported name
-    let imported_name = arg_text.rsplit('/').next().unwrap_or(&arg_text);
+    let imported_name = last_segment(&arg_text, "/");
     edges.push(Edge::new(
         sym_id,
         imported_name,

--- a/crates/cartog-languages/src/rust_lang.rs
+++ b/crates/cartog-languages/src/rust_lang.rs
@@ -3,7 +3,7 @@ use tree_sitter::{Language, Node, Parser};
 
 use cartog_core::{symbol_id, Edge, EdgeKind, Symbol, SymbolKind, Visibility};
 
-use super::{node_text, ExtractionResult, Extractor};
+use super::{last_segment, node_text, ExtractionResult, Extractor};
 
 pub struct RustExtractor {
     parser: Parser,
@@ -544,7 +544,7 @@ fn collect_use_names_recursive(node: Node, source: &str, names: &mut Vec<String>
 
 fn last_path_segment(node: Node, source: &str) -> String {
     let text = node_text(node, source);
-    text.rsplit("::").next().unwrap_or(text).to_string()
+    last_segment(text, "::").to_string()
 }
 
 // ── Mod items ──

--- a/crates/cartog-lsp/Cargo.toml
+++ b/crates/cartog-lsp/Cargo.toml
@@ -18,3 +18,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-mcp/Cargo.toml
+++ b/crates/cartog-mcp/Cargo.toml
@@ -27,3 +27,6 @@ lsp = ["dep:cartog-lsp", "cartog-indexer/lsp"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-process-lock/Cargo.toml
+++ b/crates/cartog-process-lock/Cargo.toml
@@ -15,3 +15,6 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-rag/Cargo.toml
+++ b/crates/cartog-rag/Cargo.toml
@@ -21,3 +21,6 @@ reqwest = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -26,15 +26,14 @@ const DB_BATCH_LIMIT: usize = 256;
 fn flush_embedding_batch<P: EmbeddingProvider + ?Sized>(
     provider: &mut P,
     db: &Database,
-    texts: &[String],
-    symbol_ids: &[String],
+    batch: &[(String, String)],
     db_batch: &mut Vec<(i64, Vec<u8>)>,
     result: &mut RagIndexResult,
 ) -> Result<usize> {
-    let str_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+    let str_refs: Vec<&str> = batch.iter().map(|(t, _)| t.as_str()).collect();
     match provider.embed_documents(&str_refs) {
         Ok(embeddings) => {
-            for (embedding, sid) in embeddings.iter().zip(symbol_ids.iter()) {
+            for (embedding, (_, sid)) in embeddings.iter().zip(batch.iter()) {
                 let embedding_id = db.get_or_create_embedding_id(sid)?;
                 let bytes = embedding_to_bytes(embedding);
                 db_batch.push((embedding_id, bytes));
@@ -50,7 +49,7 @@ fn flush_embedding_batch<P: EmbeddingProvider + ?Sized>(
         Err(e) => {
             tracing::warn!(error = %e, "Batch embedding failed, falling back to sequential");
             let mut count = 0;
-            for (text, sid) in texts.iter().zip(symbol_ids.iter()) {
+            for (text, sid) in batch.iter() {
                 match provider.embed_document(text) {
                     Ok(embedding) => {
                         let embedding_id = db.get_or_create_embedding_id(sid)?;
@@ -305,10 +304,7 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
 
     for batch in pairs.chunks(CHUNK_SIZE) {
         check_cancel()?;
-        let texts: Vec<String> = batch.iter().map(|(t, _)| t.clone()).collect();
-        let sids: Vec<String> = batch.iter().map(|(_, s)| s.clone()).collect();
-
-        let count = flush_embedding_batch(provider, db, &texts, &sids, &mut db_batch, &mut result)?;
+        let count = flush_embedding_batch(provider, db, batch, &mut db_batch, &mut result)?;
         processed += count;
 
         emit(ProgressUpdate::Embedding {

--- a/crates/cartog-rag/src/providers/ollama.rs
+++ b/crates/cartog-rag/src/providers/ollama.rs
@@ -15,7 +15,7 @@ pub struct OllamaEmbeddingProvider {
 #[derive(Serialize)]
 struct EmbedRequest<'a> {
     model: &'a str,
-    input: Vec<&'a str>,
+    input: &'a [&'a str],
 }
 
 #[derive(Deserialize)]
@@ -80,7 +80,7 @@ impl OllamaEmbeddingProvider {
                     .post(format!("{base_url}/api/embed"))
                     .json(&EmbedRequest {
                         model,
-                        input: vec!["dimension probe"],
+                        input: &["dimension probe"],
                     })
                     .send()
                     .map_err(|e| connect_err(base_url, e))?
@@ -118,7 +118,7 @@ impl OllamaEmbeddingProvider {
             .post(format!("{}/api/embed", self.base_url))
             .json(&EmbedRequest {
                 model: &self.model,
-                input: texts.to_vec(),
+                input: texts,
             })
             .send()
             .map_err(|e| connect_err(&self.base_url, e))?
@@ -188,7 +188,7 @@ mod tests {
     fn test_embed_request_serialization() {
         let req = EmbedRequest {
             model: "nomic-embed-text",
-            input: vec!["hello world", "test"],
+            input: &["hello world", "test"],
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("nomic-embed-text"));

--- a/crates/cartog-watch/Cargo.toml
+++ b/crates/cartog-watch/Cargo.toml
@@ -23,3 +23,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -60,3 +60,6 @@ libc = { workspace = true }
 [[bench]]
 name = "queries"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -432,7 +432,45 @@ fn read_config(path: &Path) -> Option<CartogConfig> {
         }
     }
 
+    // Reject an unknown `provider` value at parse time. Without this a typo
+    // (`provider = "ollma"`) only surfaces later, when the provider is actually
+    // loaded — and the reranker typo never surfaces at all. Fail fast here.
+    if let Err(msg) = validate_providers(&parsed) {
+        eprintln!("cartog: error in {}: {msg}", path.display());
+        return None;
+    }
+
     Some(parsed)
+}
+
+/// Reject an unknown embedding/reranker `provider` value. Unknown values are a
+/// user typo: surface them at config load rather than at first use. Absent
+/// (`None`) means "use the default" and is always accepted.
+fn validate_providers(config: &CartogConfig) -> Result<(), String> {
+    const EMBEDDING_PROVIDERS: &[&str] = &["local", "ollama"];
+    const RERANKER_PROVIDERS: &[&str] = &["local", "none"];
+
+    if let Some(p) = config
+        .embedding
+        .as_ref()
+        .and_then(|e| e.provider.as_deref())
+    {
+        if !EMBEDDING_PROVIDERS.contains(&p) {
+            return Err(format!(
+                "unknown embedding provider '{p}'; supported: {}",
+                EMBEDDING_PROVIDERS.join(", ")
+            ));
+        }
+    }
+    if let Some(p) = config.reranker.as_ref().and_then(|r| r.provider.as_deref()) {
+        if !RERANKER_PROVIDERS.contains(&p) {
+            return Err(format!(
+                "unknown reranker provider '{p}'; supported: {}",
+                RERANKER_PROVIDERS.join(", ")
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Reject a `[remote].endpoint` value that embeds credentials via the
@@ -595,6 +633,48 @@ mod tests {
             toml::from_str("[database]\npath = \"x\"\n[embedding]\nprovider = \"local\"\n")
                 .unwrap();
         assert!(unknown_sections(&raw).is_empty());
+    }
+
+    #[test]
+    fn validate_providers_accepts_known_values() {
+        let config: CartogConfig =
+            toml::from_str("[embedding]\nprovider = \"ollama\"\n[reranker]\nprovider = \"none\"\n")
+                .unwrap();
+        assert!(validate_providers(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_providers_accepts_absent_provider() {
+        let config = CartogConfig::default();
+        assert!(validate_providers(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_providers_rejects_unknown_embedding_provider() {
+        let config: CartogConfig = toml::from_str("[embedding]\nprovider = \"ollma\"\n").unwrap();
+        let err = validate_providers(&config).unwrap_err();
+        assert!(
+            err.contains("ollma"),
+            "error should name the bad value: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_providers_rejects_unknown_reranker_provider() {
+        let config: CartogConfig = toml::from_str("[reranker]\nprovider = \"bogus\"\n").unwrap();
+        let err = validate_providers(&config).unwrap_err();
+        assert!(
+            err.contains("bogus"),
+            "error should name the bad value: {err}"
+        );
+    }
+
+    #[test]
+    fn read_config_rejects_unknown_provider() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        fs::write(&cfg_path, "[embedding]\nprovider = \"ollma\"\n").unwrap();
+        assert!(read_config(&cfg_path).is_none());
     }
 
     #[test]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,6 +119,8 @@ base_url = "http://localhost:11434"
 | `local` (default) | No config needed | `cartog rag setup` to download models | ONNX Runtime via fastembed, ~1.2GB models |
 | `ollama` | `provider = "ollama"` | Ollama server running with model pulled | No model download needed, dimension auto-detected. Compiled into every default build; **local ONNX stays the default provider** — set `provider = "ollama"` to use it. |
 
+An unknown `provider` value (embedding: `local`, `ollama`; reranker: `local`, `none`) is rejected when `.cartog.toml` is loaded, with an error naming the bad value — a typo like `provider = "ollma"` fails fast instead of silently falling back to the default.
+
 **Advanced local configuration:**
 
 ```toml


### PR DESCRIPTION
## Summary

Rust best-practices review of all 10 crates against the `rust-skills` rubric, plus the
improvements it surfaced. The codebase was already in good shape (clippy-clean, no `&Vec`/`&String`
params, correct async, parameterized SQL), so most first-pass "Critical/High" findings were false
positives that were verified and discarded. The changes here are the small set of genuinely
actionable items, each kept minimal.

No related issue.

## Changes

**Code fixes**
- `fix(indexer)`: a file whose language has no registered extractor is now logged and skipped
  instead of panicking inside the rayon worker (which aborted the whole index run). Lookup
  extracted into a testable helper with both arms covered.
- `fix(db)`: `normalize_symbol_name` uses `extend(c.to_lowercase())` — removes an infallible
  `unwrap` and preserves multi-char Unicode lowercase mappings that `.next()` dropped.
- `perf(rag)`: `flush_embedding_batch` takes the batch slice directly, dropping two per-batch
  `Vec<String>` clones; the Ollama request borrows its inputs instead of `texts.to_vec()`.
- `refactor(core)`: `#[must_use]` on `Symbol`/`Edge` constructors, builders, and value accessors.
- `refactor(languages)`: one `last_segment` helper replaces six copies of
  `s.rsplit(sep).next().unwrap_or(s)`.

**Behavior**
- `feat(config)`: an unknown embedding/reranker `provider` value is rejected when `.cartog.toml`
  is loaded (with an error naming the bad value), instead of silently falling back to the default
  (embedding) or being ignored entirely (reranker).

**Build / CI**
- `build`: `[workspace.lints]` promotes the clippy gate to every local build and enforces
  `unsafe_op_in_unsafe_fn` for the `cartog-process-lock` unsafe code (zero new warnings). Adds a
  `[profile.bench]` (release + debug symbols) so the criterion benches stay profilable.
- `ci`: the default-feature suite is no longer run twice — the `coverage` job already runs and
  gates on it via `cargo llvm-cov`, so the `test` job keeps only the `--no-default-features` build.
  Both feature configs remain gated.

**Docs**
- `docs(agents)`: a "Rust standard" section pinning this codebase's invariants (borrow-in-
  signatures, no-panic-on-input, parameterized SQL, async `spawn_blocking`, RAII, `unsafe` +
  `# Safety`, `#[must_use]`, enums-over-strings).
- `docs(usage)`: note that unknown provider values are rejected at config load.

> nextest was evaluated for the test jobs and intentionally **not** adopted: the `cartog` bin crate
> relies on `serial_test` to serialize tests that mutate the process-global cwd, and nextest's
> process-per-test model defeats `#[serial]` — adopting it would add flakiness for a modest gain.

## Checklist

- [x] `make check` passes locally (Rust + all language fixtures; Java/PHP/Dart validated via the
      Docker fallback — the native run hit the macOS `java` stub, an environment quirk unrelated to
      this PR; CI runs on Linux with real toolchains)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for new behavior (config provider validation; indexer extractor lookup)
- [x] Documentation updated (AGENTS.md, docs/usage.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for embedding and reranker provider configuration to catch typos and invalid settings early.

* **Bug Fixes**
  * Improved extractor error handling to gracefully skip unregistered languages instead of crashing.
  * Fixed Unicode character case conversion to preserve multi-character mappings.

* **Chores**
  * Enabled workspace-wide linting configuration across all crates.
  * Added benchmark profile configuration.
  * Updated CI workflow for improved test clarity.
  * Enhanced code convention guidelines in project documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->