### PR TITLE
Improve benchmarks: black_box, ONNX-aware targets, fix index contamination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # need the merge base for the PR baseline comparison
+          # The job git-checkouts arbitrary SHAs but never pushes, so do not
+          # leave credentials persisted in the workspace.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,28 +138,77 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     # Benchmarks on shared GitHub runners are noisy — never fail a PR on a
-    # variance-driven regression, but surface results as an artifact so
-    # reviewers can spot outliers. Tuned for ~1 min of actual measurement
-    # across the whole suite on top of the ~3 min compile:
-    # - `--sample-size 10` is criterion's minimum (default is 100).
-    # - `--warm-up-time 1 --measurement-time 1` trims each benchmark to
-    #   roughly 2 s of wall-clock. Statistical confidence intervals widen,
-    #   which is fine for catching order-of-magnitude regressions rather
-    #   than µs-level shifts.
+    # variance-driven regression (the job is `continue-on-error`), but surface
+    # results as an artifact and, on PRs, a same-runner comparison against the
+    # PR's merge base so reviewers can spot real shifts.
+    #
+    # CI runs three of the four bench targets. The fourth, `rag_onnx`, loads the
+    # real fastembed/ONNX model and is intentionally NOT named here — that is
+    # how it is excluded (criterion's regex filter cannot express exclusion).
+    #
+    # Budget knobs (kept short so the whole suite is ~1–2 min of measurement on
+    # top of the compile):
+    # - `--sample-size 10` is criterion's minimum (default 100).
+    # - `--warm-up-time 1 --measurement-time 1` trims each bench to ~2 s of
+    #   wall-clock. Confidence intervals widen — fine for catching
+    #   order-of-magnitude shifts, not µs-level ones. The `index_full_force/*`
+    #   benches are ms-scale and noisier; treat their numbers as indicative.
     # - `--noplot` skips SVG rendering; `estimates.json` still lands in
-    #   `target/criterion/` so the artifact stays useful.
+    #   `target/criterion/`, so the artifact stays useful.
     continue-on-error: true
+    env:
+      # Shared by every step; `index_full_force/*` reuses the same knobs.
+      CRITERION_ARGS: "--sample-size 10 --warm-up-time 1 --measurement-time 1 --noplot"
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the merge base for the PR baseline comparison
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run criterion benches
-        run: >-
-          cargo bench --bench queries --
-          --sample-size 10
-          --warm-up-time 1
-          --measurement-time 1
-          --noplot
+
+      # On a PR, establish a baseline from the merge base on THIS runner first,
+      # so the comparison controls for runner-to-runner variance (the dominant
+      # noise source). The fast µs-scale targets only — the ms-scale indexing
+      # benches are too noisy for a meaningful 1 s-window delta.
+      - name: Baseline (merge base, PR only)
+        if: github.event_name == 'pull_request'
+        # Best-effort: a target that does not yet exist on the base commit (a PR
+        # that adds a new bench) cannot be baselined — that is fine, the compare
+        # step below just skips its `--baseline` for that target. Hence no
+        # `set -e` on the per-target runs.
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="$(git rev-parse HEAD)"
+          echo "Baselining queries + rag_search at merge base $base"
+          git checkout --quiet "$base"
+          cargo bench -p cartog --bench queries -- $CRITERION_ARGS --save-baseline base || \
+            echo "::warning::queries bench not present on base; skipping its baseline"
+          cargo bench -p cartog --bench rag_search -- $CRITERION_ARGS --save-baseline base || \
+            echo "::warning::rag_search bench not present on base; skipping its baseline"
+          git checkout --quiet "$head"
+
+      - name: Query + RAG-search benches
+        run: |
+          set -euo pipefail
+          # On a PR, compare against the merge-base baseline if one was saved;
+          # on a push to main there is no baseline, so just measure. `--baseline`
+          # errors if the named baseline is absent, so fall back to a plain run.
+          run_bench() {
+            local crate_bench="$1"
+            if [ "${{ github.event_name }}" = "pull_request" ] && \
+               cargo bench $crate_bench -- $CRITERION_ARGS --baseline base 2>/dev/null; then
+              return 0
+            fi
+            cargo bench $crate_bench -- $CRITERION_ARGS
+          }
+          run_bench "-p cartog --bench queries"
+          run_bench "-p cartog --bench rag_search"
+
+      - name: Indexing benches (all languages)
+        # Artifact-only: ms-scale and the noisiest of the suite, so no baseline
+        # gate — the numbers are for spotting gross per-grammar regressions.
+        run: cargo bench -p cartog-indexer --bench indexing -- $CRITERION_ARGS
+
       - uses: actions/upload-artifact@v7
         with:
           name: criterion-report

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 .ruff_cache/
 __pycache__/
 benchmarks/results/*.jsonl
+benchmarks/.indexes/
 benchmarks/fixtures/webapp_rs/target/
 .playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ make check-fixtures-docker # same, forcing the Docker fallback for every languag
 make check-skill           # skill tests (ensure_indexed.sh unit tests)
 make eval-skill            # LLM-as-judge skill evaluation (requires claude CLI)
 make eval-agents           # LLM-as-judge agent evaluation (requires claude CLI)
-make bench                 # shell benchmark suite (13 scenarios x 5 languages)
-make bench-criterion       # Rust criterion benchmarks (query latency)
+make bench                 # shell benchmark suite (13 scenarios x 8 languages)
+make bench-criterion       # ONNX-free criterion benches (queries, per-language indexing, hybrid search)
+make bench-onnx            # real-model embed/rerank benches (needs `cartog rag setup`; not in CI)
 make bench-rag             # RAG relevancy benchmarks (in-memory + shell scenario 13)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check check-rust check-fixtures check-fixtures-docker check-skill check-py check-ts check-go check-rs check-rb check-java check-php check-dart check-install-script sync-install-script bench bench-criterion bench-rag eval-skill eval-agents
+.PHONY: check check-rust check-fixtures check-fixtures-docker check-skill check-py check-ts check-go check-rs check-rb check-java check-php check-dart check-install-script sync-install-script bench bench-criterion bench-rag bench-onnx eval-skill eval-agents
 
 # --- Full integrity check ---
 
@@ -124,8 +124,13 @@ eval-agents: ## Run LLM-as-judge agent evaluation (requires claude CLI)
 bench: ## Run shell benchmark suite (all scenarios, all fixtures)
 	./benchmarks/run.sh
 
-bench-criterion: ## Run Rust criterion benchmarks (query latency)
-	cargo bench --bench queries
+bench-criterion: ## Run all ONNX-free criterion benches (queries, per-language indexing, hybrid search)
+	cargo bench -p cartog --bench queries
+	cargo bench -p cartog-indexer --bench indexing
+	cargo bench -p cartog --bench rag_search
+
+bench-onnx: ## Run real-model embed/rerank benches (needs `cartog rag setup`; not run in CI)
+	cargo bench -p cartog --bench rag_onnx
 
 bench-rag: ## Run RAG relevancy benchmarks (in-memory + shell scenario 13)
 	cargo test --test rag_relevancy -- --nocapture

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Every code navigation tool makes you choose: fast but shallow (grep), or precise
 | **Recall** (completeness) | 78% | ~100% | **97%** [*](#benchmark-notes) |
 | **Privacy** | local | local | **100% local** |
 
-Measured across 13 scenarios, 5 languages ([benchmark suite](crates/cartog/benches/queries.rs)).
+Measured across 13 scenarios, 8 languages ([benchmark suite](benchmarks/)).
 
 <a id="benchmark-notes"></a>
 > **\*** 97 % recall requires a matching language server on PATH. The

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -63,44 +63,70 @@ All fixtures model the same domain (auth service, tokens, routes, middleware, da
 ./benchmarks/run.sh --fixture php
 ```
 
-## Criterion benchmarks (query latency)
+## Criterion benchmarks (in-process latency)
 
-Measures query latency in microseconds using Rust-native criterion benchmarks on the Python fixture indexed into an in-memory SQLite database.
+Rust-native criterion benchmarks measure cartog's own CPU-bound work against the
+`benchmarks/fixtures/` corpora indexed into in-memory SQLite. They are split into
+four `[[bench]]` targets so the ONNX boundary is expressed by target membership
+(see [docs/tech.md](../docs/tech.md#benchmarks) for the full rationale). Inputs and
+results are wrapped in `black_box`, so the µs-scale benches measure real work.
 
 ```bash
-# Run all query benchmarks
-cargo bench --bench queries
+# Everything ONNX-free (queries + per-language indexing + hybrid search)
+make bench-criterion
 
-# Run specific benchmark
-cargo bench --bench queries -- search_token
-
-# Quick run (fewer iterations)
-cargo bench --bench queries -- --quick
+# Real-model embed/rerank — needs `cartog rag setup`, not run in CI
+make bench-onnx
 ```
 
-Benchmarked operations: `search`, `refs`, `impact`, `outline`, `callees`, `hierarchy`, `deps`, `stats`.
+### `queries` — query latency (`cartog`)
 
-### Indexing benchmarks
-
-Measures indexing performance including the incremental Merkle-tree diffing path:
+Microsecond-scale latency for `search`, `refs`, `impact`, `outline`, `callees`,
+`hierarchy`, `deps`, `stats` on the Python and Java fixtures. Query latency is
+language-agnostic (same SQL regardless of source language), so two fixtures suffice.
 
 ```bash
-cargo bench --bench queries -- index_
+cargo bench -p cartog --bench queries
+cargo bench -p cartog --bench queries -- search_token   # one bench (substring match)
+```
+
+### `indexing` — per-language indexing (`cartog-indexer`)
+
+Lives in `cartog-indexer`, which has no `cartog-rag`/ONNX dependency, so it builds
+and runs without the native ONNX library. Per-language cost lives in the
+tree-sitter grammar + extractor, so the full-index scenario is parameterized over
+all 8 fixtures.
+
+```bash
+cargo bench -p cartog-indexer --bench indexing
+cargo bench -p cartog-indexer --bench indexing -- index_full_force/rs   # one language
 ```
 
 | Benchmark | What it measures |
 |-----------|-----------------|
-| `index_full_force` | Full index of fixture (force=true), baseline |
-| `index_incremental_noop` | Re-index with no changes (all files skipped via hash) |
-| `index_incremental_one_file` | One file's hash invalidated, triggers Merkle diff + scoped resolution |
+| `index_full_force/<lang>` | Full index of each fixture (force=true) — `py ts go rs rb java php dart` |
+| `index_incremental_noop` | Re-index with no changes (all files skipped via hash); Python |
+| `index_incremental_one_file` | One file's hash invalidated, triggers Merkle diff + scoped resolution; Python |
 
-The same three scenarios are also available as a standalone `cartog-indexer` bench, which builds without the ONNX runtime native dependency:
+### `rag_search` — hybrid search (`cartog`)
+
+`hybrid_search` (FTS5 + vector KNN + RRF merge) over the embedded Python fixture,
+using a deterministic stub embedding provider — no ONNX model is loaded, so it runs
+in CI.
 
 ```bash
-cargo bench -p cartog-indexer --bench indexing
+cargo bench -p cartog --bench rag_search
 ```
 
-Use this form when iterating on indexer code without a configured ONNX install. Numbers are within noise of the `cartog`-binary version.
+### `rag_onnx` — real embedding + reranking (`cartog`, opt-in)
+
+Loads the actual fastembed/ONNX models to measure `embed_query`,
+`embed_documents`, and cross-encoder `rerank`. **Not run in CI**; requires the
+models on disk (`cartog rag setup`) and skips gracefully if they are absent.
+
+```bash
+make bench-onnx   # or: cargo bench -p cartog --bench rag_onnx
+```
 
 ## Benchmark any project
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -44,6 +44,32 @@ All fixtures model the same domain (auth service, tokens, routes, middleware, da
 | 12 | "Deep impact at depth 5" | `impact --depth 5` (transitive BFS) vs flat grep |
 | 13 | "Find authentication logic" | `rag search` (FTS5 + vector KNN + reranker) vs grep keywords |
 
+## Index isolation
+
+The fixtures live inside the cartog repo, so a bare `cartog index .` walks up and
+writes to the repo-root `.cartog`, where every fixture would clobber the next and
+recall would be measured against whichever fixture indexed last. `run.sh` and the
+scenarios pin `CARTOG_DB` to a per-fixture file under `benchmarks/.indexes/`
+(gitignored) so each fixture stays isolated. Any new `cartog` invocation in a
+scenario must do the same — use `fixture_db_path "$fixture_dir"` from `lib/common.sh`.
+
+## Known cartog gaps
+
+Some scenarios deliberately keep ground truth at the *objectively correct* answer
+read from source, so cartog scores below 100% where its resolution is incomplete.
+These rows exist to track that — they should approach parity as the gaps close:
+
+- **PHP class inheritance (scenario 04)**: `hierarchy BaseService` returns nothing
+  even though `AuthService`/`AuthenticationService`/`PaymentProcessor` extend it.
+  PHP's *error* tree resolves (`TokenError -> App\AppError`), so this looks
+  namespace/`use`-related rather than a total miss.
+- **Rust traits / Go interfaces (excluded from scenario 04)**: Rust uses traits and
+  Go uses struct embedding, not class inheritance. cartog does not model
+  trait-impl or interface-satisfaction as a hierarchy, so "who implements this
+  contract?" is not answerable today. Those rows are skipped rather than scored 0.
+- **Dart mixins**: `hierarchy AuthResult` (sealed class) resolves, but `refs`
+  on a `mixin` (e.g. `TokenCache`) does not surface the `with`-ing classes.
+
 ## Usage
 
 ```bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,9 +22,15 @@ Compares cartog graph queries vs grep/cat approaches for common code navigation 
 | `fixtures/webapp_rb/` | Ruby | 51 | ~2,300 |
 | `fixtures/webapp_java/` | Java | 41 | ~1,800 |
 | `fixtures/webapp_php/` | PHP | 25 | ~1,500 |
-| **Total** | | **345** | **~18,600** |
+| `fixtures/webapp_dart/` | Dart | 9 | ~200 |
+| **Total** | | **354** | **~18,800** |
 
 All fixtures model the same domain (auth service, tokens, routes, middleware, database, cache, events, validators) with controlled, known relationships defined in `ground_truth/`.
+
+The criterion `indexing` bench exercises all 8 fixtures. The shell scenarios and
+`ground_truth/` currently cover the first 7 — `webapp_dart` has no scenario
+ground truth yet, so it is indexed by the criterion bench but not scored by the
+shell suite.
 
 ## Scenarios
 

--- a/benchmarks/ground_truth/webapp_java.json
+++ b/benchmarks/ground_truth/webapp_java.json
@@ -69,20 +69,24 @@
     ]
   },
   "04_class_hierarchy": {
-    "description": "Hierarchy of AppException",
-    "query": "hierarchy AppException",
+    "description": "Hierarchy of BaseService",
+    "query": "hierarchy BaseService",
     "expected": [
       {
-        "name": "ValidationException"
+        "child": "SessionService",
+        "parent": "BaseService"
       },
       {
-        "name": "TokenException"
+        "child": "UserService",
+        "parent": "BaseService"
       },
       {
-        "name": "AuthenticationException"
+        "child": "PaymentProcessor",
+        "parent": "BaseService"
       },
       {
-        "name": "PaymentException"
+        "child": "AuthenticationService",
+        "parent": "BaseService"
       }
     ]
   },
@@ -176,36 +180,76 @@
     "description": "Find all Token-related symbols",
     "query": "search Token",
     "expected": [
-      { "name": "TokenService" },
-      { "name": "TokenClaims" },
-      { "name": "TokenException" },
-      { "name": "ExpiredTokenException" },
-      { "name": "TOKEN_EXPIRY" },
-      { "name": "generateToken" },
-      { "name": "validateToken" },
-      { "name": "refreshToken" },
-      { "name": "revokeToken" },
-      { "name": "extractToken" }
+      {
+        "name": "TokenService"
+      },
+      {
+        "name": "TokenClaims"
+      },
+      {
+        "name": "TokenException"
+      },
+      {
+        "name": "ExpiredTokenException"
+      },
+      {
+        "name": "TOKEN_EXPIRY"
+      },
+      {
+        "name": "generateToken"
+      },
+      {
+        "name": "validateToken"
+      },
+      {
+        "name": "refreshToken"
+      },
+      {
+        "name": "revokeToken"
+      },
+      {
+        "name": "extractToken"
+      }
     ]
   },
   "09_ambiguous_symbol": {
     "description": "Where is 'validate' defined?",
     "query": "search validate",
     "expected": [
-      { "name": "validate", "file": "models/PaymentModel.java" },
-      { "name": "validate", "file": "models/UserModel.java" },
-      { "name": "validate", "file": "validators/PaymentValidator.java" },
-      { "name": "validate", "file": "validators/UserValidator.java" }
+      {
+        "name": "validate",
+        "file": "models/PaymentModel.java"
+      },
+      {
+        "name": "validate",
+        "file": "models/UserModel.java"
+      },
+      {
+        "name": "validate",
+        "file": "validators/PaymentValidator.java"
+      },
+      {
+        "name": "validate",
+        "file": "validators/UserValidator.java"
+      }
     ]
   },
   "10_high_fanout": {
     "description": "What inherits from AppException?",
     "query": "hierarchy AppException",
     "expected": [
-      { "name": "ValidationException" },
-      { "name": "TokenException" },
-      { "name": "AuthenticationException" },
-      { "name": "PaymentException" }
+      {
+        "name": "ValidationException"
+      },
+      {
+        "name": "TokenException"
+      },
+      {
+        "name": "AuthenticationException"
+      },
+      {
+        "name": "PaymentException"
+      }
     ]
   },
   "11_deep_call_chain": {
@@ -219,21 +263,66 @@
       "callees getConnection"
     ],
     "expected_chain": [
-      { "caller": "handleLogin", "callee": "UserValidator.validateLogin" },
-      { "caller": "handleLogin", "callee": "routes.handleLogin" },
-      { "caller": "authenticate", "callee": "requireInitialized" },
-      { "caller": "authenticate", "callee": "authService.login" },
-      { "caller": "authenticate", "callee": "db.insert" },
-      { "caller": "login", "callee": "tokenService.generateToken" },
-      { "caller": "login", "callee": "log.info" },
-      { "caller": "generateToken", "callee": "log.info" },
-      { "caller": "generateToken", "callee": "String.format" },
-      { "caller": "executeQuery", "callee": "pool.getConnection" },
-      { "caller": "executeQuery", "callee": "pool.releaseConnection" },
-      { "caller": "getConnection", "callee": "log.debug" },
-      { "caller": "getConnection", "callee": "conn.isInUse" },
-      { "caller": "getConnection", "callee": "conn.setInUse" },
-      { "caller": "getConnection", "callee": "log.error" }
+      {
+        "caller": "handleLogin",
+        "callee": "UserValidator.validateLogin"
+      },
+      {
+        "caller": "handleLogin",
+        "callee": "routes.handleLogin"
+      },
+      {
+        "caller": "authenticate",
+        "callee": "requireInitialized"
+      },
+      {
+        "caller": "authenticate",
+        "callee": "authService.login"
+      },
+      {
+        "caller": "authenticate",
+        "callee": "db.insert"
+      },
+      {
+        "caller": "login",
+        "callee": "tokenService.generateToken"
+      },
+      {
+        "caller": "login",
+        "callee": "log.info"
+      },
+      {
+        "caller": "generateToken",
+        "callee": "log.info"
+      },
+      {
+        "caller": "generateToken",
+        "callee": "String.format"
+      },
+      {
+        "caller": "executeQuery",
+        "callee": "pool.getConnection"
+      },
+      {
+        "caller": "executeQuery",
+        "callee": "pool.releaseConnection"
+      },
+      {
+        "caller": "getConnection",
+        "callee": "log.debug"
+      },
+      {
+        "caller": "getConnection",
+        "callee": "conn.isInUse"
+      },
+      {
+        "caller": "getConnection",
+        "callee": "conn.setInUse"
+      },
+      {
+        "caller": "getConnection",
+        "callee": "log.error"
+      }
     ]
   },
   "12_deep_impact": {
@@ -259,13 +348,27 @@
     "description": "Semantic search: validate token",
     "query": "rag search \"validate token\"",
     "expected": [
-      { "name": "validateToken" },
-      { "name": "TokenException" },
-      { "name": "ExpiredTokenException" },
-      { "name": "extractToken" },
-      { "name": "generateToken" },
-      { "name": "refreshToken" },
-      { "name": "TokenService" }
+      {
+        "name": "validateToken"
+      },
+      {
+        "name": "TokenException"
+      },
+      {
+        "name": "ExpiredTokenException"
+      },
+      {
+        "name": "extractToken"
+      },
+      {
+        "name": "generateToken"
+      },
+      {
+        "name": "refreshToken"
+      },
+      {
+        "name": "TokenService"
+      }
     ]
   }
 }

--- a/benchmarks/lib/common.sh
+++ b/benchmarks/lib/common.sh
@@ -60,6 +60,26 @@ count_tokens() {
 
 # ── Run approaches ──
 
+# Isolated index location for a fixture.
+#
+# The fixtures live inside the cartog repo, so a bare `cartog index .` walks up
+# and writes to the repo-root .cartog, where every fixture clobbers the same DB
+# and recall is measured against whichever fixture indexed last. Pinning
+# CARTOG_DB to a per-fixture path keeps each index isolated.
+#
+# The path is derived from the fixture_dir argument (an absolute
+# `.../benchmarks/fixtures/<name>`), not from $BENCH_DIR — callers may invoke
+# this after `cd`-ing into the fixture, where a relative $BENCH_DIR would be
+# wrong. Indexes land in `benchmarks/.indexes/<name>.sqlite`.
+# Usage: fixture_db_path <fixture_dir>  (absolute path required)
+fixture_db_path() {
+    local fixture_dir="${1%/}"
+    local fixtures_root indexes_root
+    fixtures_root=$(dirname "$fixture_dir")   # .../benchmarks/fixtures
+    indexes_root="$(dirname "$fixtures_root")/.indexes"  # .../benchmarks/.indexes
+    echo "$indexes_root/$(basename "$fixture_dir").sqlite"
+}
+
 # Run a grep command and capture output + metrics.
 # Usage: run_grep <label> <fixture_dir> <command...>
 # Sets: GREP_OUTPUT, GREP_TOKENS, GREP_LINES
@@ -81,13 +101,18 @@ run_cartog_cmd() {
     local fixture_dir="$1"
     shift
 
+    # Query the fixture's isolated index (see fixture_db_path) so recall is not
+    # measured against a sibling fixture's leftover symbols.
+    local db
+    db=$(fixture_db_path "$fixture_dir")
+
     # Human-readable output for token comparison (what agent actually processes)
-    CARTOG_OUTPUT=$(cd "$fixture_dir" && $CARTOG "$@" 2>/dev/null || true)
+    CARTOG_OUTPUT=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG "$@" 2>/dev/null || true)
     CARTOG_TOKENS=$(count_tokens "$CARTOG_OUTPUT")
     CARTOG_LINES=$(count_lines "$CARTOG_OUTPUT")
 
     # JSON output for recall checking (names are more reliably extractable)
-    CARTOG_JSON_OUTPUT=$(cd "$fixture_dir" && $CARTOG --json "$@" 2>/dev/null || true)
+    CARTOG_JSON_OUTPUT=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG --json "$@" 2>/dev/null || true)
 }
 
 # Run a cat command (simulating "read entire file") and capture metrics.

--- a/benchmarks/lib/common.sh
+++ b/benchmarks/lib/common.sh
@@ -28,15 +28,12 @@ should_skip_fixture() {
     if [ -z "${FIXTURE_FILTER:-}" ]; then
         return 1
     fi
+    # Match by the `_<tag>` suffix in the fixture directory name. Keep this list
+    # in sync with the languages that have fixtures under benchmarks/fixtures/.
     case "$FIXTURE_FILTER" in
-        py) [[ "$fixture_name" != *"_py"* ]] && return 0 || return 1 ;;
-        ts) [[ "$fixture_name" != *"_ts"* ]] && return 0 || return 1 ;;
-        go) [[ "$fixture_name" != *"_go"* ]] && return 0 || return 1 ;;
-        rs) [[ "$fixture_name" != *"_rs"* ]] && return 0 || return 1 ;;
-        rb) [[ "$fixture_name" != *"_rb"* ]] && return 0 || return 1 ;;
-        java) [[ "$fixture_name" != *"_java"* ]] && return 0 || return 1 ;;
-        php) [[ "$fixture_name" != *"_php"* ]] && return 0 || return 1 ;;
-        *)  return 1 ;;
+        py|ts|go|rs|rb|java|php|dart)
+            [[ "$fixture_name" != *"_${FIXTURE_FILTER}"* ]] && return 0 || return 1 ;;
+        *) return 1 ;;
     esac
 }
 
@@ -106,21 +103,7 @@ run_cat() {
 }
 
 # ── Recall computation ──
-
-# Count how many expected items appear in output.
-# Usage: count_matches <output> <item1> <item2> ...
-# Returns: count of found items
-count_matches() {
-    local output="$1"
-    shift
-    local found=0
-    for item in "$@"; do
-        if echo "$output" | grep -c "$item" >/dev/null 2>&1; then
-            found=$((found + 1))
-        fi
-    done
-    echo $found
-}
+# Recall matching itself lives in `check_recall` (compare.sh).
 
 # Compute recall as percentage.
 # Usage: compute_recall <found> <total>

--- a/benchmarks/lib/compare.sh
+++ b/benchmarks/lib/compare.sh
@@ -64,10 +64,12 @@ check_recall() {
     while IFS= read -r item; do
         [ -z "$item" ] && continue
         total=$((total + 1))
-        # Use grep -c instead of grep -q to avoid SIGPIPE with pipefail on large outputs.
-        # When grep -q finds a match and exits early, echo may still be writing,
-        # causing SIGPIPE (exit 141) which pipefail treats as failure.
-        if echo "$output" | grep -c "$item" >/dev/null 2>&1; then
+        # Fixed-string (-F), whole-word (-w) match: a symbol name must appear as
+        # a token, not as a substring (`login` must not match `login_route`) and
+        # not as a regex (a name like `User[` or `f.bar` must match literally).
+        # `-q` on a here-string has no pipe, so the SIGPIPE-with-pipefail issue
+        # that motivated the old `-c` idiom does not arise.
+        if grep -Fwq -- "$item" <<< "$output"; then
             found=$((found + 1))
         fi
     done <<< "$items"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -25,13 +25,9 @@ PROJECT_ROOT="$(cd "$BENCH_DIR/.." && pwd)"
 RESULTS_DIR="$BENCH_DIR/results"
 RESULTS_FILE="$RESULTS_DIR/latest.jsonl"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+# Colors + should_skip_fixture live in common.sh — single source of truth so the
+# runner and the scenarios share one fixture-filter definition.
+source "$BENCH_DIR/lib/common.sh"
 
 # Parse args
 SCENARIO_FILTER=""
@@ -80,19 +76,8 @@ echo -e "${BOLD}Indexing fixtures...${NC}"
 for fixture_dir in "$BENCH_DIR"/fixtures/*/; do
     fixture_name=$(basename "$fixture_dir")
 
-    # Apply fixture filter
-    if [ -n "$FIXTURE_FILTER" ]; then
-        case "$FIXTURE_FILTER" in
-            py) [[ "$fixture_name" != *"_py"* ]] && continue ;;
-            ts) [[ "$fixture_name" != *"_ts"* ]] && continue ;;
-            go) [[ "$fixture_name" != *"_go"* ]] && continue ;;
-            rs) [[ "$fixture_name" != *"_rs"* ]] && continue ;;
-            rb) [[ "$fixture_name" != *"_rb"* ]] && continue ;;
-            java) [[ "$fixture_name" != *"_java"* ]] && continue ;;
-            php) [[ "$fixture_name" != *"_php"* ]] && continue ;;
-            dart) [[ "$fixture_name" != *"_dart"* ]] && continue ;;
-        esac
-    fi
+    # Apply fixture filter (shared definition in common.sh).
+    should_skip_fixture "$fixture_name" && continue
 
     echo -n "  $fixture_name: "
     (cd "$fixture_dir" && $CARTOG index . --force 2>&1 | head -1)

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -71,6 +71,12 @@ fi
 echo ""
 
 # ── Index fixtures ──
+#
+# Each fixture indexes into its own DB under .indexes/ (see fixture_db_path).
+# Without this, `cartog index .` would walk up to the repo-root .cartog and the
+# fixtures would clobber one another's symbols, corrupting recall.
+
+mkdir -p "$BENCH_DIR/.indexes"
 
 echo -e "${BOLD}Indexing fixtures...${NC}"
 for fixture_dir in "$BENCH_DIR"/fixtures/*/; do
@@ -80,7 +86,7 @@ for fixture_dir in "$BENCH_DIR"/fixtures/*/; do
     should_skip_fixture "$fixture_name" && continue
 
     echo -n "  $fixture_name: "
-    (cd "$fixture_dir" && $CARTOG index . --force 2>&1 | head -1)
+    (cd "$fixture_dir" && CARTOG_DB="$(fixture_db_path "$fixture_dir")" $CARTOG index . --force 2>&1 | head -1)
 done
 echo ""
 

--- a/benchmarks/scenarios/04_class_hierarchy.sh
+++ b/benchmarks/scenarios/04_class_hierarchy.sh
@@ -59,8 +59,19 @@ run_scenario() {
 
 run_scenario "webapp_py" "BaseService" "class.*BaseService\|class.*(BaseService)\|class.*(AuthService)"
 run_scenario "webapp_ts" "BaseService" "class.*BaseService\|extends.*BaseService\|implements.*BaseService"
-run_scenario "webapp_go" "BaseService" "BaseService\|embed"
-run_scenario "webapp_rs" "AuthProvider" "impl.*AuthProvider\|trait AuthProvider"
 run_scenario "webapp_rb" "BaseService" "class.*BaseService\|class.*<.*BaseService\|class.*<.*AuthService"
 run_scenario "webapp_java" "BaseService" "class.*BaseService\|class.*extends.*BaseService\|class.*extends.*AuthService"
+
+# PHP has `extends BaseService` subclasses in source, but cartog only partially
+# resolves PHP inheritance: the error tree (e.g. TokenError -> App\AppError)
+# resolves while service-class extends do not, so this row currently
+# under-scores. See "Known cartog gaps" in benchmarks/README.md.
 run_scenario "webapp_php" "BaseService" "class.*BaseService\|class.*extends.*BaseService\|class.*extends.*AuthService"
+
+# Rust (traits, not class inheritance) and Go (struct embedding, not
+# inheritance) have no subclass hierarchy to resolve, so they are not part of
+# this scenario. Rust trait-impl / Go interface-satisfaction discovery is a
+# distinct capability cartog does not expose today. See
+# "Known cartog gaps" in benchmarks/README.md.
+echo -e "  ${YELLOW}[webapp_rs] skipped: Rust uses traits, not class inheritance${NC}" >&2
+echo -e "  ${YELLOW}[webapp_go] skipped: Go uses struct embedding, not class inheritance${NC}" >&2

--- a/benchmarks/scenarios/05_trace_call_chain.sh
+++ b/benchmarks/scenarios/05_trace_call_chain.sh
@@ -40,18 +40,21 @@ run_scenario() {
     local best_cmds=3
 
     # ── Cartog: sequential callees (human-readable for tokens) ──
+    # Query the fixture's isolated index (see fixture_db_path).
+    local db
+    db=$(fixture_db_path "$fixture_dir")
     local c1 c2 c3 cj1 cj2 cj3
-    c1=$(cd "$fixture_dir" && $CARTOG callees "$entry_fn" 2>/dev/null || true)
-    c2=$(cd "$fixture_dir" && $CARTOG callees "$mid_fn" 2>/dev/null || true)
-    c3=$(cd "$fixture_dir" && $CARTOG callees "$leaf_fn" 2>/dev/null || true)
+    c1=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG callees "$entry_fn" 2>/dev/null || true)
+    c2=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG callees "$mid_fn" 2>/dev/null || true)
+    c3=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG callees "$leaf_fn" 2>/dev/null || true)
     local cartog_out="${c1}${c2}${c3}"
     local cartog_tok=$(count_tokens "$cartog_out")
     local cartog_cmds=3
 
     # JSON for recall checking
-    cj1=$(cd "$fixture_dir" && $CARTOG --json callees "$entry_fn" 2>/dev/null || true)
-    cj2=$(cd "$fixture_dir" && $CARTOG --json callees "$mid_fn" 2>/dev/null || true)
-    cj3=$(cd "$fixture_dir" && $CARTOG --json callees "$leaf_fn" 2>/dev/null || true)
+    cj1=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG --json callees "$entry_fn" 2>/dev/null || true)
+    cj2=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG --json callees "$mid_fn" 2>/dev/null || true)
+    cj3=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG --json callees "$leaf_fn" 2>/dev/null || true)
     local cartog_json_out="${cj1}${cj2}${cj3}"
 
     # ── Recall: check expected chain links ──

--- a/benchmarks/scenarios/11_deep_call_chain.sh
+++ b/benchmarks/scenarios/11_deep_call_chain.sh
@@ -43,13 +43,16 @@ run_scenario() {
     local best_tok=$(count_tokens "$best_out")
 
     # ── Cartog: sequential callees for each hop ──
+    # Query the fixture's isolated index (see fixture_db_path).
+    local db
+    db=$(fixture_db_path "$fixture_dir")
     local cartog_out=""
     local cartog_json_out=""
     local cartog_cmds=${#chain[@]}
     for fn in "${chain[@]}"; do
         local c cj
-        c=$(cd "$fixture_dir" && $CARTOG callees "$fn" 2>/dev/null || true)
-        cj=$(cd "$fixture_dir" && $CARTOG --json callees "$fn" 2>/dev/null || true)
+        c=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG callees "$fn" 2>/dev/null || true)
+        cj=$(cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG --json callees "$fn" 2>/dev/null || true)
         cartog_out="${cartog_out}${c}"
         cartog_json_out="${cartog_json_out}${cj}"
     done

--- a/benchmarks/scenarios/13_rag_search.sh
+++ b/benchmarks/scenarios/13_rag_search.sh
@@ -34,10 +34,14 @@ run_scenario() {
     # RAG requires symbol content (populated during index) + embeddings.
     # Re-index to ensure symbol_content is populated, then build RAG index —
     # both into the fixture's isolated DB so the later query reads them back.
+    # Warn (but continue) on failure so a setup error is visible rather than
+    # masquerading as a 0-recall cartog result.
     local db
     db=$(fixture_db_path "$fixture_dir")
-    (cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG index . --force >/dev/null 2>&1) || true
-    (cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG rag index >/dev/null 2>&1) || true
+    (cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG index . --force >/dev/null 2>&1) ||
+        echo -e "  ${YELLOW}[$fixture_name] warning: cartog index failed (exit $?)${NC}" >&2
+    (cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG rag index >/dev/null 2>&1) ||
+        echo -e "  ${YELLOW}[$fixture_name] warning: cartog rag index failed (exit $?)${NC}" >&2
 
     echo -e "  ${CYAN}[$fixture_name]${NC} RAG search: '$QUERY'" >&2
 

--- a/benchmarks/scenarios/13_rag_search.sh
+++ b/benchmarks/scenarios/13_rag_search.sh
@@ -32,9 +32,12 @@ run_scenario() {
     should_skip_fixture "$fixture_name" && return 0
 
     # RAG requires symbol content (populated during index) + embeddings.
-    # Re-index to ensure symbol_content is populated, then build RAG index.
-    (cd "$fixture_dir" && $CARTOG index . --force >/dev/null 2>&1) || true
-    (cd "$fixture_dir" && $CARTOG rag index >/dev/null 2>&1) || true
+    # Re-index to ensure symbol_content is populated, then build RAG index —
+    # both into the fixture's isolated DB so the later query reads them back.
+    local db
+    db=$(fixture_db_path "$fixture_dir")
+    (cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG index . --force >/dev/null 2>&1) || true
+    (cd "$fixture_dir" && CARTOG_DB="$db" $CARTOG rag index >/dev/null 2>&1) || true
 
     echo -e "  ${CYAN}[$fixture_name]${NC} RAG search: '$QUERY'" >&2
 

--- a/crates/cartog-indexer/benches/indexing.rs
+++ b/crates/cartog-indexer/benches/indexing.rs
@@ -1,77 +1,57 @@
 //! ONNX-free indexing benchmarks for `cartog-indexer`.
 //!
-//! Mirrors the `index_*` benches in `crates/cartog/benches/queries.rs`, but
-//! lives in `cartog-indexer` so it can be run without the cartog-rag /
-//! ONNX runtime build chain. Useful for quick local perf checks and CI
-//! environments without the native ONNX library installed.
+//! This is the canonical home for indexing-throughput benchmarks: it lives in
+//! `cartog-indexer`, which has no `cartog-rag`/ONNX dependency, so CI can run
+//! it without the native ONNX build chain. The sibling `cartog --bench
+//! queries` target deliberately does *not* duplicate these.
 //!
-//! Run with: `cargo bench --bench indexing`
+//! Run with: `cargo bench -p cartog-indexer --bench indexing`
 //!
-//! **Keep in sync with `crates/cartog/benches/queries.rs::bench_indexing`.**
-//! When you adjust scenarios here (fixture path, page-cap, fixture file
-//! invalidated for the single-file edit case), apply the same change there
-//! so the two surfaces measure the same thing. Duplication is intentional —
-//! the cartog-binary bench depends on `cartog-rag` which depends on the
-//! ONNX native library; this crate has no such constraint.
+//! Scenarios:
+//! - `index_full_force/<lang>` — full re-index of each language fixture. Each
+//!   exercises a distinct tree-sitter grammar + extractor, which is where
+//!   indexing cost actually varies, so this is parameterized over all 8
+//!   fixtures.
+//! - `index_incremental_noop` / `index_incremental_one_file` — the incremental
+//!   skip/diff paths. These are language-agnostic (hash compare + Merkle diff
+//!   in `cartog-db`/`cartog-indexer`, not in any grammar), so they run on the
+//!   dense Python fixture only.
+//!
+//! The timed bodies live in [`cartog_indexer::bench_support`] so they stay
+//! identical to anything that reuses them.
 
-use std::path::Path;
+use std::hint::black_box;
 
-use cartog_core::FileInfo;
-use cartog_db::Database;
-use cartog_indexer::index_directory;
-use criterion::{criterion_group, criterion_main, Criterion};
+use cartog_indexer::bench_support;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
-fn fixture_dir() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("benchmarks")
-        .join("fixtures")
-        .join("webapp_py")
+fn bench_full_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("index_full_force");
+    for (lang, fixture) in bench_support::all_fixtures() {
+        group.bench_with_input(BenchmarkId::from_parameter(lang), &fixture, |b, fixture| {
+            b.iter(|| black_box(bench_support::full_force(black_box(fixture))));
+        });
+    }
+    group.finish();
 }
 
-fn bench_indexing(c: &mut Criterion) {
-    let fixture = fixture_dir();
-    assert!(
-        fixture.exists(),
-        "expected fixture at {fixture:?}; run from a checkout that includes benchmarks/"
-    );
-
-    // Full index (force=true): baseline.
-    c.bench_function("index_full_force", |b| {
-        b.iter(|| {
-            let db = Database::open_memory().unwrap();
-            index_directory(&db, &fixture, true, false, None, None).unwrap();
-        });
-    });
+fn bench_incremental(c: &mut Criterion) {
+    let fixture = bench_support::fixture_path();
 
     // No-op re-index: every file's stored hash matches; everything is skipped
     // before parsing.
     c.bench_function("index_incremental_noop", |b| {
-        let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture, true, false, None, None).unwrap();
-        b.iter(|| {
-            index_directory(&db, &fixture, false, false, None, None).unwrap();
-        });
+        let db = bench_support::seed(&fixture);
+        b.iter(|| black_box(bench_support::noop(black_box(&db), black_box(&fixture))));
     });
 
     // Single-file change: invalidate one file's stored hash so it re-parses
     // and exercises the Merkle-diff path inside Phase 3.
     c.bench_function("index_incremental_one_file", |b| {
-        let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture, true, false, None, None).unwrap();
-        b.iter(|| {
-            db.upsert_file(&FileInfo {
-                path: "auth/service.py".to_string(),
-                last_modified: 0.0,
-                hash: "invalidated".to_string(),
-                language: "python".to_string(),
-                num_symbols: 0,
-            })
-            .unwrap();
-            index_directory(&db, &fixture, false, false, None, None).unwrap();
-        });
+        let db = bench_support::seed(&fixture);
+        b.iter(|| black_box(bench_support::one_file(black_box(&db), black_box(&fixture))));
     });
 }
 
-criterion_group!(benches, bench_indexing);
+criterion_group!(benches, bench_full_index, bench_incremental);
 criterion_main!(benches);

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -1052,6 +1052,134 @@ fn extract_symbol_content(source: &str, sym: &cartog_core::Symbol) -> Option<(St
     Some((raw.to_string(), header))
 }
 
+/// Shared scenario bodies for the indexing benchmarks.
+///
+/// Both `cartog-indexer/benches/indexing.rs` (ONNX-free) and
+/// `cartog/benches/queries.rs` (pulls in `cartog-rag`/ONNX) reuse these so the
+/// timed work cannot drift between the two `[[bench]]` targets. The criterion
+/// wiring stays in each bench (criterion is only a dev-dependency).
+///
+/// Each scenario function performs exactly one timed unit of work and returns
+/// the [`IndexResult`] so the caller can hand it to `black_box`.
+#[doc(hidden)]
+pub mod bench_support {
+    use super::{index_directory, IndexResult};
+    use cartog_core::FileInfo;
+    use cartog_db::Database;
+    use std::path::{Path, PathBuf};
+
+    /// Language tags for the per-language indexing benchmark, paired with their
+    /// `benchmarks/fixtures/webapp_<tag>` directory name. Each exercises a
+    /// distinct tree-sitter grammar + extractor, which is where indexing cost
+    /// actually varies by language.
+    pub const FIXTURE_LANGS: [&str; 8] = ["py", "ts", "go", "rs", "rb", "java", "php", "dart"];
+
+    /// Absolute path to `benchmarks/fixtures`, relative to either bench crate.
+    fn fixtures_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("benchmarks")
+            .join("fixtures")
+    }
+
+    /// Path to the `webapp_py` fixture — the dense default corpus used by the
+    /// language-agnostic incremental scenarios and the query benches.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the fixture directory is missing — benches are always run
+    /// from a checkout that includes `benchmarks/`, so its absence is a bug.
+    #[must_use]
+    pub fn fixture_path() -> PathBuf {
+        fixture_for("py")
+    }
+
+    /// Path to the `webapp_<lang>` fixture for one language tag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the fixture directory is missing (a checkout/setup bug).
+    #[must_use]
+    pub fn fixture_for(lang: &str) -> PathBuf {
+        let dir = fixtures_dir().join(format!("webapp_{lang}"));
+        assert!(
+            dir.exists(),
+            "expected fixture at {dir:?}; run from a checkout that includes benchmarks/"
+        );
+        dir
+    }
+
+    /// All language fixtures as `(lang_tag, path)` pairs, for parameterizing the
+    /// full-index benchmark across every grammar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any fixture directory is missing (a checkout/setup bug).
+    #[must_use]
+    pub fn all_fixtures() -> Vec<(&'static str, PathBuf)> {
+        FIXTURE_LANGS
+            .iter()
+            .map(|&lang| (lang, fixture_for(lang)))
+            .collect()
+    }
+
+    /// Open a fresh in-memory DB and full-index the fixture (force = true).
+    ///
+    /// This is the timed body of the `index_full_force` benchmark; it returns
+    /// the [`IndexResult`] so the caller can `black_box` it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if opening the DB or indexing fails; both are setup invariants
+    /// in a benchmark, not recoverable conditions.
+    pub fn full_force(fixture: &Path) -> IndexResult {
+        let db = Database::open_memory().expect("open in-memory DB");
+        index_directory(&db, fixture, true, false, None, None).expect("full index")
+    }
+
+    /// Open an in-memory DB and full-index the fixture, returning the DB.
+    ///
+    /// Used to seed the `noop` and `one_file` benchmarks outside their timed
+    /// loop (criterion setup, not measured).
+    ///
+    /// # Panics
+    ///
+    /// Panics if opening the DB or the seed index fails (setup invariants).
+    #[must_use]
+    pub fn seed(fixture: &Path) -> Database {
+        let db = Database::open_memory().expect("open in-memory DB");
+        index_directory(&db, fixture, true, false, None, None).expect("seed index");
+        db
+    }
+
+    /// Re-index with no changes: every stored hash matches, all files skipped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if re-indexing fails (a setup invariant).
+    pub fn noop(db: &Database, fixture: &Path) -> IndexResult {
+        index_directory(db, fixture, false, false, None, None).expect("noop re-index")
+    }
+
+    /// Invalidate one file's stored hash, then re-index so it re-parses and
+    /// exercises the Merkle-diff path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if upserting the file or re-indexing fails (setup invariants).
+    pub fn one_file(db: &Database, fixture: &Path) -> IndexResult {
+        db.upsert_file(&FileInfo {
+            path: "auth/service.py".to_string(),
+            last_modified: 0.0,
+            hash: "invalidated".to_string(),
+            language: "python".to_string(),
+            num_symbols: 0,
+        })
+        .expect("invalidate file hash");
+        index_directory(db, fixture, false, false, None, None).expect("incremental re-index")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -61,5 +61,17 @@ libc = { workspace = true }
 name = "queries"
 harness = false
 
+# Hybrid-search latency with a deterministic stub embedding provider — never
+# loads an ONNX model, so it is safe to run in CI.
+[[bench]]
+name = "rag_search"
+harness = false
+
+# Embedding + reranking latency against the real fastembed/ONNX model. NOT run
+# in CI (requires the model on disk); invoke locally via `make bench-onnx`.
+[[bench]]
+name = "rag_onnx"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/cartog/benches/queries.rs
+++ b/crates/cartog/benches/queries.rs
@@ -6,25 +6,29 @@
 //! Note: separate from `benchmarks/` (shell-based integration suite measuring
 //! token efficiency and recall). Both share `benchmarks/fixtures/`.
 //!
-//! Run with: `cargo bench --bench queries`
+//! Inputs and results are wrapped in [`std::hint::black_box`] so the compiler
+//! cannot constant-fold the literal queries or eliminate the (otherwise
+//! unused) results — without it these microsecond-scale benches risk
+//! measuring nothing.
+//!
+//! Indexing throughput is measured separately by `cartog-indexer`'s `indexing`
+//! bench (ONNX-free); this target covers query latency only.
+//!
+//! Run with: `cargo bench -p cartog --bench queries`
+
+use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::path::Path;
 
 use cartog::db::Database;
-use cartog::indexer::index_directory;
-use cartog::types::{EdgeKind, FileInfo};
+use cartog::indexer::{bench_support, index_directory};
+use cartog::types::EdgeKind;
 
 /// Build an indexed database from the Python benchmark fixture.
 fn setup_db() -> Database {
-    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("benchmarks")
-        .join("fixtures")
-        .join("webapp_py");
-
     let db = Database::open_memory().expect("open in-memory DB");
-    index_directory(&db, &fixture_dir, true, false, None, None).expect("index fixture");
+    index_directory(&db, &bench_support::fixture_path(), true, false, None, None)
+        .expect("index fixture");
     db
 }
 
@@ -32,17 +36,19 @@ fn bench_search(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("search_token", |b| {
-        b.iter(|| db.search("token", None, None, 100).unwrap())
+        b.iter(|| black_box(db.search(black_box("token"), None, None, 100).unwrap()))
     });
 
     c.bench_function("search_validate", |b| {
-        b.iter(|| db.search("validate", None, None, 100).unwrap())
+        b.iter(|| black_box(db.search(black_box("validate"), None, None, 100).unwrap()))
     });
 
     c.bench_function("search_no_match", |b| {
         b.iter(|| {
-            db.search("zzz_nonexistent_symbol", None, None, 100)
-                .unwrap()
+            black_box(
+                db.search(black_box("zzz_nonexistent_symbol"), None, None, 100)
+                    .unwrap(),
+            )
         })
     });
 }
@@ -51,19 +57,24 @@ fn bench_refs(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("refs_validate_token_all", |b| {
-        b.iter(|| db.refs("validate_token", None).unwrap())
+        b.iter(|| black_box(db.refs(black_box("validate_token"), None).unwrap()))
     });
 
     c.bench_function("refs_validate_token_calls", |b| {
-        b.iter(|| db.refs("validate_token", Some(EdgeKind::Calls)).unwrap())
+        b.iter(|| {
+            black_box(
+                db.refs(black_box("validate_token"), Some(EdgeKind::Calls))
+                    .unwrap(),
+            )
+        })
     });
 
     c.bench_function("refs_get_logger_all", |b| {
-        b.iter(|| db.refs("get_logger", None).unwrap())
+        b.iter(|| black_box(db.refs(black_box("get_logger"), None).unwrap()))
     });
 
     c.bench_function("refs_AuthService", |b| {
-        b.iter(|| db.refs("AuthService", None).unwrap())
+        b.iter(|| black_box(db.refs(black_box("AuthService"), None).unwrap()))
     });
 }
 
@@ -71,15 +82,15 @@ fn bench_impact(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("impact_AuthService_d3", |b| {
-        b.iter(|| db.impact("AuthService", 3).unwrap())
+        b.iter(|| black_box(db.impact(black_box("AuthService"), 3).unwrap()))
     });
 
     c.bench_function("impact_DatabaseConnection_d5", |b| {
-        b.iter(|| db.impact("DatabaseConnection", 5).unwrap())
+        b.iter(|| black_box(db.impact(black_box("DatabaseConnection"), 5).unwrap()))
     });
 
     c.bench_function("impact_validate_token_d3", |b| {
-        b.iter(|| db.impact("validate_token", 3).unwrap())
+        b.iter(|| black_box(db.impact(black_box("validate_token"), 3).unwrap()))
     });
 }
 
@@ -87,11 +98,11 @@ fn bench_outline(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("outline_auth_service", |b| {
-        b.iter(|| db.outline("auth/service.py").unwrap())
+        b.iter(|| black_box(db.outline(black_box("auth/service.py")).unwrap()))
     });
 
     c.bench_function("outline_routes_auth", |b| {
-        b.iter(|| db.outline("routes/auth.py").unwrap())
+        b.iter(|| black_box(db.outline(black_box("routes/auth.py")).unwrap()))
     });
 }
 
@@ -99,13 +110,15 @@ fn bench_callees(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("callees_login_route", |b| {
-        b.iter(|| db.callees("login_route").unwrap())
+        b.iter(|| black_box(db.callees(black_box("login_route")).unwrap()))
     });
 
-    c.bench_function("callees_login", |b| b.iter(|| db.callees("login").unwrap()));
+    c.bench_function("callees_login", |b| {
+        b.iter(|| black_box(db.callees(black_box("login")).unwrap()))
+    });
 
     c.bench_function("callees_generate_token", |b| {
-        b.iter(|| db.callees("generate_token").unwrap())
+        b.iter(|| black_box(db.callees(black_box("generate_token")).unwrap()))
     });
 }
 
@@ -113,11 +126,11 @@ fn bench_hierarchy(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("hierarchy_BaseService", |b| {
-        b.iter(|| db.hierarchy("BaseService").unwrap())
+        b.iter(|| black_box(db.hierarchy(black_box("BaseService")).unwrap()))
     });
 
     c.bench_function("hierarchy_AppError", |b| {
-        b.iter(|| db.hierarchy("AppError").unwrap())
+        b.iter(|| black_box(db.hierarchy(black_box("AppError")).unwrap()))
     });
 }
 
@@ -125,25 +138,24 @@ fn bench_deps(c: &mut Criterion) {
     let db = setup_db();
 
     c.bench_function("deps_routes_auth", |b| {
-        b.iter(|| db.file_deps("routes/auth.py").unwrap())
+        b.iter(|| black_box(db.file_deps(black_box("routes/auth.py")).unwrap()))
     });
 
     c.bench_function("deps_auth_service", |b| {
-        b.iter(|| db.file_deps("auth/service.py").unwrap())
+        b.iter(|| black_box(db.file_deps(black_box("auth/service.py")).unwrap()))
     });
 }
 
 fn bench_stats(c: &mut Criterion) {
     let db = setup_db();
 
-    c.bench_function("stats", |b| b.iter(|| db.stats().unwrap()));
+    c.bench_function("stats", |b| b.iter(|| black_box(db.stats().unwrap())));
 }
 
 fn setup_java_db() -> Database {
-    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("benchmarks")
-        .join("fixtures")
+    let fixture_dir = bench_support::fixture_path()
+        .parent()
+        .expect("fixtures dir")
         .join("webapp_java");
 
     let db = Database::open_memory().expect("open in-memory DB");
@@ -155,17 +167,19 @@ fn bench_java_search(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_search_token", |b| {
-        b.iter(|| db.search("Token", None, None, 100).unwrap())
+        b.iter(|| black_box(db.search(black_box("Token"), None, None, 100).unwrap()))
     });
 
     c.bench_function("java_search_validate", |b| {
-        b.iter(|| db.search("validate", None, None, 100).unwrap())
+        b.iter(|| black_box(db.search(black_box("validate"), None, None, 100).unwrap()))
     });
 
     c.bench_function("java_search_no_match", |b| {
         b.iter(|| {
-            db.search("zzz_nonexistent_symbol", None, None, 100)
-                .unwrap()
+            black_box(
+                db.search(black_box("zzz_nonexistent_symbol"), None, None, 100)
+                    .unwrap(),
+            )
         })
     });
 }
@@ -174,19 +188,24 @@ fn bench_java_refs(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_refs_validateToken_all", |b| {
-        b.iter(|| db.refs("validateToken", None).unwrap())
+        b.iter(|| black_box(db.refs(black_box("validateToken"), None).unwrap()))
     });
 
     c.bench_function("java_refs_validateToken_calls", |b| {
-        b.iter(|| db.refs("validateToken", Some(EdgeKind::Calls)).unwrap())
+        b.iter(|| {
+            black_box(
+                db.refs(black_box("validateToken"), Some(EdgeKind::Calls))
+                    .unwrap(),
+            )
+        })
     });
 
     c.bench_function("java_refs_TokenException_all", |b| {
-        b.iter(|| db.refs("TokenException", None).unwrap())
+        b.iter(|| black_box(db.refs(black_box("TokenException"), None).unwrap()))
     });
 
     c.bench_function("java_refs_AuthService", |b| {
-        b.iter(|| db.refs("AuthService", None).unwrap())
+        b.iter(|| black_box(db.refs(black_box("AuthService"), None).unwrap()))
     });
 }
 
@@ -194,15 +213,15 @@ fn bench_java_impact(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_impact_AuthService_d3", |b| {
-        b.iter(|| db.impact("AuthService", 3).unwrap())
+        b.iter(|| black_box(db.impact(black_box("AuthService"), 3).unwrap()))
     });
 
     c.bench_function("java_impact_DatabaseConnection_d3", |b| {
-        b.iter(|| db.impact("DatabaseConnection", 3).unwrap())
+        b.iter(|| black_box(db.impact(black_box("DatabaseConnection"), 3).unwrap()))
     });
 
     c.bench_function("java_impact_validateToken_d3", |b| {
-        b.iter(|| db.impact("validateToken", 3).unwrap())
+        b.iter(|| black_box(db.impact(black_box("validateToken"), 3).unwrap()))
     });
 }
 
@@ -210,11 +229,11 @@ fn bench_java_outline(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_outline_token_service", |b| {
-        b.iter(|| db.outline("auth/TokenService.java").unwrap())
+        b.iter(|| black_box(db.outline(black_box("auth/TokenService.java")).unwrap()))
     });
 
     c.bench_function("java_outline_auth_routes", |b| {
-        b.iter(|| db.outline("routes/AuthRoutes.java").unwrap())
+        b.iter(|| black_box(db.outline(black_box("routes/AuthRoutes.java")).unwrap()))
     });
 }
 
@@ -222,15 +241,15 @@ fn bench_java_callees(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_callees_handleLogin", |b| {
-        b.iter(|| db.callees("handleLogin").unwrap())
+        b.iter(|| black_box(db.callees(black_box("handleLogin")).unwrap()))
     });
 
     c.bench_function("java_callees_authenticate", |b| {
-        b.iter(|| db.callees("authenticate").unwrap())
+        b.iter(|| black_box(db.callees(black_box("authenticate")).unwrap()))
     });
 
     c.bench_function("java_callees_generateToken", |b| {
-        b.iter(|| db.callees("generateToken").unwrap())
+        b.iter(|| black_box(db.callees(black_box("generateToken")).unwrap()))
     });
 }
 
@@ -238,11 +257,11 @@ fn bench_java_hierarchy(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_hierarchy_AppException", |b| {
-        b.iter(|| db.hierarchy("AppException").unwrap())
+        b.iter(|| black_box(db.hierarchy(black_box("AppException")).unwrap()))
     });
 
     c.bench_function("java_hierarchy_AuthService", |b| {
-        b.iter(|| db.hierarchy("AuthService").unwrap())
+        b.iter(|| black_box(db.hierarchy(black_box("AuthService")).unwrap()))
     });
 }
 
@@ -250,62 +269,29 @@ fn bench_java_deps(c: &mut Criterion) {
     let db = setup_java_db();
 
     c.bench_function("java_deps_auth_routes", |b| {
-        b.iter(|| db.file_deps("routes/AuthRoutes.java").unwrap())
+        b.iter(|| black_box(db.file_deps(black_box("routes/AuthRoutes.java")).unwrap()))
     });
 
     c.bench_function("java_deps_auth_service", |b| {
-        b.iter(|| db.file_deps("services/AuthenticationService.java").unwrap())
+        b.iter(|| {
+            black_box(
+                db.file_deps(black_box("services/AuthenticationService.java"))
+                    .unwrap(),
+            )
+        })
     });
 }
 
 fn bench_java_stats(c: &mut Criterion) {
     let db = setup_java_db();
 
-    c.bench_function("java_stats", |b| b.iter(|| db.stats().unwrap()));
+    c.bench_function("java_stats", |b| b.iter(|| black_box(db.stats().unwrap())));
 }
 
-// ── Indexing benchmarks ──
-
-fn bench_indexing(c: &mut Criterion) {
-    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("benchmarks")
-        .join("fixtures")
-        .join("webapp_py");
-
-    // Full index (force=true): baseline
-    c.bench_function("index_full_force", |b| {
-        b.iter(|| {
-            let db = Database::open_memory().unwrap();
-            index_directory(&db, &fixture_dir, true, false, None, None).unwrap()
-        })
-    });
-
-    // Incremental no-op: all files already indexed with matching hashes
-    c.bench_function("index_incremental_noop", |b| {
-        let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture_dir, true, false, None, None).unwrap();
-        b.iter(|| index_directory(&db, &fixture_dir, false, false, None, None).unwrap())
-    });
-
-    // Incremental one-file change: invalidate one file's hash to force re-parse + Merkle diff
-    c.bench_function("index_incremental_one_file", |b| {
-        let db = Database::open_memory().unwrap();
-        index_directory(&db, &fixture_dir, true, false, None, None).unwrap();
-        b.iter(|| {
-            // Invalidate hash to simulate file change
-            db.upsert_file(&FileInfo {
-                path: "auth/service.py".to_string(),
-                last_modified: 0.0,
-                hash: "invalidated".to_string(),
-                language: "python".to_string(),
-                num_symbols: 0,
-            })
-            .unwrap();
-            index_directory(&db, &fixture_dir, false, false, None, None).unwrap()
-        })
-    });
-}
+// Indexing benchmarks live in `cartog-indexer/benches/indexing.rs` (its own
+// `[[bench]]` target). They run without the ONNX build chain, so CI can
+// measure them directly without linking `cartog-rag`. This bench is
+// query-only.
 
 criterion_group!(
     benches,
@@ -325,6 +311,5 @@ criterion_group!(
     bench_java_hierarchy,
     bench_java_deps,
     bench_java_stats,
-    bench_indexing,
 );
 criterion_main!(benches);

--- a/crates/cartog/benches/rag_onnx.rs
+++ b/crates/cartog/benches/rag_onnx.rs
@@ -1,0 +1,62 @@
+//! Real-model embedding + reranking latency benchmarks.
+//!
+//! Unlike `rag_search` (deterministic stub provider), this bench loads the
+//! actual fastembed/ONNX models, so it is **not run in CI**. It requires the
+//! models to be present on disk (`cartog rag setup`); if a model is missing or
+//! fails to load, the affected benches skip gracefully rather than panicking.
+//! (To avoid a multi-hundred-MB download during a benchmark, set the fastembed
+//! cache offline before running.)
+//!
+//! Run locally with: `make bench-onnx` (or `cargo bench -p cartog --bench rag_onnx`).
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use cartog::rag::{create_default_embedding_provider, create_default_reranker_provider};
+
+const QUERY: &str = "validate an authentication token and return the user";
+const DOCS: [&str; 4] = [
+    "fn validate_token(token: &str) -> Result<User> { /* ... */ }",
+    "class DatabaseConnection: def __init__(self, dsn): ...",
+    "def send_welcome_email(user): smtp.send(user.email, template)",
+    "struct RateLimiter { window: Duration, max: u32 }",
+];
+
+fn bench_embedding(c: &mut Criterion) {
+    let mut provider = match create_default_embedding_provider() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("skipping rag_onnx embedding benches: model unavailable ({e})");
+            return;
+        }
+    };
+
+    c.bench_function("embed_query", |b| {
+        b.iter(|| black_box(provider.embed_query(black_box(QUERY)).unwrap()))
+    });
+
+    c.bench_function("embed_documents_batch", |b| {
+        b.iter(|| black_box(provider.embed_documents(black_box(&DOCS)).unwrap()))
+    });
+}
+
+fn bench_reranker(c: &mut Criterion) {
+    let Some(mut reranker) = create_default_reranker_provider() else {
+        eprintln!("skipping rag_onnx reranker bench: model unavailable (run `cartog rag setup`)");
+        return;
+    };
+
+    c.bench_function("rerank_score_batch", |b| {
+        b.iter(|| {
+            black_box(
+                reranker
+                    .score_batch(black_box(QUERY), black_box(&DOCS))
+                    .unwrap(),
+            )
+        })
+    });
+}
+
+criterion_group!(benches, bench_embedding, bench_reranker);
+criterion_main!(benches);

--- a/crates/cartog/benches/rag_search.rs
+++ b/crates/cartog/benches/rag_search.rs
@@ -1,0 +1,116 @@
+//! Hybrid-search latency benchmarks for the RAG pipeline.
+//!
+//! Measures `hybrid_search` (FTS5 + vector KNN + RRF merge) over the indexed
+//! Python fixture. Embeddings are produced by a deterministic stub provider, so
+//! this bench **never loads an ONNX model** and is safe to run in CI — the same
+//! approach as `tests/rag_relevancy.rs`. Real-model embed/rerank latency lives
+//! in the separate `rag_onnx` bench, which CI does not run.
+//!
+//! The reranker is intentionally `None`: the cross-encoder requires the ONNX
+//! model. Reranking latency is covered by `rag_onnx`.
+//!
+//! Run with: `cargo bench -p cartog --bench rag_search`
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use cartog::db::Database;
+use cartog::indexer::{bench_support, index_directory};
+use cartog::rag::indexer::index_embeddings;
+use cartog::rag::provider::EmbeddingProvider;
+use cartog::rag::search::{hybrid_search, KindFilter};
+
+/// Deterministic, ONNX-free embedding provider.
+///
+/// Returns a unit-length vector derived from a cheap hash of the input so that
+/// distinct texts get distinct vectors — the vector-search distance scan then
+/// does realistic work instead of comparing identical zero vectors.
+struct StubEmbeddingProvider;
+
+impl StubEmbeddingProvider {
+    const DIM: usize = 384;
+}
+
+impl EmbeddingProvider for StubEmbeddingProvider {
+    fn name(&self) -> &str {
+        "stub"
+    }
+    fn model_id(&self) -> &str {
+        "stub-model"
+    }
+    fn dimension(&self) -> usize {
+        Self::DIM
+    }
+    fn embed_document(&mut self, text: &str) -> anyhow::Result<Vec<f32>> {
+        let mut seed: u64 = 1469598103934665603;
+        for b in text.bytes() {
+            seed ^= u64::from(b);
+            seed = seed.wrapping_mul(1099511628211);
+        }
+        let mut v = vec![0.0f32; Self::DIM];
+        for (i, slot) in v.iter_mut().enumerate() {
+            let h = seed.wrapping_add((i as u64).wrapping_mul(0x9E3779B97F4A7C15));
+            *slot = ((h >> 11) as f32 / (1u64 << 53) as f32) - 0.5;
+        }
+        let norm = v
+            .iter()
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt()
+            .max(f32::EPSILON);
+        for x in &mut v {
+            *x /= norm;
+        }
+        Ok(v)
+    }
+    fn embed_documents(&mut self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        texts.iter().map(|t| self.embed_document(t)).collect()
+    }
+}
+
+/// Index the Python fixture and embed every symbol with the stub provider.
+fn setup_db() -> Database {
+    let db = Database::open_memory().expect("open in-memory DB");
+    index_directory(&db, &bench_support::fixture_path(), true, false, None, None)
+        .expect("index fixture");
+    let mut provider = StubEmbeddingProvider;
+    index_embeddings(&db, &mut provider, true, None, None).expect("embed fixture");
+    db
+}
+
+/// Representative queries spanning short/long and keyword/conceptual phrasings.
+const QUERIES: [&str; 4] = [
+    "validate token",
+    "database connection pool",
+    "authenticate user",
+    "send notification email",
+];
+
+fn bench_hybrid_search(c: &mut Criterion) {
+    let db = setup_db();
+    let mut provider = StubEmbeddingProvider;
+
+    let mut group = c.benchmark_group("hybrid_search");
+    for query in QUERIES {
+        group.bench_with_input(BenchmarkId::from_parameter(query), &query, |b, &q| {
+            b.iter(|| {
+                black_box(
+                    hybrid_search(
+                        &db,
+                        black_box(q),
+                        black_box(10),
+                        KindFilter::CodeOnly,
+                        &mut provider,
+                        None,
+                    )
+                    .unwrap(),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_hybrid_search);
+criterion_main!(benches);

--- a/docs/product.md
+++ b/docs/product.md
@@ -19,7 +19,7 @@ Code is a graph of relationships (calls, imports, inherits, type references). ca
 | Query latency | multi-step | 8–450 µs |
 | Transitive analysis | impossible | `impact --depth 3` |
 
-Measured across 13 scenarios, 5 languages. Best gains on call chain tracing (88% token reduction) and caller lookup (95% reduction).
+Measured across 13 scenarios, 8 languages. Best gains on call chain tracing (88% token reduction) and caller lookup (95% reduction).
 
 > **Recall caveat:** The 97% figure requires a matching language server on `PATH` (the default build ships LSP support). Without a server (or with `--no-lsp`), edge resolution falls to ~25–37% depending on language; with LSP it reaches 44–81%. See [README — Benchmark notes](../README.md#benchmark-notes) for methodology.
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -61,4 +61,5 @@ Each link goes to that crate's `README.md`, which has the detailed responsibilit
 - Public functions documented with `///`. Crate `lib.rs` has `//!` crate docs.
 - CLI output: human-readable by default, `--json` for structured output.
 - Tests: unit tests in each crate (`#[cfg(test)]`), integration tests in `crates/cartog/tests/`, shared fixtures in `tests/fixtures/`.
+- Benches: criterion `[[bench]]` targets in `crates/cartog/benches/` (`queries`, `rag_search`, `rag_onnx`) and `crates/cartog-indexer/benches/` (`indexing`); see [tech.md](tech.md#benchmarks). Fixtures live in `benchmarks/fixtures/`.
 - Lint gate (must pass before commit): `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`, `make check-skill`.

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -24,7 +24,7 @@
 | `fastembed` | ONNX Runtime inference for embeddings + re-ranking (local provider) | Optional via `provider-local` feature (default on). `default-features = false` drops image models (CLIP etc.). `rustls-tls` avoids OpenSSL system dependency |
 | `reqwest` | HTTP client for self-update + remote embedding providers (Ollama) | Non-optional in the `cartog` binary (self-update). The Ollama provider in `cartog-rag` is gated by `provider-ollama`, which the binary enables by default (`ollama-embedding`). Uses `blocking` + `rustls-tls` |
 | `sqlite-vec` | Vector similarity search (KNN) in SQLite | `vec0` virtual table, requires integer rowids (bridged via `symbol_embedding_map`) |
-| `criterion` (dev) | Micro-benchmarks | Query latency benchmarks (µs-level) |
+| `criterion` (dev) | Micro-benchmarks | Four `[[bench]]` targets — see [Benchmarks](#benchmarks). Inputs/results are `black_box`-wrapped so µs-scale benches measure real work |
 | `rust-s3` 0.37 (`tokio-rustls-tls`) | S3-compatible client for `cartog push` / `cartog pull` | Optional via `remote-s3` feature (default on). Chosen over `aws-sdk-s3` for size (~5 MB vs ~18 MB); supports AWS S3, MinIO, R2, floci |
 
 ## Build Profiles
@@ -34,6 +34,40 @@
 | `dev.opt-level` | `1` | Tree-sitter C grammars are machine-generated huge files that compile very slowly at opt-level 0. Level 1 also makes indexing usably fast during development |
 | `release.lto` | `"thin"` | Most binary size / performance benefits of full LTO at a fraction of the link time |
 | `release.strip` | `"debuginfo"` | Removes DWARF sections (~50% binary size reduction) but keeps function names in panic backtraces for diagnosable crash reports |
+
+## Benchmarks
+
+Two distinct surfaces, both rooted in `benchmarks/fixtures/` (8 language webapps):
+
+- **Shell suite** (`benchmarks/run.sh`, 13 scenarios × fixtures) — token efficiency
+  and recall versus grep/cat. Run with `make bench`.
+- **Criterion micro-benchmarks** — in-process latency. The guiding rule: benchmark
+  cartog's own CPU-bound work; anything dominated by an external service (the
+  Ollama daemon, S3) gets a *correctness* test at the boundary, not a latency
+  bench, so numbers never measure infrastructure.
+
+Criterion benches are split into four `[[bench]]` targets so the ONNX boundary is
+expressed by target membership — CI runs the three runtime-ONNX-free targets and
+simply never names the fourth (criterion's regex filter cannot express exclusion):
+
+| Target | Crate | Scope | Runtime ONNX | CI |
+|--------|-------|-------|--------------|-----|
+| `queries` | `cartog` | 8 query ops (search/refs/impact/outline/callees/hierarchy/deps/stats), Python + Java | no | ✅ |
+| `indexing` | `cartog-indexer` | `index_full_force/<lang>` over all 8 fixtures + 2 incremental scenarios | no (crate has no `cartog-rag` dep) | ✅ |
+| `rag_search` | `cartog` | `hybrid_search` (FTS5 + vector KNN + RRF) via a deterministic stub provider | no (stub vectors) | ✅ |
+| `rag_onnx` | `cartog` | real fastembed embed + cross-encoder rerank | **yes** | ❌ opt-in (`make bench-onnx`) |
+
+Conventions: every `b.iter` input and result is wrapped in `std::hint::black_box`
+so the compiler cannot constant-fold literal inputs or eliminate unused results —
+without it the µs-scale query benches would risk measuring nothing. Query latency
+is language-agnostic (same SQL regardless of source language), so it is benched on
+Python + Java only; per-language cost lives in the tree-sitter grammar/extractor,
+so `index_full_force` is parameterized across all 8 fixtures. The shared scenario
+bodies live in `cartog_indexer::bench_support` so `queries` and `indexing` cannot
+drift. On PRs the CI `bench` job establishes a same-runner baseline at the merge
+base and reports a `--baseline` delta (controlling for runner variance); it is
+`continue-on-error`, so a noisy result never blocks. Run everything ONNX-free
+locally with `make bench-criterion`.
 
 ## Architecture Decisions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -679,7 +679,7 @@ By tool (call counts):
      1  refs
 
 Baseline: ~1700 tokens for an equivalent grep+read sweep vs cartog's ~280.
-Measured across 13 benchmark scenarios (see crates/cartog/benches/queries.rs).
+Measured across 13 benchmark scenarios (see benchmarks/scenarios/).
 ```
 
 The header line is `cartog · <project> · <N> queries`, where `<project>` is


### PR DESCRIPTION
## Summary

Hardens both benchmark surfaces (criterion micro-benches + the shell token/recall suite). What began as a review uncovered a **suite-wide correctness bug**: fixtures shared one index, so reported recall was inflated and non-deterministic. Three self-contained commits.

## Commits

### 1. `bench:` — criterion benches correctness + structure
- **`black_box`** on every `b.iter` input/result across `queries` + `indexing`. Without it, the µs-scale read-only benches risked measuring dead-code-eliminated no-ops.
- Split into **four `[[bench]]` targets** partitioned by the ONNX runtime boundary, so CI runs the three runtime-ONNX-free ones and excludes `rag_onnx` by not naming it (criterion's regex filter can't express exclusion):
  - `queries` (cartog) — 8 query ops, Python + Java
  - `indexing` (cartog-indexer) — full index across **all 8 language fixtures** + 2 incremental scenarios
  - `rag_search` (cartog) — `hybrid_search` via a deterministic stub provider (no model load)
  - `rag_onnx` (cartog) — real embed/rerank, opt-in via `make bench-onnx`
- Shared indexing scenario bodies via `cartog_indexer::bench_support` so targets can't drift.
- CI: `-p`-qualified invocations, query/index split, same-runner merge-base baseline comparison on PRs (`continue-on-error`).

### 2. `fix(benchmarks):` — recall matching + filter unification
- Recall counted an expected symbol via `grep -c "$item"` — a **substring + regex** match (`login` matched `login_route`; names with regex metacharacters were treated as patterns), inflating reported recall. Now `grep -Fwq -- "$item"` (fixed-string, whole-word).
- The fixture filter was duplicated in `run.sh` and `common.sh` and had drifted (`dart` handled in one, not the other). `run.sh` now sources `common.sh`; one filter, one color block.
- Removed dead `count_matches`.

### 3. `fix(benchmarks):` — index isolation + scenario 04
- **Root cause of flaky recall**: fixtures have no local `.cartog`, so `cartog index .` walked up to the repo-root index and each fixture clobbered the previous one. Recall was measured against whichever fixture indexed last. Fixed by pinning `CARTOG_DB` to a per-fixture file under `benchmarks/.indexes/` (gitignored) across the runner, `run_cartog_cmd`, and scenarios 05/11/13.
- **With isolation, cartog's true average recall is ~88%** (was reported higher off the contaminated index).
- Scenario 04: Java ground truth described `hierarchy AppException` while the script queried `BaseService` (always scored 0) — realigned to `BaseService` with its 4 real subclasses. Dropped Rust/Go (traits / struct embedding, not class inheritance) with a logged skip.
- Documented the idiom-resolution gaps the clean run surfaced under "Known cartog gaps" in `benchmarks/README.md`.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.
- All 4 bench targets compile; `rag_onnx` run locally (embed 6.2ms, batch 14.5ms, rerank 23.5ms).
- Full shell suite runs clean with isolation: no root-index leak, cartog recall ~88% across 89 rows.

## Follow-ups (not in this PR)
- PHP class-inheritance resolution gap (filed as a separate issue).
- Per-language idiom scenarios (cartog can't resolve abstract trait/interface implementors today).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded benchmarking suite across 13 scenarios and 8 languages, including RAG search performance measurements.
  * Added dedicated `make bench-criterion` and `make bench-onnx` commands for running specialized benchmark tests.

* **Documentation**
  * Updated benchmark documentation and product notes to reflect expanded measurement scope.
  * Added guidance on benchmark fixture isolation and known accuracy limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrollin/cartog/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->