### PR TITLE
feat(agent-ux): cartog_trace, cartog_context, staleness banners, onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ crates/cartog/         (binary — CLI dispatch, config, self-update)
 ├── cartog-rag         (embeddings, hybrid search, reranker)
 ├── cartog-lsp         (LSP-based edge resolution — default feature)
 ├── cartog-watch       (debounced re-index + deferred RAG)
-├── cartog-mcp         (MCP server over stdio, 14 tools)
+├── cartog-mcp         (MCP server over stdio, 16 tools)
 └── cartog-process-lock (PID-file locks for serve/watch peers)
 ```
 
@@ -142,17 +142,20 @@ The MCP config JSON has one canonical copy in `docs/mcp-setup.md`; other docs li
 ## Current State
 
 - **Languages**: Python, TypeScript/JavaScript, Rust, Go, Ruby, Java, PHP, Dart, Markdown
-- **CLI**: 23 top-level commands (`init`, `ide`, `index`, `search`, `outline`, `refs`, `callees`, `impact`, `hierarchy`, `deps`, `stats`, `map`, `changes`, `config`, `doctor`, `watch`, `serve`, `push`, `pull`, `completions`, `manpage`, plus `rag` with 3 subcommands and `self` with 4 subcommands; `self update` has `--check`/`--defer`[`--to <version>`]/`--apply-pending` modes) + MCP server (14 tools)
+- **CLI**: 25 top-level commands (`init`, `ide`, `index`, `search`, `outline`, `refs`, `callees`, `impact`, `trace`, `context`, `hierarchy`, `deps`, `stats`, `map`, `changes`, `config`, `doctor`, `watch`, `serve`, `push`, `pull`, `completions`, `manpage`, plus `rag` with 3 subcommands and `self` with 4 subcommands; `self update` has `--check`/`--defer`[`--to <version>`]/`--apply-pending` modes) + MCP server (16 tools)
 - **Indexing**: incremental (git-based + SHA-256 + Merkle-tree symbol diffing), `--force` re-index. Stable symbol IDs (`file:kind:qualified_name`) survive line movements. Scoped edge resolution for changed files only
 - **Search**: symbol search (`cartog search`), hybrid FTS5+vector RAG search with RRF merge and cross-encoder re-ranking
 - **Watch**: `cartog watch` CLI + `cartog serve --watch` background mode, debounced re-index + deferred RAG embedding
-- **MCP single-writer**: `cartog serve` instances on the same DB use atomic O_EXCL election. First is primary, subsequent attach read-only (12 of 14 tools — only the 2 DB-write tools are gated); promoter on the secondary takes over within ~10s if the primary dies. Kill switch: `CARTOG_SINGLE_WRITER=0`.
+- **MCP single-writer**: `cartog serve` instances on the same DB use atomic O_EXCL election. First is primary, subsequent attach read-only (14 of 16 tools — only the 2 DB-write tools are gated); promoter on the secondary takes over within ~10s if the primary dies. Kill switch: `CARTOG_SINGLE_WRITER=0`.
 - **Deferred self-update**: inside a Claude Code session the MCP server holds the serve lock, so `cartog self update` would refuse (exit 6). `cartog self update --defer` (or the `cartog_update` MCP tool) arms a pending update without swapping; the SessionEnd hook runs `--apply-pending` once the peer exits. See [docs/updates.md](docs/updates.md).
 - **CI/CD**: fmt, clippy, test, coverage, release to crates.io + GitHub Releases
 - **Centrality**: in-degree ranking — search results prefer highly-referenced symbols
 - **Codebase map**: `cartog map --tokens N` produces budget-aware file tree + top symbols
 - **Token budget**: `--tokens N` global flag for context-window-aware output truncation
 - **Recent changes**: `cartog changes` shows symbols affected by recent git commits
+- **Call-path trace**: `cartog trace <from> <to>` / `cartog_trace` returns the shortest `calls` path between two symbols with each hop's body inline (forward BFS, static call edges only)
+- **Task-context bundle**: `cartog context <task>` / `cartog_context` fuses hybrid search seeds + 1-hop neighbors + seed-file centrality into a token-budgeted bundle
+- **Staleness banners**: when `cartog serve --watch` has pending changes/embeddings, affected MCP read-tool responses are prefixed with a `⚠️` banner; gated on a live watcher (no banner for read-only peers or watcherless serve)
 - **AST-aware embeddings**: significant body lines (skip blanks/comments/braces) for better vector search recall
 - **Embedding format versioning**: auto-detects embedding strategy changes, triggers re-embed on next `rag index`
 - **Schema versioning**: metadata-based migration system for DB schema evolution

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -787,6 +787,7 @@ fn backup_before_destructive_migration(
 // The `Database` inherent impl is split across `store/` submodules for
 // navigability; each file holds one cohesive cluster of methods.
 mod store;
+pub use store::queries::PathHop;
 
 /// An unresolved edge from the database (used by LSP resolution).
 #[derive(Debug, Clone)]
@@ -1597,6 +1598,190 @@ mod tests {
         let results = db.impact("shared", 3).unwrap();
         // 3 distinct edges, each reported exactly once.
         assert_eq!(results.len(), 3);
+    }
+
+    /// Build `a → b → c → d` over `calls` edges for trace tests.
+    fn chain_db() -> Database {
+        let db = Database::open_memory().unwrap();
+        let names = ["a", "b", "c", "d"];
+        let syms: Vec<Symbol> = names
+            .iter()
+            .map(|n| test_symbol(n, SymbolKind::Function, &format!("{n}.py"), 1))
+            .collect();
+        db.insert_symbols(&syms).unwrap();
+        let edges: Vec<Edge> = syms
+            .windows(2)
+            .map(|w| Edge {
+                source_id: w[0].id.clone(),
+                target_name: w[1].name.clone(),
+                target_id: Some(w[1].id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: w[0].file_path.clone(),
+                line: 2,
+            })
+            .collect();
+        db.insert_edges(&edges).unwrap();
+        db
+    }
+
+    #[test]
+    fn trace_returns_shortest_path_in_order() {
+        let db = chain_db();
+        let hops = db.trace("a", "d", 8).unwrap().expect("path a→d exists");
+        let names: Vec<&str> = hops.iter().map(|h| h.source_name.as_str()).collect();
+        assert_eq!(names, ["a", "b", "c"]);
+        assert_eq!(hops.last().unwrap().target_name, "d");
+    }
+
+    #[test]
+    fn trace_returns_none_when_unreachable() {
+        let db = chain_db();
+        assert!(db.trace("d", "a", 8).unwrap().is_none());
+    }
+
+    #[test]
+    fn trace_same_symbol_is_empty_path() {
+        let db = chain_db();
+        assert_eq!(db.trace("a", "a", 8).unwrap(), Some(Vec::new()));
+    }
+
+    #[test]
+    fn trace_respects_depth_limit() {
+        let db = chain_db();
+        // a→d is 3 hops; depth 2 cannot reach it.
+        assert!(db.trace("a", "d", 2).unwrap().is_none());
+    }
+
+    #[test]
+    fn trace_terminates_on_cycle() {
+        // a → b → a. trace("a","b") returns the single hop without looping.
+        let db = Database::open_memory().unwrap();
+        let a = test_symbol("a", SymbolKind::Function, "a.py", 1);
+        let b = test_symbol("b", SymbolKind::Function, "b.py", 1);
+        db.insert_symbols(&[a.clone(), b.clone()]).unwrap();
+        db.insert_edges(&[
+            Edge {
+                source_id: a.id.clone(),
+                target_name: "b".to_string(),
+                target_id: Some(b.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "a.py".to_string(),
+                line: 2,
+            },
+            Edge {
+                source_id: b.id.clone(),
+                target_name: "a".to_string(),
+                target_id: Some(a.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "b.py".to_string(),
+                line: 2,
+            },
+        ])
+        .unwrap();
+        let hops = db.trace("a", "b", 8).unwrap().expect("a→b exists");
+        assert_eq!(hops.len(), 1);
+    }
+
+    #[test]
+    fn trace_dense_cycle_does_not_loop_and_finds_target() {
+        // A fully-connected clique a,b,c,d (every node calls every other).
+        // Without the visited-set guard, BFS would re-expand nodes endlessly /
+        // explode; with it, each node is expanded once and the path to the
+        // target is the direct 1-hop edge.
+        let db = Database::open_memory().unwrap();
+        let names = ["a", "b", "c", "d"];
+        let syms: Vec<Symbol> = names
+            .iter()
+            .map(|n| test_symbol(n, SymbolKind::Function, &format!("{n}.py"), 1))
+            .collect();
+        db.insert_symbols(&syms).unwrap();
+        let mut edges = Vec::new();
+        for src in &syms {
+            for tgt in &syms {
+                if src.id != tgt.id {
+                    edges.push(Edge {
+                        source_id: src.id.clone(),
+                        target_name: tgt.name.clone(),
+                        target_id: Some(tgt.id.clone()),
+                        kind: EdgeKind::Calls,
+                        file_path: src.file_path.clone(),
+                        line: 2,
+                    });
+                }
+            }
+        }
+        db.insert_edges(&edges).unwrap();
+        // Direct edge a→d exists, so the shortest path is exactly one hop.
+        let hops = db.trace("a", "d", 20).unwrap().expect("a reaches d");
+        assert_eq!(hops.len(), 1, "shortest path in a clique is one hop");
+        assert_eq!(hops[0].source_name, "a");
+        assert_eq!(hops[0].target_name, "d");
+    }
+
+    #[test]
+    fn trace_unaffected_by_comma_in_symbol_ids() {
+        // File paths (hence symbol ids) containing commas must not corrupt the
+        // cycle guard — visited tracking is on exact ids, not a delimited string.
+        let db = Database::open_memory().unwrap();
+        let a = test_symbol("a", SymbolKind::Function, "a,b.py", 1);
+        let b = test_symbol("b", SymbolKind::Function, "c,d.py", 1);
+        let c = test_symbol("c", SymbolKind::Function, "e,f.py", 1);
+        db.insert_symbols(&[a.clone(), b.clone(), c.clone()])
+            .unwrap();
+        db.insert_edges(&[
+            Edge {
+                source_id: a.id.clone(),
+                target_name: "b".to_string(),
+                target_id: Some(b.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: a.file_path.clone(),
+                line: 2,
+            },
+            Edge {
+                source_id: b.id.clone(),
+                target_name: "c".to_string(),
+                target_id: Some(c.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: b.file_path.clone(),
+                line: 2,
+            },
+        ])
+        .unwrap();
+        let hops = db
+            .trace("a", "c", 8)
+            .unwrap()
+            .expect("a→b→c despite commas");
+        assert_eq!(hops.len(), 2);
+        assert_eq!(hops[0].source_id, a.id);
+        assert_eq!(hops[1].source_id, b.id);
+    }
+
+    #[test]
+    fn trace_hop_carries_exact_source_id_for_overloaded_name() {
+        // Two symbols share the name `helper` in the same file; the hop must
+        // carry the id of the symbol actually on the path, not a name lookup.
+        let db = Database::open_memory().unwrap();
+        let caller = test_symbol("caller", SymbolKind::Function, "m.py", 1);
+        let h1 = Symbol::new("helper", SymbolKind::Function, "m.py", 10, 12, 0, 5, None);
+        let h2 = Symbol::new("helper", SymbolKind::Method, "m.py", 20, 22, 6, 11, None);
+        db.insert_symbols(&[caller.clone(), h1.clone(), h2.clone()])
+            .unwrap();
+        // caller → the method overload (h2) specifically (resolved target_id).
+        db.insert_edges(&[Edge {
+            source_id: caller.id.clone(),
+            target_name: "helper".to_string(),
+            target_id: Some(h2.id.clone()),
+            kind: EdgeKind::Calls,
+            file_path: caller.file_path.clone(),
+            line: 2,
+        }])
+        .unwrap();
+        let hops = db
+            .trace("caller", "helper", 8)
+            .unwrap()
+            .expect("caller→helper");
+        assert_eq!(hops.len(), 1);
+        assert_eq!(hops[0].source_id, caller.id, "hop names the exact source");
     }
 
     #[test]

--- a/crates/cartog-db/src/store/mod.rs
+++ b/crates/cartog-db/src/store/mod.rs
@@ -6,6 +6,6 @@ use super::*;
 mod crud;
 mod lifecycle;
 mod lsp;
-mod queries;
+pub(crate) mod queries;
 mod rag;
 mod resolution;

--- a/crates/cartog-db/src/store/queries.rs
+++ b/crates/cartog-db/src/store/queries.rs
@@ -4,6 +4,31 @@
 
 use super::*;
 
+/// One hop on a call path returned by [`Database::trace`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PathHop {
+    /// Id of the calling symbol — the exact source on this hop, so callers can
+    /// hydrate its body without re-resolving an ambiguous name.
+    pub source_id: String,
+    pub source_name: String,
+    pub target_name: String,
+    pub kind: EdgeKind,
+    pub file_path: String,
+    pub line: u32,
+}
+
+/// Internal call-edge record used during BFS in [`Database::trace`].
+#[derive(Debug, Clone)]
+struct CallHop {
+    source_id: String,
+    source_name: String,
+    target_name: String,
+    target_id: Option<String>,
+    kind: EdgeKind,
+    file_path: String,
+    line: u32,
+}
+
 impl Database {
     // ── Queries ──
 
@@ -261,6 +286,143 @@ impl Database {
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
+    }
+
+    /// Shortest forward `calls` path from `from` to `to`, or `None` if `to` is
+    /// unreachable within `max_depth` hops. `from == to` yields an empty path.
+    /// Matches the source symbol by name, so an ambiguous `from` follows every
+    /// match and the globally-shortest path wins. Only statically-resolved
+    /// `calls` edges participate (dynamic dispatch is absent).
+    ///
+    /// # Errors
+    /// Returns an error if the SQLite query fails.
+    pub fn trace(&self, from: &str, to: &str, max_depth: u32) -> Result<Option<Vec<PathHop>>> {
+        if from == to {
+            return Ok(Some(Vec::new()));
+        }
+        if max_depth == 0 {
+            return Ok(None);
+        }
+
+        // Breadth-first over `calls` edges, expanding each symbol once. Visited
+        // is keyed on exact symbol id (a HashSet, not a delimited string), so
+        // ids containing commas can't corrupt the cycle break, and the global
+        // visited set bounds the search to O(V+E) — no per-path enumeration.
+        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // parent[id] = (edge that reached it, predecessor symbol id).
+        let mut parent: std::collections::HashMap<String, (CallHop, String)> =
+            std::collections::HashMap::new();
+
+        // Seed: every symbol named `from` starts the frontier at depth 0.
+        let mut frontier: Vec<String> = self.symbol_ids_named(from)?;
+        for id in &frontier {
+            visited.insert(id.clone());
+        }
+
+        for _ in 0..max_depth {
+            if frontier.is_empty() {
+                break;
+            }
+            let mut next: Vec<String> = Vec::new();
+            for src_id in &frontier {
+                for hop in self.outgoing_calls(src_id)? {
+                    // A reached symbol is any symbol whose name matches the
+                    // edge's target (resolved id preferred when present).
+                    for tgt_id in self.resolved_call_targets(&hop)? {
+                        if !visited.insert(tgt_id.clone()) {
+                            continue;
+                        }
+                        parent.insert(tgt_id.clone(), (hop.clone(), src_id.clone()));
+                        if self.symbol_name(&tgt_id)?.as_deref() == Some(to) {
+                            return Ok(Some(self.reconstruct_path(&tgt_id, &parent)));
+                        }
+                        next.push(tgt_id);
+                    }
+                }
+            }
+            frontier = next;
+        }
+        Ok(None)
+    }
+
+    /// Walk `parent` back from `end` to the seed, returning hops in call order.
+    fn reconstruct_path(
+        &self,
+        end: &str,
+        parent: &std::collections::HashMap<String, (CallHop, String)>,
+    ) -> Vec<PathHop> {
+        let mut chain: Vec<&CallHop> = Vec::new();
+        let mut cur = end;
+        while let Some((hop, pred)) = parent.get(cur) {
+            chain.push(hop);
+            cur = pred;
+        }
+        chain.reverse();
+        chain
+            .into_iter()
+            .map(|h| PathHop {
+                source_id: h.source_id.clone(),
+                source_name: h.source_name.clone(),
+                target_name: h.target_name.clone(),
+                kind: h.kind,
+                file_path: h.file_path.clone(),
+                line: h.line,
+            })
+            .collect()
+    }
+
+    /// Symbol ids whose name is exactly `name`.
+    fn symbol_ids_named(&self, name: &str) -> Result<Vec<String>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id FROM symbols WHERE name = ?1")?;
+        let ids = stmt
+            .query_map(params![name], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(ids)
+    }
+
+    /// Name of the symbol with id `id`, if it exists.
+    fn symbol_name(&self, id: &str) -> Result<Option<String>> {
+        let name = self
+            .conn
+            .prepare_cached("SELECT name FROM symbols WHERE id = ?1")?
+            .query_row(params![id], |row| row.get::<_, String>(0))
+            .optional()?;
+        Ok(name)
+    }
+
+    /// Outgoing `calls` edges from the symbol with id `source_id`.
+    fn outgoing_calls(&self, source_id: &str) -> Result<Vec<CallHop>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT s.name, e.target_name, e.target_id, e.kind, e.file_path, e.line
+             FROM edges e JOIN symbols s ON e.source_id = s.id
+             WHERE e.source_id = ?1 AND e.kind = 'calls'",
+        )?;
+        let hops = stmt
+            .query_map(params![source_id], |row| {
+                let kind_str: String = row.get(3)?;
+                Ok(CallHop {
+                    source_id: source_id.to_string(),
+                    source_name: row.get(0)?,
+                    target_name: row.get(1)?,
+                    target_id: row.get(2)?,
+                    kind: kind_str.parse().unwrap_or(EdgeKind::Calls),
+                    file_path: row.get(4)?,
+                    line: row.get(5)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(hops)
+    }
+
+    /// Symbol ids a call hop reaches: the resolved `target_id` if set, else
+    /// every symbol whose name matches the edge's `target_name`.
+    fn resolved_call_targets(&self, hop: &CallHop) -> Result<Vec<String>> {
+        if let Some(id) = &hop.target_id {
+            return Ok(vec![id.clone()]);
+        }
+        self.symbol_ids_named(&hop.target_name)
     }
 
     /// True when no symbols have been indexed yet (fresh/empty DB). Cheap —

--- a/crates/cartog-db/src/store/queries.rs
+++ b/crates/cartog-db/src/store/queries.rs
@@ -133,6 +133,34 @@ impl Database {
         Ok(rows)
     }
 
+    /// Resolved symbol ids that the symbol `source_id` calls. Only edges with a
+    /// resolved `target_id` are returned — keyed on the exact source id (not a
+    /// name), so an overloaded source resolves to the right callees.
+    pub fn callee_ids_of(&self, source_id: &str) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT DISTINCT e.target_id FROM edges e
+             WHERE e.source_id = ?1 AND e.kind = 'calls' AND e.target_id IS NOT NULL",
+        )?;
+        let ids = stmt
+            .query_map(params![source_id], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(ids)
+    }
+
+    /// Source symbol ids that call the symbol `target_id` (resolved incoming
+    /// `calls` edges). Keyed on the exact target id, so callers of one overload
+    /// aren't confused with another sharing its name.
+    pub fn caller_ids_of(&self, target_id: &str) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT DISTINCT e.source_id FROM edges e
+             WHERE e.target_id = ?1 AND e.kind = 'calls'",
+        )?;
+        let ids = stmt
+            .query_map(params![target_id], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(ids)
+    }
+
     /// All references to a name, with the source symbol resolved.
     /// Optionally filter by edge kind.
     pub fn refs(
@@ -296,6 +324,7 @@ impl Database {
     ///
     /// # Errors
     /// Returns an error if the SQLite query fails.
+    #[must_use = "the traced path is the result; ignoring it wastes the query"]
     pub fn trace(&self, from: &str, to: &str, max_depth: u32) -> Result<Option<Vec<PathHop>>> {
         if from == to {
             return Ok(Some(Vec::new()));

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -207,6 +207,71 @@ fn is_zero(v: &u32) -> bool {
     *v == 0
 }
 
+/// Render a human-readable one-block summary of an [`IndexResult`].
+///
+/// Shared by the `cartog index` CLI output and the `cartog_index` MCP tool so
+/// both surfaces report identical file/symbol/edge counts.
+#[must_use]
+pub fn render_index_summary(r: &IndexResult) -> String {
+    let lsp_part = if r.edges_lsp_resolved > 0
+        || r.edges_marked_unresolvable > 0
+        || r.edges_marked_external > 0
+    {
+        let mut s = format!(
+            " ({} heuristic + {} LSP",
+            r.edges_resolved, r.edges_lsp_resolved
+        );
+        if r.edges_marked_unresolvable > 0 {
+            s.push_str(&format!(
+                ", {} marked unresolvable",
+                r.edges_marked_unresolvable
+            ));
+        }
+        if r.edges_marked_external > 0 {
+            s.push_str(&format!(", {} external", r.edges_marked_external));
+        }
+        s.push(')');
+        s
+    } else {
+        String::new()
+    };
+    let sym_detail = if r.symbols_modified > 0 || r.symbols_unchanged > 0 {
+        format!(
+            " ({} new, {} modified, {} unchanged, {} removed)",
+            r.symbols_added, r.symbols_modified, r.symbols_unchanged, r.symbols_removed
+        )
+    } else {
+        String::new()
+    };
+    let unsupported = if r.files_unsupported > 0 {
+        let breakdown = r
+            .unsupported_by_ext
+            .iter()
+            .take(5)
+            .map(|(ext, n)| format!("{n} .{ext}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "\n  {} files in unsupported languages not indexed ({breakdown})",
+            r.files_unsupported
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        "Indexed {} files ({} skipped, {} removed)\n  {} symbols{}, {} edges ({} resolved{}){}\n",
+        r.files_indexed,
+        r.files_skipped,
+        r.files_removed,
+        r.symbols_added + r.symbols_modified + r.symbols_unchanged,
+        sym_detail,
+        r.edges_added,
+        r.edges_resolved + r.edges_lsp_resolved,
+        lsp_part,
+        unsupported,
+    )
+}
+
 /// Coarse-grained progress events emitted by [`index_directory`].
 ///
 /// Plain data — no transport or runtime types — so callers (CLI, watcher,
@@ -983,6 +1048,52 @@ mod tests {
     #[test]
     fn extract_with_cached_returns_none_for_unregistered_language() {
         assert!(extract_with_cached("klingon", "irrelevant", "a.kl").is_none());
+    }
+
+    #[test]
+    fn index_summary_reports_file_symbol_and_edge_counts() {
+        let r = IndexResult {
+            files_indexed: 3,
+            files_skipped: 1,
+            symbols_added: 12,
+            edges_added: 20,
+            edges_resolved: 18,
+            ..Default::default()
+        };
+        let s = render_index_summary(&r);
+        assert!(s.contains("Indexed 3 files (1 skipped, 0 removed)"));
+        assert!(s.contains("12 symbols"));
+        assert!(s.contains("20 edges (18 resolved)"));
+    }
+
+    #[test]
+    fn index_summary_breaks_out_lsp_resolution_when_present() {
+        let r = IndexResult {
+            files_indexed: 1,
+            symbols_added: 5,
+            edges_added: 10,
+            edges_resolved: 6,
+            edges_lsp_resolved: 3,
+            edges_marked_external: 1,
+            ..Default::default()
+        };
+        let s = render_index_summary(&r);
+        assert!(s.contains("9 resolved"), "6 heuristic + 3 LSP = 9");
+        assert!(s.contains("6 heuristic + 3 LSP"));
+        assert!(s.contains("1 external"));
+    }
+
+    #[test]
+    fn index_summary_lists_unsupported_languages() {
+        let r = IndexResult {
+            files_indexed: 2,
+            files_unsupported: 4,
+            unsupported_by_ext: vec![("kt".into(), 3), ("swift".into(), 1)],
+            ..Default::default()
+        };
+        let s = render_index_summary(&r);
+        assert!(s.contains("4 files in unsupported languages"));
+        assert!(s.contains("3 .kt"));
     }
 
     #[test]

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -235,7 +235,7 @@ pub fn render_index_summary(r: &IndexResult) -> String {
     } else {
         String::new()
     };
-    let sym_detail = if r.symbols_modified > 0 || r.symbols_unchanged > 0 {
+    let sym_detail = if r.symbols_modified > 0 || r.symbols_unchanged > 0 || r.symbols_removed > 0 {
         format!(
             " ({} new, {} modified, {} unchanged, {} removed)",
             r.symbols_added, r.symbols_modified, r.symbols_unchanged, r.symbols_removed
@@ -1064,6 +1064,22 @@ mod tests {
         assert!(s.contains("Indexed 3 files (1 skipped, 0 removed)"));
         assert!(s.contains("12 symbols"));
         assert!(s.contains("20 edges (18 resolved)"));
+    }
+
+    #[test]
+    fn index_summary_shows_detail_for_removal_only_delta() {
+        // A pass that only removes symbols (no new/modified/unchanged) must
+        // still report the removed count, not a bare "0 symbols".
+        let r = IndexResult {
+            files_indexed: 1,
+            symbols_removed: 4,
+            ..Default::default()
+        };
+        let s = render_index_summary(&r);
+        assert!(
+            s.contains("4 removed"),
+            "removal-only delta must surface the removed count: {s}"
+        );
     }
 
     #[test]

--- a/crates/cartog-mcp/README.md
+++ b/crates/cartog-mcp/README.md
@@ -10,7 +10,7 @@ Exposes cartog's graph queries, indexing, and semantic search as MCP tools over 
 
 ### MCP tools
 
-13 tools are exposed via rmcp's `#[tool_router]` macro with auto-generated JSON Schema parameters. Each tool also carries `annotations` (a `title` and `readOnlyHint`: `true` for the 11 query tools, `false` for the two index tools), and the read tools declare an `outputSchema`:
+16 tools are exposed via rmcp's `#[tool_router]` macro with auto-generated JSON Schema parameters. Each tool also carries `annotations` (a `title` and `readOnlyHint`: `true` for the 13 query tools, `false` for the two index tools and `cartog_update`), and the read tools declare an `outputSchema`:
 
 | Tool | Description |
 |------|-------------|
@@ -20,6 +20,8 @@ Exposes cartog's graph queries, indexing, and semantic search as MCP tools over 
 | `cartog_refs` | All references to a symbol |
 | `cartog_callees` | Outgoing calls from a symbol |
 | `cartog_impact` | Transitive impact analysis (max depth: 10) |
+| `cartog_trace` | Shortest call path between two symbols, bodies inline |
+| `cartog_context` | One-shot task-context bundle (semantic + structural + centrality) |
 | `cartog_hierarchy` | Inheritance hierarchy for a class |
 | `cartog_deps` | File-level import dependencies |
 | `cartog_search` | Search symbols by name |
@@ -27,6 +29,7 @@ Exposes cartog's graph queries, indexing, and semantic search as MCP tools over 
 | `cartog_changes` | Symbols affected by recent git changes |
 | `cartog_rag_index` | Build embedding index for semantic search |
 | `cartog_rag_search` | Semantic search over code symbols |
+| `cartog_update` | Arm a deferred self-update |
 
 ### Path validation
 

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -815,6 +815,18 @@ fn tool_response_named(
     if !banner.is_empty() {
         text.insert_str(0, &banner);
     }
+    // Final hard clamp: the per-branch budgeting reserves space for the banner
+    // and a 256-byte notice, but appended suffixes (suggestions, hints) aren't
+    // individually counted. Trim to a char boundary so `text.len()` is provably
+    // ≤ the cap no matter which suffixes fired.
+    let cap = mcp_max_bytes();
+    if text.len() > cap {
+        let cut = (cap.saturating_sub(3)..=cap)
+            .rev()
+            .find(|&i| text.is_char_boundary(i))
+            .unwrap_or(0);
+        text.truncate(cut);
+    }
     Ok(success_result(text, structured))
 }
 
@@ -2332,6 +2344,30 @@ mod tests {
             text.len() <= mcp_max_bytes(),
             "banner + body must stay under the {}-byte cap, got {}",
             mcp_max_bytes(),
+            text.len()
+        );
+    }
+
+    /// The final clamp also covers the NON-truncated path: a body just under the
+    /// banner-adjusted budget, plus a banner and an appended suggestion, must
+    /// still end up ≤ the cap (suffixes aren't individually budgeted).
+    #[test]
+    fn tool_response_banner_plus_suffix_stays_under_cap() {
+        let db = populated_memory_db();
+        let cap = mcp_max_bytes();
+        // Body sized so banner + body alone is just under cap; the appended
+        // suggestion would push it over without the final clamp.
+        let payload = "y".repeat(cap - 200);
+        let json = format!("[\"{payload}\"]");
+        let stale = Some(snap(3, 0, 0));
+        let result = tool_response(&db, json, None, "cartog_rag_search", stale).expect("response");
+        let text = match &result.content.first().expect("content").raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        assert!(
+            text.len() <= cap,
+            "banner + body + suffix must stay under {cap}, got {}",
             text.len()
         );
     }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -1,7 +1,7 @@
 //! MCP server for the cartog code graph.
 //!
 //! Exposes cartog's graph queries, indexing, semantic search, and deferred
-//! self-update as 14 MCP tools over stdio transport. Designed for Claude Code,
+//! self-update as 16 MCP tools over stdio transport. Designed for Claude Code,
 //! Cursor, and other MCP clients.
 
 use std::path::{Path, PathBuf};
@@ -25,11 +25,14 @@ use cartog_db::{Database, PinnedAttach, MAX_SEARCH_LIMIT};
 use cartog_indexer as indexer;
 use cartog_rag as rag;
 use cartog_watch as watch;
-use cartog_watch::{WatchConfig, WatchHandle};
+use cartog_watch::{StaleSnapshot, WatchConfig, WatchHandle};
 
 mod progress;
 
 const MAX_IMPACT_DEPTH: u32 = 10;
+const MAX_TRACE_DEPTH: u32 = 20;
+const DEFAULT_CONTEXT_TOKENS: u32 = 6000;
+const MAX_CONTEXT_TOKENS: u32 = 20000;
 
 // ── Parameter types ──
 
@@ -72,6 +75,16 @@ pub struct ImpactParams {
     /// Symbol name to analyze impact for
     pub name: String,
     /// Maximum traversal depth (default 3, max 10)
+    pub depth: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TraceParams {
+    /// Starting symbol (the caller end of the path)
+    pub from: String,
+    /// Target symbol (the callee end of the path)
+    pub to: String,
+    /// Maximum path length to search (default 8, max 20)
     pub depth: Option<u32>,
 }
 
@@ -128,6 +141,14 @@ pub struct RagSearchParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ContextParams {
+    /// Natural-language description of the task you're about to work on
+    pub task: String,
+    /// Approximate token budget for the returned bundle (default 6000)
+    pub tokens: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct MapParams {
     /// Maximum top-ranked symbols to include in the map (default 50).
     /// Symbols are ranked by in-degree centrality so the most-referenced
@@ -178,6 +199,24 @@ struct RefList {
 #[derive(Debug, Serialize, JsonSchema)]
 struct ImpactList {
     results: Vec<ImpactEntry>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct TraceHop {
+    source_name: String,
+    target_name: String,
+    kind: String,
+    file_path: String,
+    line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct TraceList {
+    /// Empty when `from == to`; absent path is reported as `found: false`.
+    found: bool,
+    hops: Vec<TraceHop>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -366,9 +405,11 @@ fn suggestions_for(tool: &str) -> Option<&'static str> {
         "cartog_map" => Some("Next: use cartog_outline on an interesting file, cartog_rag_search for a concept, or cartog_search for a specific name."),
         "cartog_search" => Some("Next: use cartog_refs to find usages, cartog_callees to trace calls, or cartog_impact to assess blast radius."),
         "cartog_rag_search" => Some("Next: use cartog_outline to see file structure, or cartog_refs to find all usages of a symbol."),
+        "cartog_context" => Some("Next: use cartog_outline or Read on a returned symbol, or cartog_trace to follow a call path between two of them."),
         "cartog_outline" => Some("Next: use Read with offset/limit to see specific lines, or cartog_refs to find usages of a symbol."),
         "cartog_refs" => Some("Next: use cartog_impact to assess blast radius, or cartog_callees to trace what a function calls."),
         "cartog_callees" => Some("Next: use cartog_refs to find callers, or cartog_impact to assess blast radius."),
+        "cartog_trace" => Some("Next: read the hop bodies, or use cartog_refs/cartog_impact on a hop to widen the view."),
         "cartog_impact" => Some("Next: read the affected files to plan changes, or use cartog_hierarchy to check class inheritance."),
         "cartog_hierarchy" => Some("Next: use cartog_refs to find usages, or cartog_impact to assess blast radius."),
         "cartog_deps" => Some("Next: use cartog_outline to see file structure, or cartog_refs to find usages of a symbol."),
@@ -400,6 +441,7 @@ fn narrowing_hint_for(tool: &str) -> &'static str {
         "cartog_changes" => "Re-run with a smaller --commits window.",
         "cartog_search" | "cartog_rag_search" => "Re-run with a tighter query or --limit.",
         "cartog_refs" => "Re-run with a more specific symbol name, or filter by --kind.",
+        "cartog_trace" => "Re-run with a smaller --depth, or pick closer endpoints.",
         _ => "Re-run with a narrower scope or filter.",
     }
 }
@@ -602,8 +644,57 @@ fn tool_response(
     json: String,
     structured: Option<serde_json::Value>,
     tool: &str,
+    stale: Option<StaleSnapshot>,
 ) -> Result<CallToolResult, McpError> {
-    tool_response_named(db, json, structured, tool, None)
+    tool_response_named(db, json, structured, tool, None, stale)
+}
+
+/// Build a staleness banner for `tool`, or `None` when nothing is stale or the
+/// tool is unaffected. RAG staleness only warns the semantic tools; a debounce
+/// gap warns every read tool. Prepended to the response so the agent sees it
+/// first. Pure, so it's unit-testable without an MCP result.
+fn stale_banner(snapshot: Option<StaleSnapshot>, tool: &str) -> Option<String> {
+    let snap = snapshot?;
+    let rag_tool = matches!(tool, "cartog_rag_search" | "cartog_context");
+    if snap.rag_stale() && rag_tool {
+        return Some(format!(
+            "⚠️ {} symbol(s) awaiting re-embedding since the last index; semantic results may be stale.\n\n",
+            snap.rag_pending
+        ));
+    }
+    if snap.structural_stale() {
+        return Some(
+            "⚠️ File change(s) detected; the index is catching up and results may be stale.\n\n"
+                .to_string(),
+        );
+    }
+    None
+}
+
+/// Body of the trace hop with id `source_id` — the exact symbol on the path.
+/// Stored RAG content if present, else the source byte-slice read relative to
+/// `cwd`. `None` when neither is found.
+fn trace_hop_body(db: &Database, cwd: &Path, source_id: &str) -> Option<String> {
+    if let Some((content, _)) = db.get_symbol_content(source_id).ok().flatten() {
+        return Some(content);
+    }
+    let sym = db
+        .get_symbols_by_ids(std::slice::from_ref(&source_id.to_string()))
+        .ok()?
+        .into_iter()
+        .next()?;
+    let src = std::fs::read_to_string(cwd.join(&sym.file_path)).ok()?;
+    let (mut start, mut end) = (sym.start_byte as usize, sym.end_byte as usize);
+    if start >= end || end > src.len() {
+        return None;
+    }
+    while start < end && !src.is_char_boundary(start) {
+        start += 1;
+    }
+    while end > start && !src.is_char_boundary(end) {
+        end -= 1;
+    }
+    Some(src[start..end].to_string())
 }
 
 /// Record a successful read tool call into the query log for
@@ -642,7 +733,9 @@ fn tool_response_named(
     structured: Option<serde_json::Value>,
     tool: &str,
     queried_name: Option<&str>,
+    stale: Option<StaleSnapshot>,
 ) -> Result<CallToolResult, McpError> {
+    let banner = stale_banner(stale, tool).unwrap_or_default();
     let is_empty = !db
         .has_indexed_files()
         .map_err(|e| mcp_err(format!("stats check failed: {e}")))?;
@@ -663,7 +756,7 @@ fn tool_response_named(
                     .map(|c| c.into_iter().map(|s| s.name).collect::<Vec<_>>())
                     .unwrap_or_default();
                 if let Some(suffix) = did_you_mean_suffix(name, &candidates) {
-                    let mut text = json;
+                    let mut text = format!("{banner}{json}");
                     text.push_str(&suffix);
                     // No structured content: the empty `[]` result plus a prose
                     // hint has no useful typed form.
@@ -673,7 +766,9 @@ fn tool_response_named(
         }
     }
 
-    let budget = mcp_max_bytes();
+    // Reserve the banner's bytes up front so the final `banner + text [+
+    // structured]` stays under the cap (the banner is prepended at the end).
+    let budget = mcp_max_bytes().saturating_sub(banner.len());
     let (mut text, truncated_bytes) = if json.len() > budget {
         // Leave room for the truncation notice.
         let notice_cap = 256;
@@ -705,7 +800,8 @@ fn tool_response_named(
     if truncated_bytes > 0 {
         text.push_str(&format!(
             "\n\n(Response truncated: {truncated_bytes} bytes omitted to stay under the \
-             {budget}-byte cap. {hint})",
+             {cap}-byte cap. {hint})",
+            cap = mcp_max_bytes(),
             hint = narrowing_hint_for(tool),
         ));
     } else if is_empty {
@@ -714,6 +810,10 @@ fn tool_response_named(
     } else if let Some(hint) = suggestions_for(tool) {
         text.push_str("\n\n");
         text.push_str(hint);
+    }
+    // Prepend after truncation so the banner survives an oversized body.
+    if !banner.is_empty() {
+        text.insert_str(0, &banner);
     }
     Ok(success_result(text, structured))
 }
@@ -747,7 +847,7 @@ pub struct CartogServer {
     /// Single-writer election role. `Primary` holds the `serve` PID lock
     /// and owns the RW DB connection. `ReadOnly` attached via
     /// [`Database::open_readonly`] because another cartog process owns
-    /// the slot — the 2 write tools are gated, the 11 read tools work
+    /// the slot — the 2 write tools are gated, the 13 read tools work
     /// unchanged. Mutated atomically when the Phase 5 promoter detects
     /// the primary died and takes over.
     role: Arc<AtomicRole>,
@@ -758,6 +858,11 @@ pub struct CartogServer {
     /// promotion — surfaced in `cartog_stats` output so users can see
     /// the degraded state.
     watcher_active: Arc<std::sync::atomic::AtomicBool>,
+    /// Staleness state published by the watcher (when `--watch` is active),
+    /// read to prepend "results may be stale" banners. A cell so the Phase 5
+    /// promoter can install one after spawning a post-promotion watcher.
+    /// `None`/empty for `cartog serve` without `--watch` and read-only peers.
+    stale: Arc<Mutex<Option<Arc<cartog_watch::StaleState>>>>,
     /// Secret-redaction policy applied to indexing tools.
     redact: indexer::RedactionConfig,
 }
@@ -845,6 +950,22 @@ impl CartogServer {
     /// DB and pre-built providers and assembles the server. Keeping the struct
     /// literal here (instead of duplicated per constructor) means a new field
     /// is wired once and the test path can't silently drift from production.
+    /// Snapshot the watcher's staleness state for banner decisions, or `None`
+    /// when no live watcher publishes it (no `--watch`, read-only peer, or a
+    /// degraded primary). Read with a brief lock — never held across `.await`.
+    fn stale_snapshot(&self) -> Option<StaleSnapshot> {
+        if !self
+            .watcher_active
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return None;
+        }
+        self.stale
+            .lock()
+            .ok()
+            .and_then(|cell| cell.as_ref().map(|s| s.snapshot()))
+    }
+
     fn from_parts(
         db: Database,
         provider: Box<dyn rag::provider::EmbeddingProvider>,
@@ -863,6 +984,7 @@ impl CartogServer {
             cwd: Arc::from(cwd),
             role: Arc::new(AtomicRole::new(role)),
             watcher_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            stale: Arc::new(Mutex::new(None)),
             redact,
         })
     }
@@ -990,7 +1112,8 @@ impl CartogServer {
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
-            let mut text = json;
+            // Human summary first, then the raw JSON, so the agent sees counts at a glance.
+            let mut text = format!("{}\n{json}", indexer::render_index_summary(&result));
             if let Some(hint) = suggestions_for("cartog_index") {
                 text.push_str("\n\n");
                 text.push_str(hint);
@@ -1023,6 +1146,7 @@ impl CartogServer {
     ) -> Result<CallToolResult, McpError> {
         let file = params.file;
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             debug!(file = %file, "outline");
@@ -1036,7 +1160,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&symbols)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(SymbolList { results: symbols }).ok();
-            tool_response(&db, json, structured, "cartog_outline")
+            tool_response(&db, json, structured, "cartog_outline", stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1059,6 +1183,7 @@ impl CartogServer {
         let name = params.name;
         let kind_str = params.kind;
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             let kind_filter = kind_str
@@ -1089,7 +1214,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&entries)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(RefList { results: entries }).ok();
-            tool_response_named(&db, json, structured, "cartog_refs", Some(&name))
+            tool_response_named(&db, json, structured, "cartog_refs", Some(&name), stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1111,6 +1236,7 @@ impl CartogServer {
     ) -> Result<CallToolResult, McpError> {
         let name = params.name;
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             debug!(name = %name, "callees");
@@ -1124,7 +1250,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&edges)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(EdgeList { results: edges }).ok();
-            tool_response_named(&db, json, structured, "cartog_callees", Some(&name))
+            tool_response_named(&db, json, structured, "cartog_callees", Some(&name), stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1147,6 +1273,7 @@ impl CartogServer {
         let name = params.name;
         let depth = params.depth.unwrap_or(3).min(MAX_IMPACT_DEPTH);
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             debug!(name = %name, depth, "impact");
@@ -1165,7 +1292,63 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&entries)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(ImpactList { results: entries }).ok();
-            tool_response_named(&db, json, structured, "cartog_impact", Some(&name))
+            tool_response_named(&db, json, structured, "cartog_impact", Some(&name), stale)
+        })
+        .await
+        .map_err(|e| mcp_err(format!("task join failed: {e}")))?
+    }
+
+    /// Find a call path between two symbols, with each hop's body inline.
+    #[tool(
+        description = "Trace how one symbol reaches another through the call graph. Returns the shortest call path from `from` to `to`, each hop carrying the calling symbol's body inline. Use when asked 'how does A reach B?', 'trace the execution flow from X to Y', 'what's the call path between X and Y?'. Only statically-resolved `calls` edges are followed (dynamic dispatch is not traced). Not for: all callers (use cartog_refs), or blast radius (use cartog_impact). Returns: {found: bool, hops: [{source_name, target_name, kind, file_path, line, body?}]}.",
+        annotations(
+            title = "Trace call path",
+            read_only_hint = true,
+            open_world_hint = false
+        ),
+        output_schema = output_schema_for::<TraceList>()
+    )]
+    async fn cartog_trace(
+        &self,
+        Parameters(params): Parameters<TraceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let from = params.from;
+        let to = params.to;
+        let depth = params.depth.unwrap_or(8).min(MAX_TRACE_DEPTH);
+        let db = Arc::clone(&self.db);
+        let cwd = Arc::clone(&self.cwd);
+        let stale = self.stale_snapshot();
+
+        tokio::task::spawn_blocking(move || {
+            debug!(from = %from, to = %to, depth, "trace");
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
+            let path = db
+                .trace(&from, &to, depth)
+                .map_err(|e| mcp_err(format!("trace query failed: {e}")))?;
+
+            let hops: Vec<TraceHop> = path
+                .iter()
+                .flatten()
+                .map(|h| TraceHop {
+                    body: trace_hop_body(&db, &cwd, &h.source_id),
+                    source_name: h.source_name.clone(),
+                    target_name: h.target_name.clone(),
+                    kind: h.kind.to_string(),
+                    file_path: h.file_path.clone(),
+                    line: h.line,
+                })
+                .collect();
+
+            let result = TraceList {
+                found: path.is_some(),
+                hops,
+            };
+            let json = serde_json::to_string_pretty(&result)
+                .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
+            let structured = serde_json::to_value(&result).ok();
+            tool_response_named(&db, json, structured, "cartog_trace", Some(&from), stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1187,6 +1370,7 @@ impl CartogServer {
     ) -> Result<CallToolResult, McpError> {
         let name = params.name;
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             debug!(name = %name, "hierarchy");
@@ -1205,7 +1389,14 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&entries)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(HierarchyList { results: entries }).ok();
-            tool_response_named(&db, json, structured, "cartog_hierarchy", Some(&name))
+            tool_response_named(
+                &db,
+                json,
+                structured,
+                "cartog_hierarchy",
+                Some(&name),
+                stale,
+            )
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1227,6 +1418,7 @@ impl CartogServer {
     ) -> Result<CallToolResult, McpError> {
         let file = params.file;
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             debug!(file = %file, "deps");
@@ -1240,7 +1432,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&edges)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(EdgeList { results: edges }).ok();
-            tool_response(&db, json, structured, "cartog_deps")
+            tool_response(&db, json, structured, "cartog_deps", stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1266,6 +1458,7 @@ impl CartogServer {
         let limit = params.limit.unwrap_or(30).min(MAX_SEARCH_LIMIT);
         let db = Arc::clone(&self.db);
         let cwd = Arc::clone(&self.cwd);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             if query.is_empty() {
@@ -1301,7 +1494,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&symbols)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(SymbolList { results: symbols }).ok();
-            tool_response(&db, json, structured, "cartog_search")
+            tool_response(&db, json, structured, "cartog_search", stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1418,6 +1611,7 @@ impl CartogServer {
     ) -> Result<CallToolResult, McpError> {
         let limit = params.limit.unwrap_or(50);
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             debug!(limit, "map");
@@ -1436,7 +1630,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(&result).ok();
-            tool_response(&db, json, structured, "cartog_map")
+            tool_response(&db, json, structured, "cartog_map", stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1459,6 +1653,7 @@ impl CartogServer {
         let commits = params.commits.unwrap_or(5);
         let kind_str = params.kind;
         let db = Arc::clone(&self.db);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             let kind_filter = kind_str
@@ -1493,7 +1688,7 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(&result).ok();
-            tool_response(&db, json, structured, "cartog_changes")
+            tool_response(&db, json, structured, "cartog_changes", stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -1605,6 +1800,7 @@ impl CartogServer {
         let db = Arc::clone(&self.db);
         let provider = Arc::clone(&self.embedding_provider);
         let reranker = Arc::clone(&self.reranker_provider);
+        let stale = self.stale_snapshot();
 
         tokio::task::spawn_blocking(move || {
             if query.is_empty() {
@@ -1645,7 +1841,78 @@ impl CartogServer {
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
             let structured = serde_json::to_value(&result).ok();
-            tool_response(&db, json, structured, "cartog_rag_search")
+            tool_response(&db, json, structured, "cartog_rag_search", stale)
+        })
+        .await
+        .map_err(|e| mcp_err(format!("task join failed: {e}")))?
+    }
+
+    /// Build a one-shot task-context bundle fusing semantic search, structural
+    /// neighbors, and centrality.
+    #[tool(
+        description = "Build everything you need to start a task in ONE call: the most relevant symbols (semantic + keyword), their 1-hop call neighbors, and high-centrality definitions in the same files — with bodies inline, budgeted to fit. Use at the START of a task: 'where do I work on X?', 'give me context for implementing Y', 'what's relevant to Z?'. Routes through semantic search, so it finds code by concept, not just name. Not for: a single known symbol (use cartog_search), or a specific call path (use cartog_trace). Returns: {task, entries: [{symbol, reason, score, body?}], approx_tokens}.",
+        annotations(
+            title = "Task context bundle",
+            read_only_hint = true,
+            open_world_hint = false
+        ),
+        output_schema = output_schema_for::<rag::context::TaskContext>()
+    )]
+    async fn cartog_context(
+        &self,
+        Parameters(params): Parameters<ContextParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let task = params.task;
+        let tokens = params
+            .tokens
+            .unwrap_or(DEFAULT_CONTEXT_TOKENS)
+            .min(MAX_CONTEXT_TOKENS);
+        let db = Arc::clone(&self.db);
+        let provider = Arc::clone(&self.embedding_provider);
+        let reranker = Arc::clone(&self.reranker_provider);
+        let stale = self.stale_snapshot();
+
+        tokio::task::spawn_blocking(move || {
+            if task.is_empty() {
+                return Err(mcp_err("task description cannot be empty"));
+            }
+            debug!(task = %task, tokens, "context");
+            let db = db.lock().map_err(|_| {
+                mcp_err("internal error: database lock poisoned (server restart required)")
+            })?;
+            let mut provider = provider.lock().map_err(|_| {
+                mcp_err(
+                    "internal error: embedding provider lock poisoned (server restart required)",
+                )
+            })?;
+            let mut reranker = reranker.lock().map_err(|_| {
+                mcp_err("internal error: reranker lock poisoned (server restart required)")
+            })?;
+            let opts = rag::context::ContextOptions::default();
+            let result = match reranker.as_mut() {
+                Some(r) => rag::context::build_task_context(
+                    &db,
+                    &task,
+                    tokens,
+                    provider.as_mut(),
+                    Some(r.as_mut()),
+                    &opts,
+                ),
+                None => rag::context::build_task_context(
+                    &db,
+                    &task,
+                    tokens,
+                    provider.as_mut(),
+                    None,
+                    &opts,
+                ),
+            }
+            .map_err(|e| mcp_err(format!("context build failed: {e}")))?;
+
+            let json = serde_json::to_string_pretty(&result)
+                .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
+            let structured = serde_json::to_value(&result).ok();
+            tool_response(&db, json, structured, "cartog_context", stale)
         })
         .await
         .map_err(|e| mcp_err(format!("task join failed: {e}")))?
@@ -2008,7 +2275,7 @@ mod tests {
         let json = serde_json::to_string_pretty(&symbols).expect("json");
         let structured = serde_json::to_value(SymbolList { results: symbols }).ok();
 
-        let result = tool_response(&db, json, structured, "cartog_search").expect("response");
+        let result = tool_response(&db, json, structured, "cartog_search", None).expect("response");
 
         let structured = result
             .structured_content
@@ -2030,7 +2297,7 @@ mod tests {
         let json = format!("[\"{big}\"]");
         let structured = Some(serde_json::json!({ "results": [] }));
 
-        let result = tool_response(&db, json, structured, "cartog_search").expect("response");
+        let result = tool_response(&db, json, structured, "cartog_search", None).expect("response");
 
         assert!(
             result.structured_content.is_none(),
@@ -2043,6 +2310,29 @@ mod tests {
         assert!(
             text.contains("Response truncated"),
             "truncation notice present"
+        );
+    }
+
+    /// A staleness banner must not push a truncated response over the cap: the
+    /// banner's bytes are reserved before truncation, so banner + body ≤ cap.
+    #[test]
+    fn tool_response_with_banner_stays_under_cap() {
+        let db = populated_memory_db();
+        let big = "x".repeat(mcp_max_bytes() + 1024);
+        let json = format!("[\"{big}\"]");
+        // rag_pending on a rag tool fires the longest banner.
+        let stale = Some(snap(9, 0, 0));
+        let result = tool_response(&db, json, None, "cartog_rag_search", stale).expect("response");
+        let text = match &result.content.first().expect("content").raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        assert!(text.starts_with("⚠️"), "banner present: {}", &text[..40]);
+        assert!(
+            text.len() <= mcp_max_bytes(),
+            "banner + body must stay under the {}-byte cap, got {}",
+            mcp_max_bytes(),
+            text.len()
         );
     }
 
@@ -2060,7 +2350,7 @@ mod tests {
         let structured = Some(serde_json::json!({ "results": [payload.clone()] }));
 
         assert!(json.len() <= budget, "text alone fits the cap");
-        let result = tool_response(&db, json, structured, "cartog_search").expect("response");
+        let result = tool_response(&db, json, structured, "cartog_search", None).expect("response");
 
         assert!(
             result.structured_content.is_none(),
@@ -2282,6 +2572,36 @@ mod tests {
     #[test]
     fn did_you_mean_suffix_none_without_candidates() {
         assert!(did_you_mean_suffix("Whatever", &[]).is_none());
+    }
+
+    fn snap(rag_pending: u32, change_seq: u64, reindexed_seq: u64) -> StaleSnapshot {
+        StaleSnapshot {
+            rag_pending,
+            change_seq,
+            reindexed_seq,
+        }
+    }
+
+    #[test]
+    fn stale_banner_none_when_not_stale() {
+        assert!(stale_banner(Some(snap(0, 10, 10)), "cartog_rag_search").is_none());
+        assert!(stale_banner(None, "cartog_rag_search").is_none());
+    }
+
+    #[test]
+    fn stale_banner_rag_only_warns_semantic_tools() {
+        // Pending embeddings warn rag_search/context...
+        assert!(stale_banner(Some(snap(3, 10, 10)), "cartog_rag_search").is_some());
+        assert!(stale_banner(Some(snap(3, 10, 10)), "cartog_context").is_some());
+        // ...but not a structural tool (no debounce gap here).
+        assert!(stale_banner(Some(snap(3, 10, 10)), "cartog_refs").is_none());
+    }
+
+    #[test]
+    fn stale_banner_structural_warns_every_read_tool() {
+        // A change after the last reindex warns refs and rag_search alike.
+        assert!(stale_banner(Some(snap(0, 20, 10)), "cartog_refs").is_some());
+        assert!(stale_banner(Some(snap(0, 20, 10)), "cartog_rag_search").is_some());
     }
 
     #[test]
@@ -2859,6 +3179,7 @@ mod tests {
             role,
             lock_cell: Arc::new(Mutex::new(None)),
             watch_cell: Arc::new(Mutex::new(None)),
+            stale_cell: Arc::new(Mutex::new(None)),
             watcher_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             embedding_provider: Arc::new(Mutex::new(test_provider())),
             db_path: db_path.clone(),
@@ -3570,6 +3891,146 @@ def main():
         assert!(
             text.trim_start().starts_with('['),
             "impact returns a JSON array"
+        );
+    }
+
+    #[tokio::test]
+    async fn trace_finds_path_from_speak_to_helper() {
+        let (_dir, server) = indexed_server();
+        let result = server
+            .cartog_trace(Parameters(TraceParams {
+                from: "speak".to_string(),
+                to: "helper".to_string(),
+                depth: Some(8),
+            }))
+            .await
+            .expect("trace succeeds");
+        let text = result_text(&result);
+        assert!(text.contains("\"found\": true"), "path exists: {text}");
+        assert!(text.contains("helper"), "hop should reach helper: {text}");
+    }
+
+    #[tokio::test]
+    async fn trace_reports_no_path_when_unreachable() {
+        let (_dir, server) = indexed_server();
+        let result = server
+            .cartog_trace(Parameters(TraceParams {
+                from: "helper".to_string(),
+                to: "speak".to_string(),
+                depth: Some(8),
+            }))
+            .await
+            .expect("trace succeeds");
+        let text = result_text(&result);
+        assert!(text.contains("\"found\": false"), "no path: {text}");
+    }
+
+    #[tokio::test]
+    async fn trace_hop_includes_body_when_content_indexed() {
+        let (_dir, server) = indexed_server();
+        // Seed RAG content for every `speak` symbol (the hop sources on the
+        // speak→helper path), so the hop body is populated.
+        {
+            let db = server.db.lock().unwrap();
+            for sym in db.search("speak", None, None, 10).unwrap() {
+                db.upsert_symbol_content(
+                    &sym.id,
+                    "speak",
+                    "def speak(self):\n    return helper()",
+                    "// method speak",
+                )
+                .unwrap();
+            }
+        }
+        let result = server
+            .cartog_trace(Parameters(TraceParams {
+                from: "speak".to_string(),
+                to: "helper".to_string(),
+                depth: Some(8),
+            }))
+            .await
+            .expect("trace succeeds");
+        let text = result_text(&result);
+        assert!(
+            text.contains("\"body\""),
+            "hop carries an inline body when content is indexed: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn context_bundles_relevant_symbols_for_a_task() {
+        let (_dir, server) = indexed_server();
+        let result = server
+            .cartog_context(Parameters(ContextParams {
+                task: "speak".to_string(),
+                tokens: Some(6000),
+            }))
+            .await
+            .expect("context succeeds");
+        let text = result_text(&result);
+        assert!(text.contains("\"task\": \"speak\""), "echoes task: {text}");
+        assert!(text.contains("\"entries\""), "returns entries: {text}");
+    }
+
+    #[tokio::test]
+    async fn rag_search_prepends_banner_when_embeddings_pending() {
+        let (_dir, server) = indexed_server();
+        // Simulate a live watcher with pending embeddings.
+        let stale = cartog_watch::StaleState::new();
+        stale.note_reindex(0, 7);
+        *server.stale.lock().unwrap() = Some(stale);
+        server
+            .watcher_active
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let result = server
+            .cartog_rag_search(Parameters(RagSearchParams {
+                query: "helper".to_string(),
+                kind: None,
+                limit: Some(5),
+            }))
+            .await
+            .expect("rag search succeeds");
+        let text = result_text(&result);
+        assert!(
+            text.starts_with("⚠️") && text.contains("re-embedding"),
+            "banner prepended: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_banner_without_active_watcher() {
+        let (_dir, server) = indexed_server();
+        // Stale state present but watcher_active is false (degraded/no watcher).
+        let stale = cartog_watch::StaleState::new();
+        stale.note_reindex(0, 7);
+        *server.stale.lock().unwrap() = Some(stale);
+
+        let result = server
+            .cartog_rag_search(Parameters(RagSearchParams {
+                query: "helper".to_string(),
+                kind: None,
+                limit: Some(5),
+            }))
+            .await
+            .expect("rag search succeeds");
+        assert!(!result_text(&result).starts_with("⚠️"), "no banner");
+    }
+
+    #[tokio::test]
+    async fn context_rejects_empty_task() {
+        let (_dir, server) = indexed_server();
+        let err = server
+            .cartog_context(Parameters(ContextParams {
+                task: String::new(),
+                tokens: None,
+            }))
+            .await
+            .expect_err("empty task must be rejected");
+        assert!(
+            err.message.contains("cannot be empty"),
+            "got: {}",
+            err.message
         );
     }
 

--- a/crates/cartog-mcp/src/single_writer.rs
+++ b/crates/cartog-mcp/src/single_writer.rs
@@ -188,12 +188,17 @@ pub async fn run_server(
         Some(s) => Some(serve_to_watch_slot(s)?),
         None => None,
     };
+    // Staleness state the primary's watcher publishes for banner decisions.
+    // `None` when there's no primary watcher (read-only peer / no `--watch`).
+    let initial_stale: Option<Arc<cartog_watch::StaleState>> =
+        (watch && role == Role::Primary).then(cartog_watch::StaleState::new);
     let initial_watch_handle: Option<WatchHandle> = if watch && role == Role::Primary {
         let cwd = std::env::current_dir()?;
         let mut config = WatchConfig::new(cwd);
         config.rag = rag;
         config.rag_config = rag_config.clone();
         config.redact = redact;
+        config.stale = initial_stale.clone();
         // Claim the watcher's PID slot so a separately-running `cartog watch`
         // from a terminal correctly refuses to start against the same DB.
         config.pid_lock_dir = opts.pid_lock_dir.clone();
@@ -231,6 +236,14 @@ pub async fn run_server(
         std::sync::atomic::Ordering::Relaxed,
     );
 
+    // Install the staleness state only when the watcher actually started, so
+    // the cell stays consistent with `watcher_active`.
+    if initial_watch_handle.is_some() {
+        if let Ok(mut cell) = server.stale.lock() {
+            *cell = initial_stale;
+        }
+    }
+
     // Shared cells so the promoter (if any) can install the lock + watcher
     // after winning election, and so the cells stay alive for the whole
     // `run_server` lifetime — Drop on shutdown fires here.
@@ -262,6 +275,7 @@ pub async fn run_server(
                     role: Arc::clone(&server.role),
                     lock_cell: Arc::clone(&lock_cell),
                     watch_cell: Arc::clone(&watch_cell),
+                    stale_cell: Arc::clone(&server.stale),
                     watcher_active: Arc::clone(&server.watcher_active),
                     embedding_provider: Arc::clone(&server.embedding_provider),
                     db_path: db_path.to_path_buf(),
@@ -333,6 +347,10 @@ pub(crate) struct PromoterArgs {
     /// Slot for the watcher handle spawned after promotion (when the user
     /// asked for `serve --watch`).
     pub(crate) watch_cell: Arc<Mutex<Option<WatchHandle>>>,
+    /// Server's staleness cell. The promoter installs a fresh [`StaleState`]
+    /// here when it spawns a post-promotion watcher, so banners work after
+    /// failover.
+    pub(crate) stale_cell: Arc<Mutex<Option<Arc<cartog_watch::StaleState>>>>,
     /// Reflects whether a file watcher is currently running. Set to true
     /// on a successful post-promotion spawn, left false if the watcher
     /// failed to start (degraded Primary: surfaced in `cartog_stats`).
@@ -494,6 +512,9 @@ pub(crate) async fn promoter_task(args: PromoterArgs) {
         // keeps the invariant "Primary always owns its watcher when
         // watch_requested" intact rather than leaving a degraded Primary
         // with no watcher and only a stderr warning.
+        // Fresh staleness state for the post-promotion watcher; installed
+        // into the server's cell alongside the watcher handle below.
+        let new_stale = cartog_watch::StaleState::new();
         let new_watch_handle: Option<WatchHandle> = if args.watch_requested {
             // Reuse the cwd captured at server startup, not
             // std::env::current_dir() — the latter follows runtime
@@ -503,6 +524,7 @@ pub(crate) async fn promoter_task(args: PromoterArgs) {
             config.rag = args.rag;
             config.rag_config = args.rag_config.clone();
             config.redact = args.redact;
+            config.stale = Some(Arc::clone(&new_stale));
             config.pid_lock_dir = Some(args.state_dir.clone());
             config.pid_lock_slot = Some(args.watch_slot.clone());
             // Skip migrations because we validated the schema when we
@@ -576,6 +598,9 @@ pub(crate) async fn promoter_task(args: PromoterArgs) {
             match args.watch_cell.lock() {
                 Ok(mut guard) => {
                     *guard = Some(handle);
+                    if let Ok(mut cell) = args.stale_cell.lock() {
+                        *cell = Some(new_stale);
+                    }
                     args.watcher_active
                         .store(true, std::sync::atomic::Ordering::Relaxed);
                 }

--- a/crates/cartog-rag/src/context.rs
+++ b/crates/cartog-rag/src/context.rs
@@ -1,0 +1,473 @@
+//! One-shot task-context builder: fuse semantic seeds, structural neighbors,
+//! and centrality into a token-budgeted bundle for an agent's task.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use serde::Serialize;
+
+use cartog_core::{EdgeKind, Symbol};
+use cartog_db::Database;
+
+use crate::provider::{EmbeddingProvider, RerankerProvider};
+use crate::search::{hybrid_search_tuned, KindFilter, SearchTuning};
+
+/// Why a symbol is in a [`TaskContext`] bundle. Variants are ordered
+/// strongest-first, so `Ord` ranks `Seed < Neighbor < Central`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextReason {
+    /// Surfaced directly by semantic/keyword search.
+    Seed,
+    /// A 1-hop callee or caller of a seed.
+    Neighbor,
+    /// A high-centrality definition in a seed's file.
+    Central,
+}
+
+/// One symbol in a task-context bundle.
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct ContextEntry {
+    pub symbol: Symbol,
+    pub reason: ContextReason,
+    /// Combined relevance score; higher ranks first.
+    pub score: f64,
+    /// Body, attached to top entries until the token budget is spent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+/// A task-context bundle: ranked, deduplicated entries within a token budget.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct TaskContext {
+    pub task: String,
+    pub entries: Vec<ContextEntry>,
+    /// Approximate tokens occupied by the attached bodies (`bytes / 4`, min 1
+    /// per non-empty body).
+    pub approx_tokens: u32,
+}
+
+/// Tunables for [`build_task_context`].
+#[derive(Debug, Clone, Copy)]
+pub struct ContextOptions {
+    /// Semantic seeds to retrieve.
+    pub seed_count: u32,
+    /// Top seeds whose 1-hop neighbors are pulled in.
+    pub expand_count: usize,
+    /// Centrality candidates considered (filtered to seed files).
+    pub central_count: u32,
+    pub tuning: SearchTuning,
+}
+
+impl Default for ContextOptions {
+    fn default() -> Self {
+        Self {
+            seed_count: 8,
+            expand_count: 3,
+            central_count: 20,
+            tuning: SearchTuning::default(),
+        }
+    }
+}
+
+/// Rough tokens-per-byte for budget accounting (code averages ~4 chars/token).
+const BYTES_PER_TOKEN: usize = 4;
+
+/// Score bands keep Seeds above Neighbors above Central regardless of raw signal.
+const SEED_BASE: f64 = 2.0;
+const NEIGHBOR_BASE: f64 = 1.0;
+const CENTRAL_BASE: f64 = 0.5;
+
+/// Build a task-context bundle for `task`.
+///
+/// Pipeline: (1) [`hybrid_search_tuned`] for semantic seeds; (2) 1-hop callees
+/// and callers of the top seeds; (3) high-centrality definitions in seed files;
+/// (4) dedup by symbol id keeping the strongest reason, rank, then greedily
+/// attach bodies until `token_budget` is spent.
+///
+/// Degrades to keyword-only seeds when no embeddings are indexed, and to RRF
+/// ranking when `reranker` is `None`.
+///
+/// # Errors
+/// Returns an error if a database query or the search pipeline fails.
+pub fn build_task_context<E: EmbeddingProvider + ?Sized>(
+    db: &Database,
+    task: &str,
+    token_budget: u32,
+    embedding_provider: &mut E,
+    reranker: Option<&mut dyn RerankerProvider>,
+    opts: &ContextOptions,
+) -> Result<TaskContext> {
+    let seeds = hybrid_search_tuned(
+        db,
+        task,
+        opts.seed_count,
+        KindFilter::CodeOnly,
+        embedding_provider,
+        reranker,
+        &opts.tuning,
+    )?;
+
+    // id → (symbol, reason, score). On a stronger reason, adopt the new
+    // reason AND its score (so the score always matches the winning reason);
+    // on the same reason, keep the higher score.
+    let mut picked: HashMap<String, (Symbol, ContextReason, f64)> = HashMap::new();
+    let consider = |map: &mut HashMap<String, (Symbol, ContextReason, f64)>,
+                    sym: Symbol,
+                    reason: ContextReason,
+                    score: f64| {
+        map.entry(sym.id.clone())
+            .and_modify(|e| {
+                if reason < e.1 {
+                    e.1 = reason;
+                    e.2 = score;
+                } else if reason == e.1 && score > e.2 {
+                    e.2 = score;
+                }
+            })
+            .or_insert((sym, reason, score));
+    };
+
+    let seed_files: HashSet<&str> = seeds
+        .results
+        .iter()
+        .map(|r| r.symbol.file_path.as_str())
+        .collect();
+
+    for (rank, r) in seeds.results.iter().enumerate() {
+        let base = r.rerank_score.unwrap_or(r.rrf_score);
+        let score = SEED_BASE + base + rank_bonus(rank);
+        consider(&mut picked, r.symbol.clone(), ContextReason::Seed, score);
+    }
+
+    // Expand the top seeds' 1-hop neighborhood (callees + callers).
+    for r in seeds.results.iter().take(opts.expand_count) {
+        let boost = picked.get(&r.symbol.id).map_or(0.0, |e| e.2);
+        for edge in db.callees(&r.symbol.name)? {
+            if let Some(sym) = resolve_one(db, &edge.target_name)? {
+                let score = NEIGHBOR_BASE + neighbor_weight(boost, sym.in_degree);
+                consider(&mut picked, sym, ContextReason::Neighbor, score);
+            }
+        }
+        // Callers, restricted to `calls` edges — a symbol that merely imports
+        // or subclasses a seed is not a call neighbor.
+        for (_, source) in db.refs(&r.symbol.name, Some(EdgeKind::Calls))? {
+            if let Some(sym) = source {
+                let score = NEIGHBOR_BASE + neighbor_weight(boost, sym.in_degree);
+                consider(&mut picked, sym, ContextReason::Neighbor, score);
+            }
+        }
+    }
+
+    // Centrality: high in-degree definitions living in a seed's file.
+    if !seed_files.is_empty() {
+        for sym in db.top_symbols(opts.central_count)? {
+            if seed_files.contains(sym.file_path.as_str()) {
+                let score = CENTRAL_BASE + centrality_weight(sym.in_degree);
+                consider(&mut picked, sym, ContextReason::Central, score);
+            }
+        }
+    }
+
+    let mut entries: Vec<ContextEntry> = picked
+        .into_values()
+        .map(|(symbol, reason, score)| ContextEntry {
+            symbol,
+            reason,
+            score,
+            content: None,
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(b.symbol.in_degree.cmp(&a.symbol.in_degree))
+            .then(a.symbol.id.cmp(&b.symbol.id))
+    });
+
+    let approx_tokens = hydrate_within_budget(db, &mut entries, token_budget)?;
+
+    Ok(TaskContext {
+        task: task.to_string(),
+        entries,
+        approx_tokens,
+    })
+}
+
+/// Small descending bonus so seeds keep their search order within the band.
+fn rank_bonus(rank: usize) -> f64 {
+    1.0 / (rank as f64 + 1.0)
+}
+
+/// Neighbor score lift from its seed's score and its own centrality.
+fn neighbor_weight(seed_score: f64, in_degree: u32) -> f64 {
+    seed_score * 0.1 + (f64::from(in_degree)).ln_1p() * 0.1
+}
+
+/// Central score lift from centrality alone.
+fn centrality_weight(in_degree: u32) -> f64 {
+    (f64::from(in_degree)).ln_1p() * 0.1
+}
+
+/// Resolve a name to its single best-ranked symbol, if any.
+fn resolve_one(db: &Database, name: &str) -> Result<Option<Symbol>> {
+    if name.is_empty() {
+        return Ok(None);
+    }
+    Ok(db.search(name, None, None, 1)?.into_iter().next())
+}
+
+/// Attach bodies to ranked entries until `token_budget` is spent. Returns the
+/// approximate tokens consumed. Entries past the budget keep `content: None`.
+fn hydrate_within_budget(
+    db: &Database,
+    entries: &mut [ContextEntry],
+    token_budget: u32,
+) -> Result<u32> {
+    let budget = token_budget as usize;
+    let mut spent = 0usize;
+    for entry in entries.iter_mut() {
+        if spent >= budget {
+            break;
+        }
+        if let Some((content, _)) = db.get_symbol_content(&entry.symbol.id)? {
+            // Non-empty bodies cost at least 1 token so tiny (<4-byte) bodies
+            // can't slip the cap for free.
+            let cost = (content.len() / BYTES_PER_TOKEN).max(1);
+            if spent + cost > budget {
+                // Entries are score-sorted: a higher-ranked body that doesn't
+                // fit means stop, rather than letting a lower-ranked smaller
+                // body jump ahead of it.
+                break;
+            }
+            spent += cost;
+            entry.content = Some(content);
+        }
+    }
+    Ok(spent as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::test_utils::MockEmbeddingProvider;
+    use cartog_core::{Edge, EdgeKind, Symbol, SymbolKind};
+
+    fn insert(db: &Database, name: &str, kind: SymbolKind, file: &str, content: &str) -> Symbol {
+        let sym = Symbol::new(name, kind, file, 1, 11, 0, content.len() as u32, None);
+        db.insert_symbol(&sym).unwrap();
+        let header = format!("// {kind} {name}");
+        db.upsert_symbol_content(&sym.id, name, content, &header)
+            .unwrap();
+        sym
+    }
+
+    /// `authenticate → generate_token` over a `calls` edge in one auth file.
+    fn seed_auth(db: &Database) -> (Symbol, Symbol) {
+        let auth = insert(
+            db,
+            "authenticate",
+            SymbolKind::Function,
+            "auth.py",
+            "def authenticate(user, pw):\n    return generate_token(user)",
+        );
+        let gen = insert(
+            db,
+            "generate_token",
+            SymbolKind::Function,
+            "auth.py",
+            "def generate_token(user):\n    return jwt.encode(user)",
+        );
+        db.insert_edges(&[Edge {
+            source_id: auth.id.clone(),
+            target_name: "generate_token".to_string(),
+            target_id: Some(gen.id.clone()),
+            kind: EdgeKind::Calls,
+            file_path: "auth.py".to_string(),
+            line: 2,
+        }])
+        .unwrap();
+        (auth, gen)
+    }
+
+    #[test]
+    fn context_surfaces_seeds_and_their_neighbors() {
+        let db = Database::open_memory().unwrap();
+        seed_auth(&db);
+        let ctx = build_task_context(
+            &db,
+            "authenticate user",
+            6000,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = ctx.entries.iter().map(|e| e.symbol.name.as_str()).collect();
+        assert!(names.contains(&"authenticate"), "seed present: {names:?}");
+        assert!(
+            names.contains(&"generate_token"),
+            "1-hop callee present: {names:?}"
+        );
+    }
+
+    #[test]
+    fn context_ranks_seeds_above_neighbors() {
+        let db = Database::open_memory().unwrap();
+        seed_auth(&db);
+        let ctx = build_task_context(
+            &db,
+            "authenticate",
+            6000,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+        // Entries are score-sorted; the first must be a Seed.
+        assert_eq!(ctx.entries[0].reason, ContextReason::Seed);
+    }
+
+    #[test]
+    fn context_has_no_duplicate_symbols() {
+        let db = Database::open_memory().unwrap();
+        seed_auth(&db);
+        let ctx = build_task_context(
+            &db,
+            "token",
+            6000,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+        let mut ids: Vec<&str> = ctx.entries.iter().map(|e| e.symbol.id.as_str()).collect();
+        let before = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(before, ids.len(), "no symbol id should repeat");
+    }
+
+    #[test]
+    fn context_tiny_budget_keeps_entries_without_bodies() {
+        let db = Database::open_memory().unwrap();
+        seed_auth(&db);
+        let ctx = build_task_context(
+            &db,
+            "authenticate",
+            0, // no room for any body
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+        assert!(!ctx.entries.is_empty(), "seeds still returned");
+        assert!(
+            ctx.entries.iter().all(|e| e.content.is_none()),
+            "zero budget attaches no bodies"
+        );
+        assert_eq!(ctx.approx_tokens, 0);
+    }
+
+    #[test]
+    fn context_empty_index_returns_empty_bundle() {
+        let db = Database::open_memory().unwrap();
+        let ctx = build_task_context(
+            &db,
+            "anything",
+            6000,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+        assert!(ctx.entries.is_empty());
+    }
+
+    #[test]
+    fn context_neighbors_exclude_non_call_edges() {
+        // A symbol that only IMPORTS the seed must not be classified as a call
+        // Neighbor. (It may still appear as a Seed if keyword search surfaces
+        // it, but never via the import edge as a neighbor.)
+        let db = Database::open_memory().unwrap();
+        let (auth, _gen) = seed_auth(&db);
+        // Name + content share NO term with the query so search won't seed it;
+        // its only link to the seed is an import edge.
+        let importer = insert(
+            &db,
+            "zzz_loader",
+            SymbolKind::Function,
+            "config.py",
+            "def zzz_loader():\n    return 1",
+        );
+        db.insert_edges(&[Edge {
+            source_id: importer.id.clone(),
+            target_name: "authenticate".to_string(),
+            target_id: Some(auth.id.clone()),
+            kind: EdgeKind::Imports,
+            file_path: "config.py".to_string(),
+            line: 2,
+        }])
+        .unwrap();
+
+        let ctx = build_task_context(
+            &db,
+            "authenticate",
+            6000,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+        let names: Vec<&str> = ctx.entries.iter().map(|e| e.symbol.name.as_str()).collect();
+        assert!(
+            !names.contains(&"zzz_loader"),
+            "an import-only caller is not pulled in as a call neighbor: {names:?}"
+        );
+    }
+
+    #[test]
+    fn context_budget_prioritizes_higher_ranked_bodies() {
+        // Top-ranked seed has a body that exceeds the budget; a lower-ranked
+        // neighbor's smaller body must NOT jump ahead of it.
+        let db = Database::open_memory().unwrap();
+        let big = "x".repeat(400); // ~100 tokens
+        let seed = insert(&db, "validate_token", SymbolKind::Function, "t.py", &big);
+        let small = insert(
+            &db,
+            "helper",
+            SymbolKind::Function,
+            "t.py",
+            "def helper(): pass",
+        );
+        db.insert_edges(&[Edge {
+            source_id: seed.id.clone(),
+            target_name: "helper".to_string(),
+            target_id: Some(small.id.clone()),
+            kind: EdgeKind::Calls,
+            file_path: "t.py".to_string(),
+            line: 1,
+        }])
+        .unwrap();
+
+        // Budget of 10 tokens: too small for the 100-token seed body.
+        let ctx = build_task_context(
+            &db,
+            "validate_token",
+            10,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions::default(),
+        )
+        .unwrap();
+        // The seed ranks first; since its body didn't fit, hydration stops and
+        // the lower-ranked helper does NOT get a body either.
+        assert_eq!(ctx.entries[0].symbol.name, "validate_token");
+        assert!(
+            ctx.entries.iter().all(|e| e.content.is_none()),
+            "no body jumps ahead of the unfittable top-ranked entry"
+        );
+    }
+}

--- a/crates/cartog-rag/src/context.rs
+++ b/crates/cartog-rag/src/context.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use serde::Serialize;
 
-use cartog_core::{EdgeKind, Symbol};
+use cartog_core::Symbol;
 use cartog_db::Database;
 
 use crate::provider::{EmbeddingProvider, RerankerProvider};
@@ -90,6 +90,7 @@ const CENTRAL_BASE: f64 = 0.5;
 ///
 /// # Errors
 /// Returns an error if a database query or the search pipeline fails.
+#[must_use = "the task-context bundle is the result; ignoring it wastes the query"]
 pub fn build_task_context<E: EmbeddingProvider + ?Sized>(
     db: &Database,
     task: &str,
@@ -140,22 +141,19 @@ pub fn build_task_context<E: EmbeddingProvider + ?Sized>(
         consider(&mut picked, r.symbol.clone(), ContextReason::Seed, score);
     }
 
-    // Expand the top seeds' 1-hop neighborhood (callees + callers).
+    // Expand the top seeds' 1-hop call neighborhood, keyed on the seed's exact
+    // id so an overloaded name doesn't pull in the wrong symbol's neighbors.
+    // Callees + callers, resolved `calls` edges only.
     for r in seeds.results.iter().take(opts.expand_count) {
         let boost = picked.get(&r.symbol.id).map_or(0.0, |e| e.2);
-        for edge in db.callees(&r.symbol.name)? {
-            if let Some(sym) = resolve_one(db, &edge.target_name)? {
-                let score = NEIGHBOR_BASE + neighbor_weight(boost, sym.in_degree);
-                consider(&mut picked, sym, ContextReason::Neighbor, score);
-            }
-        }
-        // Callers, restricted to `calls` edges — a symbol that merely imports
-        // or subclasses a seed is not a call neighbor.
-        for (_, source) in db.refs(&r.symbol.name, Some(EdgeKind::Calls))? {
-            if let Some(sym) = source {
-                let score = NEIGHBOR_BASE + neighbor_weight(boost, sym.in_degree);
-                consider(&mut picked, sym, ContextReason::Neighbor, score);
-            }
+        let neighbor_ids: Vec<String> = db
+            .callee_ids_of(&r.symbol.id)?
+            .into_iter()
+            .chain(db.caller_ids_of(&r.symbol.id)?)
+            .collect();
+        for sym in db.get_symbols_by_ids(&neighbor_ids)? {
+            let score = NEIGHBOR_BASE + neighbor_weight(boost, sym.in_degree);
+            consider(&mut picked, sym, ContextReason::Neighbor, score);
         }
     }
 
@@ -208,14 +206,6 @@ fn neighbor_weight(seed_score: f64, in_degree: u32) -> f64 {
 /// Central score lift from centrality alone.
 fn centrality_weight(in_degree: u32) -> f64 {
     (f64::from(in_degree)).ln_1p() * 0.1
-}
-
-/// Resolve a name to its single best-ranked symbol, if any.
-fn resolve_one(db: &Database, name: &str) -> Result<Option<Symbol>> {
-    if name.is_empty() {
-        return Ok(None);
-    }
-    Ok(db.search(name, None, None, 1)?.into_iter().next())
 }
 
 /// Attach bodies to ranked entries until `token_budget` is spent. Returns the
@@ -468,6 +458,100 @@ mod tests {
         assert!(
             ctx.entries.iter().all(|e| e.content.is_none()),
             "no body jumps ahead of the unfittable top-ranked entry"
+        );
+    }
+
+    #[test]
+    fn context_expands_neighbors_by_exact_seed_id_not_name() {
+        // Two symbols share the name `process` in different files. Only the
+        // seed in a.py calls `target_a`; the b.py overload calls `target_b`.
+        // Expansion keyed on the seed's exact id must pull target_a, not
+        // target_b (which a name-based fan-out would wrongly include).
+        let db = Database::open_memory().unwrap();
+        let seed = insert(
+            &db,
+            "process",
+            SymbolKind::Function,
+            "a.py",
+            "def process(): target_a()",
+        );
+        let other = insert(
+            &db,
+            "process",
+            SymbolKind::Function,
+            "b.py",
+            "def process(): target_b()",
+        );
+        let target_a = insert(
+            &db,
+            "target_a",
+            SymbolKind::Function,
+            "a.py",
+            "def target_a(): pass",
+        );
+        let target_b = insert(
+            &db,
+            "target_b",
+            SymbolKind::Function,
+            "b.py",
+            "def target_b(): pass",
+        );
+        assert_ne!(seed.id, other.id, "overloads have distinct ids");
+        db.insert_edges(&[
+            Edge {
+                source_id: seed.id.clone(),
+                target_name: "target_a".to_string(),
+                target_id: Some(target_a.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "a.py".to_string(),
+                line: 1,
+            },
+            Edge {
+                source_id: other.id.clone(),
+                target_name: "target_b".to_string(),
+                target_id: Some(target_b.id.clone()),
+                kind: EdgeKind::Calls,
+                file_path: "b.py".to_string(),
+                line: 1,
+            },
+        ])
+        .unwrap();
+
+        // Confirm the DB helper resolves callees by the exact seed id.
+        assert_eq!(
+            db.callee_ids_of(&seed.id).unwrap(),
+            vec![target_a.id.clone()]
+        );
+        assert_eq!(
+            db.callee_ids_of(&other.id).unwrap(),
+            vec![target_b.id.clone()]
+        );
+
+        let ctx = build_task_context(
+            &db,
+            "process",
+            6000,
+            &mut MockEmbeddingProvider::new(384),
+            None,
+            &ContextOptions {
+                expand_count: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let names: Vec<&str> = ctx.entries.iter().map(|e| e.symbol.name.as_str()).collect();
+        // The top seed's exact callee is present; the other overload's callee
+        // is only present if its `process` was itself a seed — assert at least
+        // that expansion is id-scoped by checking target_a came in as a neighbor.
+        let target_a_entry = ctx.entries.iter().find(|e| e.symbol.id == target_a.id);
+        assert!(
+            target_a_entry.is_some(),
+            "seed's exact callee target_a is expanded: {names:?}"
+        );
+        assert_eq!(
+            target_a_entry.unwrap().reason,
+            ContextReason::Neighbor,
+            "target_a enters as a call neighbor"
         );
     }
 }

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -7,6 +7,7 @@
 //! - **local** (default): ONNX models via fastembed (feature `provider-local`)
 //! - **ollama**: HTTP API to an Ollama server (feature `provider-ollama`)
 
+pub mod context;
 #[cfg(feature = "provider-local")]
 pub mod embeddings;
 pub mod indexer;

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -368,7 +368,11 @@ fn watch_loop(
         });
     }
 
-    // Initial incremental index to ensure DB is current
+    // Initial incremental index to ensure DB is current. Symbols left needing
+    // embedding here arm the RAG timer + staleness state below, so the initial
+    // batch is embedded on the same deferred schedule as change-driven reindexes
+    // (and shows the staleness banner meanwhile) rather than only on shutdown.
+    let mut initial_pending = 0u32;
     let initial_start = Instant::now();
     match indexer::index_directory(&db, root, false, false, None, None, config.redact) {
         Ok(r) => {
@@ -389,6 +393,17 @@ fn watch_loop(
                     edges_resolved: r.edges_resolved,
                     duration_ms: initial_start.elapsed().as_millis(),
                 });
+            }
+            if config.rag {
+                match db.symbols_needing_embeddings() {
+                    Ok(needing) => initial_pending = needing.len() as u32,
+                    Err(e) => warn!(error = %e, "failed to check embedding status"),
+                }
+            }
+            // Publish the post-initial-index state (no changes observed yet, so
+            // change_seq is 0; caught up to 0).
+            if let Some(s) = &config.stale {
+                s.note_reindex(s.change_seq(), initial_pending);
             }
         }
         Err(e) => {
@@ -442,9 +457,10 @@ fn watch_loop(
             }
         };
 
-    // RAG timer state: when we last indexed (to defer embedding)
-    let mut rag_pending = false;
-    let mut last_index_time: Option<Instant> = None;
+    // RAG timer state: when we last indexed (to defer embedding). Seed from the
+    // initial index so its pending symbols embed on the deferred schedule.
+    let mut rag_pending = config.rag && initial_pending > 0;
+    let mut last_index_time: Option<Instant> = rag_pending.then(Instant::now);
 
     loop {
         if shutdown.load(Ordering::SeqCst) {

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -21,6 +21,9 @@ use cartog_indexer as indexer;
 use cartog_indexer::is_ignored_dirname;
 use cartog_rag as rag;
 
+mod stale;
+pub use stale::{StaleSnapshot, StaleState};
+
 /// Configuration for the watch loop.
 pub struct WatchConfig {
     /// Root directory to watch.
@@ -60,6 +63,9 @@ pub struct WatchConfig {
     /// when it pinned `PinnedAttach`; running them again would re-trigger
     /// the SQLITE_BUSY race the election prevents).
     pub skip_migrations: bool,
+    /// Shared staleness state for the MCP server to read. `None` (the default,
+    /// e.g. standalone `cartog watch`) disables staleness publishing.
+    pub stale: Option<Arc<StaleState>>,
 }
 
 impl WatchConfig {
@@ -84,6 +90,7 @@ impl WatchConfig {
             pid_lock_dir: None,
             pid_lock_slot: None,
             skip_migrations: false,
+            stale: None,
         }
     }
 }
@@ -463,6 +470,13 @@ fn watch_loop(
                         count = events.len(),
                         "file change events received, re-indexing"
                     );
+                    // Capture the change count BEFORE reindexing; a change that
+                    // arrives while the reindex runs bumps the seq past this and
+                    // stays flagged stale.
+                    let caught_up_to = config.stale.as_ref().map(|s| {
+                        s.note_change();
+                        s.change_seq()
+                    });
                     let reindex_start = Instant::now();
                     match indexer::index_directory(
                         &db,
@@ -495,6 +509,7 @@ fn watch_loop(
                                 });
                             }
                             // Check if RAG embedding is needed
+                            let mut pending_count = 0u32;
                             if config.rag {
                                 match db.symbols_needing_embeddings() {
                                     Ok(needing) if !needing.is_empty() => {
@@ -502,6 +517,7 @@ fn watch_loop(
                                             pending = needing.len(),
                                             "symbols need embedding, starting RAG timer"
                                         );
+                                        pending_count = needing.len() as u32;
                                         rag_pending = true;
                                         last_index_time = Some(Instant::now());
                                     }
@@ -513,6 +529,9 @@ fn watch_loop(
                                         warn!(error = %e, "failed to check embedding status");
                                     }
                                 }
+                            }
+                            if let (Some(s), Some(seq)) = (&config.stale, caught_up_to) {
+                                s.note_reindex(seq, pending_count);
                             }
                         }
                         Err(e) => {
@@ -563,6 +582,10 @@ fn watch_loop(
                                                 duration_ms: embed_start.elapsed().as_millis(),
                                             });
                                         }
+                                        // Embeddings are current — clear the stale signal.
+                                        if let Some(s) = &config.stale {
+                                            s.clear_rag_pending();
+                                        }
                                     }
                                     Err(e) => {
                                         warn!(error = %e, "RAG embedding failed");
@@ -571,9 +594,13 @@ fn watch_loop(
                                                 error: e.to_string(),
                                             });
                                         }
+                                        // Leave the stale signal set: embeddings did NOT
+                                        // catch up, so callers must still be warned.
                                     }
                                 }
                             }
+                            // Disarm the local retry timer regardless (avoid a tight
+                            // re-embed loop); a later file change re-arms it.
                             rag_pending = false;
                             last_index_time = None;
                         }

--- a/crates/cartog-watch/src/stale.rs
+++ b/crates/cartog-watch/src/stale.rs
@@ -1,0 +1,145 @@
+//! Lock-light staleness state the watcher publishes for the MCP server to read.
+//!
+//! The watcher writes timestamps + a pending-embedding count; the MCP response
+//! layer reads a [`StaleSnapshot`] to decide whether to prepend a "results may
+//! be stale" banner. All fields are atomics, so reads never block and never
+//! hold a lock across `.await`.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Shared staleness state, written by the watch thread and read by the MCP
+/// server over an `Arc<StaleState>`.
+///
+/// Structural staleness uses monotonic sequence counters, not wall-clock time:
+/// `change_seq` bumps on every observed change, and a reindex records the
+/// `change_seq` value it caught up to. This is exact regardless of how fast
+/// changes and reindexes interleave (a wall-clock second can hold both).
+#[derive(Debug, Default)]
+pub struct StaleState {
+    /// Symbols awaiting RAG embedding after the last reindex; 0 when current.
+    rag_pending: AtomicU32,
+    /// Count of relevant file changes observed (monotonically increasing).
+    change_seq: AtomicU64,
+    /// The `change_seq` value the most recent completed reindex caught up to.
+    reindexed_seq: AtomicU64,
+}
+
+impl StaleState {
+    /// Construct a fresh shared state.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Record that a relevant file change was observed (debounce-window start).
+    pub fn note_change(&self) {
+        self.change_seq.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a completed reindex: it caught the structural index up to the
+    /// change count observed when it *started* (`caught_up_to`), and left
+    /// `rag_pending` symbols awaiting embedding. Pass the `change_seq` read
+    /// before the reindex ran so a change arriving mid-reindex stays counted.
+    pub fn note_reindex(&self, caught_up_to: u64, rag_pending: u32) {
+        self.reindexed_seq.store(caught_up_to, Ordering::Relaxed);
+        self.rag_pending.store(rag_pending, Ordering::Relaxed);
+    }
+
+    /// Current observed-change count, to capture before starting a reindex.
+    #[must_use]
+    pub fn change_seq(&self) -> u64 {
+        self.change_seq.load(Ordering::Relaxed)
+    }
+
+    /// Clear the pending-embedding count after embeddings catch up.
+    pub fn clear_rag_pending(&self) {
+        self.rag_pending.store(0, Ordering::Relaxed);
+    }
+
+    /// Read a point-in-time snapshot for banner decisions.
+    #[must_use]
+    pub fn snapshot(&self) -> StaleSnapshot {
+        StaleSnapshot {
+            rag_pending: self.rag_pending.load(Ordering::Relaxed),
+            change_seq: self.change_seq.load(Ordering::Relaxed),
+            reindexed_seq: self.reindexed_seq.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// An immutable read of [`StaleState`].
+#[derive(Debug, Clone, Copy)]
+pub struct StaleSnapshot {
+    pub rag_pending: u32,
+    pub change_seq: u64,
+    pub reindexed_seq: u64,
+}
+
+impl StaleSnapshot {
+    /// True when embeddings are behind the structural index (RAG staleness).
+    #[must_use]
+    pub fn rag_stale(&self) -> bool {
+        self.rag_pending > 0
+    }
+
+    /// True when changes have been observed that the last reindex didn't cover
+    /// (debounce gap or a change that arrived mid-reindex).
+    #[must_use]
+    pub fn structural_stale(&self) -> bool {
+        self.change_seq > self.reindexed_seq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn change_then_no_reindex_is_structurally_stale() {
+        let s = StaleState::new();
+        s.note_change();
+        assert!(s.snapshot().structural_stale());
+    }
+
+    #[test]
+    fn reindex_caught_up_to_change_clears_structural_staleness() {
+        let s = StaleState::new();
+        s.note_change();
+        let seq = s.change_seq();
+        s.note_reindex(seq, 0);
+        assert!(!s.snapshot().structural_stale());
+    }
+
+    #[test]
+    fn change_arriving_mid_reindex_stays_stale() {
+        // Reindex captures change_seq=1 at start; a 2nd change bumps to 2 before
+        // it records. The reindex caught up only to 1, so seq 2 is still stale —
+        // no wall-clock granularity gap can hide it.
+        let s = StaleState::new();
+        s.note_change(); // seq = 1
+        let caught = s.change_seq();
+        s.note_change(); // seq = 2 (arrived during the reindex)
+        s.note_reindex(caught, 0);
+        assert!(
+            s.snapshot().structural_stale(),
+            "the mid-reindex change is not yet covered"
+        );
+    }
+
+    #[test]
+    fn pending_embeddings_are_rag_stale_until_cleared() {
+        let s = StaleState::new();
+        s.note_reindex(0, 5);
+        assert!(s.snapshot().rag_stale());
+        s.clear_rag_pending();
+        assert!(!s.snapshot().rag_stale());
+    }
+
+    #[test]
+    fn fresh_state_is_not_stale() {
+        let snap = StaleState::new().snapshot();
+        assert!(!snap.rag_stale());
+        assert!(!snap.structural_stale());
+    }
+}

--- a/crates/cartog-watch/tests/initial_index_staleness_test.rs
+++ b/crates/cartog-watch/tests/initial_index_staleness_test.rs
@@ -1,0 +1,83 @@
+//! The initial index a watcher runs on startup must publish RAG-pending state
+//! so the staleness banner fires for the initial batch, not only after a later
+//! change-driven reindex.
+
+use std::time::{Duration, Instant};
+
+use cartog_db::Database;
+use cartog_indexer as indexer;
+use cartog_watch::{spawn_watch, StaleState, WatchConfig};
+
+fn wait_for<F: FnMut() -> bool>(mut pred: F, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if pred() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    pred()
+}
+
+#[test]
+fn initial_index_publishes_rag_pending_to_stale_state() {
+    let workspace = tempfile::TempDir::new().unwrap();
+    // The walker prunes dot-prefixed dirs, and TempDir names start with ".tmp";
+    // index a named subdir so files aren't skipped.
+    let root = &workspace.path().join("project");
+    std::fs::create_dir(root).unwrap();
+    // Bodies must clear the indexer's MIN_CONTENT_BYTES (~50) so symbol_content
+    // is stored (and thus shows up as needing an embedding).
+    let src = "def authenticate(user, password, mfa_token, remember_me):
+    token = generate_token(user, password, mfa_token)
+    return token
+
+
+def generate_token(user, password, mfa_token):
+    payload = {'user': user, 'mfa': mfa_token}
+    return str(payload)
+";
+    std::fs::write(root.join("lib.py"), src).unwrap();
+    let db_path = root.join("cartog.db");
+
+    // Plain index first: writes symbol_content but NO embeddings, so
+    // symbols_needing_embeddings() returns rows the watcher's initial index
+    // will publish as RAG-pending.
+    {
+        let db = Database::open(&db_path, 384).unwrap();
+        indexer::index_directory(
+            &db,
+            root,
+            true,
+            false,
+            None,
+            None,
+            indexer::RedactionConfig::disabled(),
+        )
+        .expect("plain index");
+        assert!(
+            !db.symbols_needing_embeddings().unwrap().is_empty(),
+            "content present, embeddings absent → pending rows exist"
+        );
+    }
+
+    let stale = StaleState::new();
+    let mut config = WatchConfig::new(root.to_path_buf());
+    config.rag = true;
+    // Long delay so the deferred embed (which would need an ONNX model) never
+    // fires during the test — we only assert the *initial* publish.
+    config.rag_delay = Duration::from_secs(3600);
+    config.stale = Some(std::sync::Arc::clone(&stale));
+
+    let handle = spawn_watch(config, &db_path.to_string_lossy()).expect("spawn watch");
+
+    // After the initial index, the watcher should have published the pending
+    // embedding count — rag_stale() becomes true without any file change.
+    let published = wait_for(|| stale.snapshot().rag_stale(), Duration::from_secs(10));
+    handle.stop();
+
+    assert!(
+        published,
+        "initial index must publish RAG-pending state (rag_stale) on startup"
+    );
+}

--- a/crates/cartog/README.md
+++ b/crates/cartog/README.md
@@ -16,11 +16,13 @@ Binary crate and library facade. Provides the `cartog` CLI with 25 top-level com
 | `outline FILE` | Show symbols and structure of a file |
 | `callees NAME` | Find what a symbol calls |
 | `impact NAME` | Transitive impact analysis (`--depth`, default: 3) |
+| `trace FROM TO` | Shortest call path between two symbols, bodies inline (`--depth`, default: 8) |
 | `refs NAME` | All references to a symbol (`--kind` filter) |
 | `hierarchy NAME` | Inheritance hierarchy for a class |
 | `deps FILE` | File-level import dependencies |
 | `stats` | Index statistics summary |
 | `search QUERY` | Search symbols by name (`--kind`, `--file`, `--limit`) |
+| `context TASK` | One-shot task bundle: relevant symbols + bodies (`--tokens`, default: 6000) |
 | `map` | Token-budget-aware codebase summary (`--tokens`, default: 4000) |
 | `changes` | Symbols affected by recent git changes (`--commits`, `--kind`) |
 | `watch [PATH]` | Auto-re-index on file changes (`--rag`, `--debounce`) |

--- a/crates/cartog/README.md
+++ b/crates/cartog/README.md
@@ -4,7 +4,7 @@ Code graph indexer for LLM coding agents. Map your codebase, navigate by graph.
 
 ## Overview
 
-Binary crate and library facade. Provides the `cartog` CLI with 23 top-level commands for code graph indexing, querying, and semantic search. Also re-exports workspace crates under the `cartog::` namespace for use by benches and integration tests.
+Binary crate and library facade. Provides the `cartog` CLI with 25 top-level commands for code graph indexing, querying, and semantic search. Also re-exports workspace crates under the `cartog::` namespace for use by benches and integration tests.
 
 ## CLI commands
 

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -167,6 +167,29 @@ pub enum Command {
         depth: u32,
     },
 
+    /// Build a one-shot task-context bundle: relevant symbols + bodies for a task
+    Context {
+        /// Natural-language description of the task
+        task: String,
+
+        /// Approximate token budget for the bundle
+        #[arg(long, default_value = "6000")]
+        tokens: u32,
+    },
+
+    /// Find a call path between two symbols, with each hop's body inline
+    Trace {
+        /// Starting symbol (the caller end of the path)
+        from: String,
+
+        /// Target symbol (the callee end of the path)
+        to: String,
+
+        /// Maximum path length to search
+        #[arg(long, default_value = "8")]
+        depth: u32,
+    },
+
     /// All references to a symbol (calls, imports, inherits, references, raises)
     Refs {
         /// Symbol name to search for

--- a/crates/cartog/src/commands/ide.rs
+++ b/crates/cartog/src/commands/ide.rs
@@ -877,7 +877,60 @@ pub enum PickerOutcome {
 /// Returns one row per unique `ClientKind`, with one `ScopeOption` per
 /// (kind, scope) entry in the catalogue. Claude Code ends up with two scope
 /// options; every other client has one.
+/// CLI binary name for a client, if it ships one we can detect on `PATH`.
+fn client_binary(kind: ClientKind) -> Option<&'static str> {
+    match kind {
+        ClientKind::ClaudeCode => Some("claude"),
+        ClientKind::Codex => Some("codex"),
+        ClientKind::Gemini => Some("gemini"),
+        ClientKind::Opencode => Some("opencode"),
+        ClientKind::Windsurf => Some("windsurf"),
+        ClientKind::Zed => Some("zed"),
+        // No reliable CLI: GUI apps (Claude Desktop) or editor-embedded (Cursor, VS Code).
+        ClientKind::ClaudeDesktop | ClientKind::Cursor | ClientKind::Vscode => None,
+    }
+}
+
+/// True if an executable `name` exists in any `paths` entry (PATH-style list).
+/// Side-effect-free and injectable for tests. On Windows, also tries each
+/// suffix in `%PATHEXT%` (falling back to a standard default) so `.bat`/`.com`
+/// shims are found, not just `.exe`/`.cmd`.
+fn binary_in(paths: &std::ffi::OsStr, name: &str) -> bool {
+    let mut candidates = vec![name.to_string()];
+    if cfg!(windows) {
+        let pathext =
+            std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+        for ext in pathext.split(';').filter(|e| !e.is_empty()) {
+            candidates.push(format!("{name}{}", ext.to_ascii_lowercase()));
+        }
+    }
+    std::env::split_paths(paths).any(|dir| candidates.iter().any(|c| dir.join(c).is_file()))
+}
+
+/// Stronger "is this client installed?" check than parent-dir existence: a
+/// known CLI on `path_env` (the PATH-style list, passed in for determinism +
+/// testability) OR the config dir present. Project-scope clients are always
+/// considered installable (the parent is the repo).
+fn client_installed(
+    kind: ClientKind,
+    scope: Scope,
+    path: &Path,
+    path_env: Option<&std::ffi::OsStr>,
+) -> bool {
+    if scope == Scope::Project {
+        return true;
+    }
+    if let (Some(bin), Some(p)) = (client_binary(kind), path_env) {
+        if binary_in(p, bin) {
+            return true;
+        }
+    }
+    // Fall back to the config-dir proxy (the only signal for GUI-only clients).
+    path.parent().is_some_and(Path::exists)
+}
+
 pub fn picker_items(cwd: &Path, homes: &HomeDirs) -> Vec<PickerItem> {
+    let path_env = std::env::var_os("PATH");
     let mut by_kind: Vec<PickerItem> = Vec::new();
     for entry in CLIENT_CATALOGUE.iter() {
         let path = match entry.scope {
@@ -890,12 +943,7 @@ pub fn picker_items(cwd: &Path, homes: &HomeDirs) -> Vec<PickerItem> {
                 None => continue,
             },
         };
-        let installed = match entry.scope {
-            // Project parents always exist (it's the repo).
-            Scope::Project => true,
-            // Missing parent dir = client not installed on this machine.
-            Scope::User => path.parent().is_some_and(Path::exists),
-        };
+        let installed = client_installed(entry.kind, entry.scope, &path, path_env.as_deref());
         let opt = ScopeOption {
             scope: entry.scope,
             file_present: path.exists(),
@@ -1114,8 +1162,9 @@ fn run_ide_for_clients(
     let mut summary = IdeSummary::default();
     for spec in specs {
         // `interactive = false` here: the picker already prompted, so per-spec
-        // confirmation prompts would be redundant.
-        let step = process_spec(&spec, cwd, false, dry_run);
+        // confirmation prompts would be redundant. `auto_only = false`: the user
+        // explicitly picked these rows, so wire them even if detection is unsure.
+        let step = process_spec(&spec, cwd, false, dry_run, false);
         summary.total += 1;
         match step.status {
             IdeStatus::Created => summary.created += 1,
@@ -1196,8 +1245,11 @@ pub fn run_ide(
     let mut steps = Vec::with_capacity(specs.len());
     let mut summary = IdeSummary::default();
 
+    // No explicit client → only wire user clients we detect as installed.
+    // An explicit `--client X` always proceeds, even if X isn't detected.
+    let auto_only = client.is_none();
     for spec in specs {
-        let step = process_spec(&spec, cwd, interactive, dry_run);
+        let step = process_spec(&spec, cwd, interactive, dry_run, auto_only);
         match step.status {
             IdeStatus::Created => summary.created += 1,
             IdeStatus::Updated => summary.updated += 1,
@@ -1212,7 +1264,13 @@ pub fn run_ide(
     Ok(IdeReport { steps, summary })
 }
 
-fn process_spec(spec: &ClientSpec, cwd: &Path, interactive: bool, dry_run: bool) -> IdeStep {
+fn process_spec(
+    spec: &ClientSpec,
+    cwd: &Path,
+    interactive: bool,
+    dry_run: bool,
+    auto_only: bool,
+) -> IdeStep {
     let client = client_name(spec.kind).to_string();
     let scope = match spec.scope {
         Scope::Project => "project",
@@ -1230,15 +1288,22 @@ fn process_spec(spec: &ClientSpec, cwd: &Path, interactive: bool, dry_run: bool)
         diff,
     };
 
-    if spec.scope == Scope::User {
-        let parent_missing = spec.path.parent().map(|p| !p.exists()).unwrap_or(true);
-        if parent_missing {
-            return make(
-                IdeStatus::Skipped,
-                "config directory not found (client likely not installed)".into(),
-                None,
-            );
-        }
+    // In the auto path (no explicit client), skip user clients we can't detect
+    // as installed. An explicitly-requested client is always wired.
+    if auto_only
+        && spec.scope == Scope::User
+        && !client_installed(
+            spec.kind,
+            spec.scope,
+            &spec.path,
+            std::env::var_os("PATH").as_deref(),
+        )
+    {
+        return make(
+            IdeStatus::Skipped,
+            "client not detected (no CLI on PATH, no config directory)".into(),
+            None,
+        );
     }
 
     let existing = match fs::read_to_string(&spec.path) {
@@ -1850,29 +1915,98 @@ mod tests {
     }
 
     #[test]
-    fn picker_items_marks_user_clients_not_installed_when_parent_missing() {
+    fn picker_items_marks_no_cli_user_client_not_installed_when_parent_missing() {
+        // Claude Desktop has no CLI binary, so detection relies solely on the
+        // config-dir proxy — PATH-independent, unlike CLI clients (claude,
+        // codex, ...) whose installed-ness now depends on the test host's PATH.
         let tmp = tempfile::tempdir().unwrap();
         let homes = HomeDirs {
-            claude_code: tmp.path().join("does/not/exist/claude.json"),
             claude_desktop: tmp.path().join("does/not/exist/desktop.json"),
-            codex: tmp.path().join("does/not/exist/codex.toml"),
-            gemini: tmp.path().join("does/not/exist/gemini.json"),
-            windsurf: tmp.path().join("does/not/exist/windsurf.json"),
-            opencode: tmp.path().join("does/not/exist/opencode.json"),
-            zed: tmp.path().join("does/not/exist/zed.json"),
+            ..HomeDirs::default()
         };
         let items = picker_items(tmp.path(), &homes);
-        for item in &items {
-            for opt in &item.scopes {
-                if opt.scope == Scope::User {
-                    assert!(
-                        !opt.installed,
-                        "{:?} user-scope should be flagged not-installed",
-                        item.kind
-                    );
-                }
-            }
-        }
+        let desktop = items
+            .iter()
+            .find(|i| i.kind == ClientKind::ClaudeDesktop)
+            .unwrap();
+        assert!(
+            !desktop.scopes[0].installed,
+            "Claude Desktop with no config dir should be not-installed"
+        );
+    }
+
+    #[test]
+    fn binary_in_finds_executable_on_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bin");
+        std::fs::create_dir(&dir).unwrap();
+        let exe = if cfg!(windows) {
+            "mytool.exe"
+        } else {
+            "mytool"
+        };
+        std::fs::write(dir.join(exe), b"#!/bin/sh\n").unwrap();
+        let paths = std::env::join_paths([dir.as_path()]).unwrap();
+        assert!(binary_in(&paths, "mytool"), "executable on PATH is found");
+        assert!(
+            !binary_in(&paths, "absent"),
+            "missing executable is not found"
+        );
+    }
+
+    #[test]
+    fn client_installed_is_always_true_for_project_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope/mcp.json");
+        assert!(client_installed(
+            ClientKind::Cursor,
+            Scope::Project,
+            &missing,
+            None
+        ));
+    }
+
+    #[test]
+    fn client_installed_no_cli_client_uses_dir_proxy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let present = tmp.path().join("cfg.json"); // parent (tmp) exists
+        let absent = tmp.path().join("nope/cfg.json"); // parent missing
+                                                       // Claude Desktop has no CLI, so only the dir proxy applies.
+        assert!(client_installed(
+            ClientKind::ClaudeDesktop,
+            Scope::User,
+            &present,
+            None
+        ));
+        assert!(!client_installed(
+            ClientKind::ClaudeDesktop,
+            Scope::User,
+            &absent,
+            None
+        ));
+    }
+
+    #[test]
+    fn client_installed_detects_cli_only_via_injected_path() {
+        // Codex (a CLI client) with a missing config dir is "installed" only
+        // when its binary is on the injected PATH — deterministic, not the host's.
+        let tmp = tempfile::tempdir().unwrap();
+        let bindir = tmp.path().join("bin");
+        std::fs::create_dir(&bindir).unwrap();
+        let exe = if cfg!(windows) { "codex.exe" } else { "codex" };
+        std::fs::write(bindir.join(exe), b"#!/bin/sh\n").unwrap();
+        let with_codex = std::env::join_paths([bindir.as_path()]).unwrap();
+        let empty = std::env::join_paths::<_, &Path>([]).unwrap();
+        let cfg = tmp.path().join("nope/config.toml"); // parent missing
+
+        assert!(
+            client_installed(ClientKind::Codex, Scope::User, &cfg, Some(&with_codex)),
+            "codex on the injected PATH counts as installed"
+        );
+        assert!(
+            !client_installed(ClientKind::Codex, Scope::User, &cfg, Some(&empty)),
+            "no codex on PATH and no config dir → not installed"
+        );
     }
 
     #[test]
@@ -2000,7 +2134,7 @@ mod tests {
         let cfg = tmp.path().join("mcp.json");
         let spec = project_spec(cfg.clone());
 
-        let step = process_spec(&spec, tmp.path(), false, false);
+        let step = process_spec(&spec, tmp.path(), false, false, false);
         assert_eq!(step.status, IdeStatus::Created);
         assert!(cfg.exists(), "config file written to disk");
         let written = fs::read_to_string(&cfg).unwrap();
@@ -2014,9 +2148,9 @@ mod tests {
         let cfg = tmp.path().join("mcp.json");
         let spec = project_spec(cfg);
 
-        let first = process_spec(&spec, tmp.path(), false, false);
+        let first = process_spec(&spec, tmp.path(), false, false, false);
         assert_eq!(first.status, IdeStatus::Created);
-        let second = process_spec(&spec, tmp.path(), false, false);
+        let second = process_spec(&spec, tmp.path(), false, false, false);
         assert_eq!(
             second.status,
             IdeStatus::Unchanged,
@@ -2030,24 +2164,45 @@ mod tests {
         let cfg = tmp.path().join("mcp.json");
         let spec = project_spec(cfg.clone());
 
-        let step = process_spec(&spec, tmp.path(), false, true);
+        let step = process_spec(&spec, tmp.path(), false, true, false);
         assert_eq!(step.status, IdeStatus::Created);
         assert!(step.diff.is_some(), "dry-run carries a before/after diff");
         assert!(!cfg.exists(), "dry-run must not write the file");
     }
 
     #[test]
-    fn process_spec_skips_user_scope_when_parent_missing() {
+    fn process_spec_skips_undetected_user_client_in_auto_mode() {
         let tmp = tempfile::TempDir::new().unwrap();
-        // A user-scoped path whose parent directory does not exist → the
-        // client is treated as not installed and skipped.
+        // Cursor has no CLI binary, and this user-scoped parent dir is absent →
+        // undetected. In auto mode (no explicit client) it is skipped.
         let cfg = tmp.path().join("no-such-dir").join("config.json");
         let mut spec = project_spec(cfg.clone());
         spec.scope = Scope::User;
 
-        let step = process_spec(&spec, tmp.path(), false, false);
+        let step = process_spec(&spec, tmp.path(), false, false, true);
         assert_eq!(step.status, IdeStatus::Skipped);
         assert!(!cfg.exists(), "nothing written for a not-installed client");
+    }
+
+    #[test]
+    fn process_spec_wires_undetected_user_client_when_explicit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Same undetected client, but auto_only = false (the user named it) →
+        // wired regardless of detection. The config dir is absent and is
+        // created from scratch: an explicit `cartog install X` materializes the
+        // client's config even when X isn't installed yet (intended).
+        let cfg = tmp.path().join("brand-new-dir").join("config.json");
+        assert!(!cfg.parent().unwrap().exists(), "parent dir starts absent");
+        let mut spec = project_spec(cfg.clone());
+        spec.scope = Scope::User;
+
+        let step = process_spec(&spec, tmp.path(), false, false, false);
+        assert_eq!(step.status, IdeStatus::Created);
+        assert!(cfg.exists(), "explicitly-requested client is wired");
+        assert!(
+            cfg.parent().unwrap().exists(),
+            "config dir created on demand"
+        );
     }
 
     #[test]
@@ -2057,7 +2212,7 @@ mod tests {
         fs::write(&cfg, "{ this is not valid json").unwrap();
         let spec = project_spec(cfg.clone());
 
-        let step = process_spec(&spec, tmp.path(), false, false);
+        let step = process_spec(&spec, tmp.path(), false, false, false);
         assert_eq!(
             step.status,
             IdeStatus::Skipped,

--- a/crates/cartog/src/commands/ide.rs
+++ b/crates/cartog/src/commands/ide.rs
@@ -920,9 +920,14 @@ fn client_installed(
     if scope == Scope::Project {
         return true;
     }
-    if let (Some(bin), Some(p)) = (client_binary(kind), path_env) {
-        if binary_in(p, bin) {
-            return true;
+    // Only trust a PATH match when we have a real home: `HomeDirs::default()`
+    // (no resolvable home) anchors user paths at "." (relative), and wiring a
+    // config there would litter the cwd. A genuine home path is absolute.
+    if path.is_absolute() {
+        if let (Some(bin), Some(p)) = (client_binary(kind), path_env) {
+            if binary_in(p, bin) {
+                return true;
+            }
         }
     }
     // Fall back to the config-dir proxy (the only signal for GUI-only clients).
@@ -2006,6 +2011,31 @@ mod tests {
         assert!(
             !client_installed(ClientKind::Codex, Scope::User, &cfg, Some(&empty)),
             "no codex on PATH and no config dir → not installed"
+        );
+    }
+
+    #[test]
+    fn client_installed_ignores_path_when_home_is_relative_fallback() {
+        // HomeDirs::default() anchors user paths at "." (relative). A PATH match
+        // must NOT count then — wiring would litter the cwd. The config path is
+        // relative, so even with codex on PATH the client is "not installed".
+        let tmp = tempfile::tempdir().unwrap();
+        let bindir = tmp.path().join("bin");
+        std::fs::create_dir(&bindir).unwrap();
+        let exe = if cfg!(windows) { "codex.exe" } else { "codex" };
+        std::fs::write(bindir.join(exe), b"#!/bin/sh\n").unwrap();
+        let with_codex = std::env::join_paths([bindir.as_path()]).unwrap();
+        // Relative path (the "." fallback shape), parent "." exists but isn't a home.
+        let relative_cfg = Path::new("config.toml");
+
+        assert!(
+            !client_installed(
+                ClientKind::Codex,
+                Scope::User,
+                relative_cfg,
+                Some(&with_codex)
+            ),
+            "PATH match must be ignored when the config path is relative (no real home)"
         );
     }
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -278,11 +278,8 @@ pub fn cmd_index(
     let root = Path::new(path);
     let db = open_db(db_path, embedding_dim)?;
 
-    let spinner = if json {
-        None
-    } else {
-        Spinner::start("Indexing").map(Arc::new)
-    };
+    // Stderr-only; `Spinner::start` self-gates (TTY or CARTOG_PROGRESS), so --json stdout stays clean.
+    let spinner = Spinner::start("Indexing").map(Arc::new);
     let cb = spinner_callback(&spinner, indexer::ProgressUpdate::label);
     let cb_ref: Option<indexer::ProgressCallback<'_>> =
         cb.as_ref().map(|f| f as &(dyn Fn(_) + Send + Sync));
@@ -314,65 +311,7 @@ pub fn cmd_index(
         return Ok(());
     }
 
-    output(&result, json, None, |r| {
-        let lsp_part = if r.edges_lsp_resolved > 0
-            || r.edges_marked_unresolvable > 0
-            || r.edges_marked_external > 0
-        {
-            let mut s = format!(
-                " ({} heuristic + {} LSP",
-                r.edges_resolved, r.edges_lsp_resolved
-            );
-            if r.edges_marked_unresolvable > 0 {
-                s.push_str(&format!(
-                    ", {} marked unresolvable",
-                    r.edges_marked_unresolvable
-                ));
-            }
-            if r.edges_marked_external > 0 {
-                s.push_str(&format!(", {} external", r.edges_marked_external));
-            }
-            s.push(')');
-            s
-        } else {
-            String::new()
-        };
-        let sym_detail = if r.symbols_modified > 0 || r.symbols_unchanged > 0 {
-            format!(
-                " ({} new, {} modified, {} unchanged, {} removed)",
-                r.symbols_added, r.symbols_modified, r.symbols_unchanged, r.symbols_removed
-            )
-        } else {
-            String::new()
-        };
-        let unsupported = if r.files_unsupported > 0 {
-            let breakdown = r
-                .unsupported_by_ext
-                .iter()
-                .take(5)
-                .map(|(ext, n)| format!("{n} .{ext}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!(
-                "\n  {} files in unsupported languages not indexed ({breakdown})",
-                r.files_unsupported
-            )
-        } else {
-            String::new()
-        };
-        format!(
-            "Indexed {} files ({} skipped, {} removed)\n  {} symbols{}, {} edges ({} resolved{}){}\n",
-            r.files_indexed,
-            r.files_skipped,
-            r.files_removed,
-            r.symbols_added + r.symbols_modified + r.symbols_unchanged,
-            sym_detail,
-            r.edges_added,
-            r.edges_resolved + r.edges_lsp_resolved,
-            lsp_part,
-            unsupported,
-        )
-    })
+    output(&result, json, None, indexer::render_index_summary)
 }
 
 /// Show symbols and structure of a file.
@@ -503,6 +442,128 @@ pub fn cmd_impact(
         }
         out
     })
+}
+
+/// Find a call path between two symbols, with each hop's body inline.
+pub fn cmd_trace(
+    db_path: &Path,
+    from: &str,
+    to: &str,
+    depth: u32,
+    json: bool,
+    token_budget: Option<u32>,
+    embedding_dim: usize,
+) -> Result<()> {
+    const MAX_TRACE_DEPTH: u32 = 20;
+    let db = open_db(db_path, embedding_dim)?;
+    let path = db.trace(from, to, depth.min(MAX_TRACE_DEPTH))?;
+    if path.is_some() {
+        db.log_query("trace", "cli");
+    }
+
+    #[derive(Serialize)]
+    struct HydratedHop {
+        source_name: String,
+        target_name: String,
+        kind: cartog_core::EdgeKind,
+        file_path: String,
+        line: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
+    }
+
+    // `{found, hops}` so `--json` distinguishes "no path" (found=false) from
+    // "from == to" (found=true, hops=[]) — matching the cartog_trace MCP shape.
+    #[derive(Serialize)]
+    struct TraceResult {
+        from: String,
+        to: String,
+        found: bool,
+        hops: Vec<HydratedHop>,
+    }
+
+    let hops: Vec<HydratedHop> = path
+        .iter()
+        .flatten()
+        .map(|h| HydratedHop {
+            body: hop_body(&db, &h.source_id),
+            source_name: h.source_name.clone(),
+            target_name: h.target_name.clone(),
+            kind: h.kind,
+            file_path: h.file_path.clone(),
+            line: h.line,
+        })
+        .collect();
+
+    let result = TraceResult {
+        from: from.to_string(),
+        to: to.to_string(),
+        found: path.is_some(),
+        hops,
+    };
+    output(&result, json, token_budget, |r| {
+        if !r.found {
+            return format!(
+                "No call path from '{from}' to '{to}'{}{}{}\n",
+                empty_index_hint(&db),
+                did_you_mean(&db, &r.from),
+                did_you_mean(&db, &r.to),
+            );
+        }
+        if r.hops.is_empty() {
+            return format!("'{}' is the target.\n", r.from);
+        }
+        let mut out = String::new();
+        for hop in &r.hops {
+            out.push_str(&format!(
+                "{src} → {dst}  {file}:{line}\n",
+                src = hop.source_name,
+                dst = hop.target_name,
+                file = hop.file_path,
+                line = hop.line,
+            ));
+            if let Some(body) = &hop.body {
+                out.push_str(body);
+                out.push('\n');
+            }
+        }
+        out
+    })
+}
+
+/// Body of the symbol with id `source_id` — the exact symbol on the call path.
+/// Prefers stored RAG content (redaction-aware), else reads source by byte
+/// range relative to cwd. `None` when neither is available (header-only hop).
+fn hop_body(db: &Database, source_id: &str) -> Option<String> {
+    if let Some((content, _)) = db.get_symbol_content(source_id).ok().flatten() {
+        return Some(content);
+    }
+    let sym = db
+        .get_symbols_by_ids(std::slice::from_ref(&source_id.to_string()))
+        .ok()?
+        .into_iter()
+        .next()?;
+    source_slice(
+        &sym.file_path,
+        sym.start_byte as usize,
+        sym.end_byte as usize,
+    )
+}
+
+/// Read `path` (relative to cwd) and return the `[start, end)` byte slice,
+/// snapped to char boundaries. `None` on any read or range error.
+fn source_slice(path: &str, mut start: usize, mut end: usize) -> Option<String> {
+    let src = std::fs::read_to_string(path).ok()?;
+    if start >= end || end > src.len() {
+        return None;
+    }
+    while start < end && !src.is_char_boundary(start) {
+        start += 1;
+    }
+    while end > start && !src.is_char_boundary(end) {
+        end -= 1;
+    }
+    Some(src[start..end].to_string())
 }
 
 /// All references to a symbol (calls, imports, inherits, references, raises).
@@ -1087,11 +1148,8 @@ pub fn cmd_rag_index(
     db.reconcile_embedding_fingerprint(&rag::fingerprint_of(provider.as_ref()))
         .context("failed to reconcile embedding fingerprint")?;
 
-    let spinner = if json {
-        None
-    } else {
-        Spinner::start("Indexing code graph").map(Arc::new)
-    };
+    // Progress on stderr; `Spinner::start` self-gates (TTY or CARTOG_PROGRESS).
+    let spinner = Spinner::start("Indexing code graph").map(Arc::new);
     let ix_cb = spinner_callback(&spinner, indexer::ProgressUpdate::label);
     let ix_cb_ref: Option<indexer::ProgressCallback<'_>> =
         ix_cb.as_ref().map(|f| f as &(dyn Fn(_) + Send + Sync));
@@ -1100,11 +1158,7 @@ pub fn cmd_rag_index(
     stop_spinner(spinner);
     let _index_result = index_res?;
 
-    let spinner = if json {
-        None
-    } else {
-        Spinner::start("Embedding symbols").map(Arc::new)
-    };
+    let spinner = Spinner::start("Embedding symbols").map(Arc::new);
     let rag_cb = spinner_callback(&spinner, rag::indexer::ProgressUpdate::label);
     let rag_cb_ref: Option<rag::indexer::ProgressCallback<'_>> =
         rag_cb.as_ref().map(|f| f as &(dyn Fn(_) + Send + Sync));
@@ -1216,6 +1270,80 @@ pub fn cmd_rag_search(
                     .collect::<Vec<_>>()
                     .join("\n");
                 out.push_str(&format!("{preview}\n\n"));
+            }
+        }
+        out
+    })
+}
+
+/// Build a token-budgeted task-context bundle for a natural-language task.
+pub fn cmd_context(
+    db_path: &Path,
+    task: &str,
+    tokens: u32,
+    json: bool,
+    provider_config: &rag::EmbeddingProviderConfig,
+    tuning: &rag::search::SearchTuning,
+) -> Result<()> {
+    let mut provider = rag::create_embedding_provider(provider_config)?;
+    let db = open_db(db_path, provider.dimension())?;
+
+    // Build the bundle in its own scope so the provider/reranker borrows end
+    // before the `output` closure (which re-borrows `&db`) runs.
+    let ctx = {
+        let mut reranker = if provider_config.reranker_provider == "none" {
+            None
+        } else {
+            rag::create_reranker_provider(&provider_config.reranker_provider)
+        };
+        let opts = rag::context::ContextOptions {
+            tuning: *tuning,
+            ..Default::default()
+        };
+        // `match` (not `as_deref_mut`) keeps the reranker borrow scoped to the
+        // call so it drops before `output` re-borrows `db`.
+        match reranker.as_mut() {
+            Some(r) => rag::context::build_task_context(
+                &db,
+                task,
+                tokens,
+                provider.as_mut(),
+                Some(r.as_mut()),
+                &opts,
+            ),
+            None => {
+                rag::context::build_task_context(&db, task, tokens, provider.as_mut(), None, &opts)
+            }
+        }?
+    };
+    if !ctx.entries.is_empty() {
+        db.log_query("context", "cli");
+    }
+    let task = task.to_string();
+
+    output(&ctx, json, None, |ctx| {
+        if ctx.entries.is_empty() {
+            return format!("No context found for '{task}'{}\n", empty_index_hint(&db));
+        }
+        let mut out = format!(
+            "Context for '{task}' ({} symbols, ~{} tokens)\n\n",
+            ctx.entries.len(),
+            ctx.approx_tokens
+        );
+        for entry in &ctx.entries {
+            out.push_str(&format!(
+                "[{reason:?}] {kind} {name}  {file}:{line}\n",
+                reason = entry.reason,
+                kind = entry.symbol.kind,
+                name = entry.symbol.name,
+                file = entry.symbol.file_path,
+                line = entry.symbol.start_line,
+            ));
+            if let Some(body) = &entry.content {
+                for l in body.lines() {
+                    out.push_str(&format!("    {l}\n"));
+                }
+                out.push('\n');
             }
         }
         out
@@ -1544,6 +1672,34 @@ def main():
         cmd_impact(&db, "helper", 3, false, None, 384).expect("impact ok");
         cmd_impact(&db, "helper", 3, true, None, 384).expect("impact --json ok");
     }
+
+    #[test]
+    fn cmd_trace_logs_a_query_only_when_a_path_is_found() {
+        let (_tmp, db) = indexed_db();
+        let before = queries_logged(&db);
+        cmd_trace(&db, "speak", "helper", 8, false, None, 384).expect("trace ok");
+        let after_hit = queries_logged(&db);
+        cmd_trace(&db, "speak", "no_such_symbol", 8, false, None, 384)
+            .expect("no-path trace is ok");
+        let after_miss = queries_logged(&db);
+
+        assert_eq!(after_hit, before + 1, "a found path logs one query");
+        assert_eq!(
+            after_miss, after_hit,
+            "a no-path result must not log a query"
+        );
+    }
+
+    #[test]
+    fn cmd_trace_json_branch_does_not_error() {
+        let (_tmp, db) = indexed_db();
+        cmd_trace(&db, "speak", "helper", 8, true, None, 384).expect("trace --json ok");
+    }
+
+    // No CLI test for `cmd_context`: it builds a real embedding provider
+    // (ONNX model), so it can't run model-independently in CI. The fusion
+    // logic is covered by `cartog_rag::context` unit tests (MockEmbeddingProvider)
+    // and the `cartog_context` MCP tool test (test_provider).
 
     #[test]
     fn cmd_hierarchy_plain_json_and_mermaid_branches_do_not_error() {

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -456,6 +456,10 @@ pub fn cmd_trace(
 ) -> Result<()> {
     const MAX_TRACE_DEPTH: u32 = 20;
     let db = open_db(db_path, embedding_dim)?;
+    // `file_path` is stored relative to the index root. The DB lives at
+    // `<root>/.cartog/db.sqlite`, so the root is the db's grandparent — robust
+    // regardless of the cwd `cartog trace` was launched from.
+    let index_root = index_root_from_db_path(db_path);
     let path = db.trace(from, to, depth.min(MAX_TRACE_DEPTH))?;
     if path.is_some() {
         db.log_query("trace", "cli");
@@ -486,7 +490,7 @@ pub fn cmd_trace(
         .iter()
         .flatten()
         .map(|h| HydratedHop {
-            body: hop_body(&db, &h.source_id),
+            body: hop_body(&db, &index_root, &h.source_id),
             source_name: h.source_name.clone(),
             target_name: h.target_name.clone(),
             kind: h.kind,
@@ -531,10 +535,22 @@ pub fn cmd_trace(
     })
 }
 
+/// Index root for a DB at `<root>/.cartog/db.sqlite` — the db's grandparent.
+/// Falls back to the db's own parent (legacy `.cartog.db` layout), then `.`.
+fn index_root_from_db_path(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .and_then(Path::parent)
+        .or_else(|| db_path.parent())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 /// Body of the symbol with id `source_id` — the exact symbol on the call path.
 /// Prefers stored RAG content (redaction-aware), else reads source by byte
-/// range relative to cwd. `None` when neither is available (header-only hop).
-fn hop_body(db: &Database, source_id: &str) -> Option<String> {
+/// range from `root`-relative `file_path`. `None` when neither is available
+/// (header-only hop).
+fn hop_body(db: &Database, root: &Path, source_id: &str) -> Option<String> {
     if let Some((content, _)) = db.get_symbol_content(source_id).ok().flatten() {
         return Some(content);
     }
@@ -544,16 +560,18 @@ fn hop_body(db: &Database, source_id: &str) -> Option<String> {
         .into_iter()
         .next()?;
     source_slice(
+        root,
         &sym.file_path,
         sym.start_byte as usize,
         sym.end_byte as usize,
     )
 }
 
-/// Read `path` (relative to cwd) and return the `[start, end)` byte slice,
-/// snapped to char boundaries. `None` on any read or range error.
-fn source_slice(path: &str, mut start: usize, mut end: usize) -> Option<String> {
-    let src = std::fs::read_to_string(path).ok()?;
+/// Read `path` (resolved against `root`; absolute paths pass through) and return
+/// the `[start, end)` byte slice, snapped to char boundaries. `None` on any read
+/// or range error.
+fn source_slice(root: &Path, path: &str, mut start: usize, mut end: usize) -> Option<String> {
+    let src = std::fs::read_to_string(root.join(path)).ok()?;
     if start >= end || end > src.len() {
         return None;
     }
@@ -1396,6 +1414,27 @@ pub use self_cmd::{
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn index_root_is_db_grandparent() {
+        // New layout: <root>/.cartog/db.sqlite → root.
+        let root = index_root_from_db_path(Path::new("/proj/.cartog/db.sqlite"));
+        assert_eq!(root, Path::new("/proj"));
+    }
+
+    #[test]
+    fn source_slice_resolves_relative_path_against_root() {
+        // file_path is stored relative to the index root; reading must join it
+        // to the root, not the process cwd.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("a.py"), "def f():\n    return 1\n").unwrap();
+        // Byte range covering "def f()".
+        let body = source_slice(root, "a.py", 0, 7).expect("reads relative to root");
+        assert_eq!(body, "def f()");
+        // A path that doesn't exist under root → None (not a cwd-relative read).
+        assert!(source_slice(root, "missing.py", 0, 5).is_none());
+    }
 
     #[test]
     fn capitalized_index_phase_labels() {

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -195,6 +195,23 @@ fn main() -> Result<()> {
             token_budget,
             embedding_dim,
         ),
+        Command::Context { task, tokens } => commands::cmd_context(
+            &db_path,
+            &task,
+            tokens,
+            cli.json,
+            &provider_config,
+            &search_tuning,
+        ),
+        Command::Trace { from, to, depth } => commands::cmd_trace(
+            &db_path,
+            &from,
+            &to,
+            depth,
+            cli.json,
+            token_budget,
+            embedding_dim,
+        ),
         Command::Refs { name, kind } => {
             commands::cmd_refs(&db_path, &name, kind, cli.json, token_budget, embedding_dim)
         }

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -53,7 +53,7 @@ Each link goes to that crate's `README.md`, which has the detailed responsibilit
 - **[cartog-watch](../crates/cartog-watch/README.md)** — debounced file watcher (`notify-debouncer-mini`), incremental re-index, deferred RAG embedding.
 - **[cartog-mcp](../crates/cartog-mcp/README.md)** — MCP server over stdio (`rmcp`). 13 tool handlers, single-writer election (primary + read-only attach + promotion).
 - **[cartog-process-lock](../crates/cartog-process-lock/README.md)** — cross-platform PID-file locks (`<state_dir>/{slot}.pid`). Two-line format with `is_same_process(pid, start_time)` to close the PID-reuse window. Used by `cartog serve`, `cartog watch`, and `cartog self update`.
-- **[cartog](../crates/cartog/README.md)** — binary crate: 23 top-level CLI commands via clap (including `cartog push`/`pull` for S3 index sync and `cartog self update/version/rollback/migrate-db`), config resolution, logging, tokio runtime for `cartog serve`, daily background update probe.
+- **[cartog](../crates/cartog/README.md)** — binary crate: 25 top-level CLI commands via clap (including `cartog trace`/`context` for call paths and task-context bundles, `cartog push`/`pull` for S3 index sync, and `cartog self update/version/rollback/migrate-db`), config resolution, logging, tokio runtime for `cartog serve`, daily background update probe.
 
 ## Conventions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -375,15 +375,19 @@ want to edit by hand or audit what cartog wrote.
 | `cartog_refs` | `name`, `kind?` | All references to a symbol |
 | `cartog_callees` | `name` | What a symbol calls |
 | `cartog_impact` | `name`, `depth?` | Transitive impact analysis |
+| `cartog_trace` | `from`, `to`, `depth?` | Shortest call path between two symbols, bodies inline |
+| `cartog_context` | `task`, `tokens?` | One-shot task bundle: relevant symbols + bodies |
 | `cartog_hierarchy` | `name` | Inheritance tree |
 | `cartog_deps` | `file` | File-level imports |
 | `cartog_stats` | — | Index summary |
 | `cartog_map` | `tokens?` | Token-budget-aware codebase summary (file tree + top symbols by centrality) |
 | `cartog_changes` | `commits?`, `kind?` | Symbols affected by recent git changes |
-| `cartog_rag_index` | `path?`, `force?` | Build embedding index for semantic search |
+| `cartog_rag_index` | `path?`, `force?` | Build embedding index for semantic search (write) |
 | `cartog_rag_search` | `query`, `kind?`, `limit?` | Semantic search (FTS5 + vector + re-ranking) |
+| `cartog_update` | `version?` | Arm a deferred self-update (write; touches the state file, not the index) |
 
-All tool responses are JSON.
+Read tools (everything except `cartog_index`, `cartog_rag_index`, and `cartog_update`)
+carry an `outputSchema` and return `structuredContent`. All tool responses also include a JSON text block.
 
 **Path restriction**: `cartog_index` and `cartog_rag_index` reject paths outside the project directory (CWD subtree). Agents cannot index arbitrary filesystem locations.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -296,7 +296,9 @@ bash skills/cartog/scripts/ensure_indexed.sh
 
 ## MCP Server
 
-`cartog serve` runs cartog as an MCP server over stdio, exposing 14 tools for MCP-compatible clients (Claude Code, Cursor, Windsurf, etc.). Each tool carries a human-readable `title` and a `readOnlyHint` annotation: 11 query tools are read-only; `cartog_index` and `cartog_rag_index` write the index; and `cartog_update` arms a deferred self-update (`readOnlyHint = false` because it writes the machine-level state file, but it never touches the index). Clients can skip approval prompts for the read-only ones.
+`cartog serve` runs cartog as an MCP server over stdio, exposing 16 tools for MCP-compatible clients (Claude Code, Cursor, Windsurf, etc.). Each tool carries a human-readable `title` and a `readOnlyHint` annotation: 13 query tools are read-only (including `cartog_trace` for call paths and `cartog_context` for one-shot task bundles); `cartog_index` and `cartog_rag_index` write the index; and `cartog_update` arms a deferred self-update (`readOnlyHint = false` because it writes the machine-level state file, but it never touches the index). Clients can skip approval prompts for the read-only ones.
+
+When `cartog serve --watch` is running and a file changes (or RAG embeddings are still catching up), affected read-tool responses are prefixed with a `⚠️` staleness banner so the agent knows the answer may be momentarily behind the working tree. Read-only secondaries and `cartog serve` without `--watch` never show the banner.
 
 Read tools also declare an `outputSchema` and return `structuredContent` (the typed result mirrored alongside the human-readable text block) so schema-aware clients get validated, machine-readable output. To keep responses within the caller's context window, the size cap (`CARTOG_MCP_MAX_BYTES`, default 64 KB) counts the text block plus the structured copy: `structuredContent` is dropped when the combined size would exceed the cap (and when the text block itself is truncated, which adds a truncation notice).
 
@@ -967,8 +969,8 @@ When `--watch` is passed, a background file watcher keeps the code graph up to d
 Opening two Claude Code windows on the same project (or running `cartog serve` in a terminal while a Claude Code window has its own MCP child) is supported via **single-writer election**:
 
 - The first instance acquires `<state_dir>/serve-<hash>.pid` atomically (O_EXCL) and runs as **primary** — owns the file watcher, exposes all 13 MCP tools. The `<hash>` is a 16-char SHA-256 prefix of the canonical DB path, so two cartog peers on different projects coexist without colliding on the same slot.
-- Subsequent instances see the held lock, attach **read-only** (no migrations), and expose 12 of 14 tools. The two indexing tools (`cartog_index`, `cartog_rag_index`) return a clear error pointing at the primary; queries (`cartog_search`, `cartog_rag_search`, etc.) and `cartog_update` (which arms a machine-level deferred update, not a DB write) work normally. `cartog_stats` includes `"role": "read-only"` so you can tell which is which.
-- If the primary process dies (Cmd-Q, `kill`, crash), the secondary's background promoter detects this within ~10s, validates the on-disk schema hasn't drifted, atomically acquires the lock, and takes over without restart. All 14 tools become available on what was the secondary.
+- Subsequent instances see the held lock, attach **read-only** (no migrations), and expose 14 of 16 tools. The two indexing tools (`cartog_index`, `cartog_rag_index`) return a clear error pointing at the primary; queries (`cartog_search`, `cartog_rag_search`, etc.) and `cartog_update` (which arms a machine-level deferred update, not a DB write) work normally. `cartog_stats` includes `"role": "read-only"` so you can tell which is which.
+- If the primary process dies (Cmd-Q, `kill`, crash), the secondary's background promoter detects this within ~10s, validates the on-disk schema hasn't drifted, atomically acquires the lock, and takes over without restart. All 16 tools become available on what was the secondary.
 
 Escape hatches:
 

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -339,11 +339,11 @@ cartog serve --watch --rag    <span class="comment"># + watcher + deferred seman
 
         <table>
           <thead>
-            <tr><th>Field</th><th>Read tools (search, refs, map, …)</th><th>Write tools (<code>cartog_index</code>, <code>cartog_rag_index</code>)</th></tr>
+            <tr><th>Field</th><th>Read tools (search, refs, trace, context, map, …)</th><th>Write tools (<code>cartog_index</code>, <code>cartog_rag_index</code>, <code>cartog_update</code>)</th></tr>
           </thead>
           <tbody>
             <tr><td><code>title</code></td><td>e.g. "Search symbols", "Find references"</td><td>e.g. "Index codebase"</td></tr>
-            <tr><td><code>readOnlyHint</code></td><td><code>true</code> — client can run without an approval prompt</td><td><code>false</code> — mutates the index</td></tr>
+            <tr><td><code>readOnlyHint</code></td><td><code>true</code> — client can run without an approval prompt</td><td><code>false</code> — mutates state (<code>cartog_update</code> writes the machine-level update file, not the index)</td></tr>
             <tr><td><code>openWorldHint</code></td><td><code>false</code> — closed domain (the local index)</td><td><code>false</code></td></tr>
             <tr><td><code>outputSchema</code></td><td>present — typed result schema</td><td>—</td></tr>
           </tbody>

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -51,6 +51,7 @@ import Base from "../layouts/Base.astro";
             <a href="#cmd-changes">cartog changes</a>
             <a href="#cmd-completions">cartog completions</a>
             <a href="#cmd-config">cartog config</a>
+            <a href="#cmd-context">cartog context</a>
             <a href="#cmd-deps">cartog deps</a>
             <a href="#cmd-doctor">cartog doctor</a>
             <a href="#cmd-hierarchy">cartog hierarchy</a>
@@ -67,6 +68,7 @@ import Base from "../layouts/Base.astro";
             <a href="#cmd-serve">cartog serve</a>
             <a href="#cmd-stats">cartog stats</a>
             <a href="#cmd-savings">cartog savings</a>
+            <a href="#cmd-trace">cartog trace</a>
             <a href="#cmd-watch">cartog watch</a>
           </details>
           <details class="sidebar-group">
@@ -300,14 +302,14 @@ cartog rag search "deployment architecture" --kind document</pre>
         <pre>/plugin install cartog@cartog-plugins</pre>
 
         <h2 id="mcp-server">MCP Server</h2>
-        <p><code>cartog serve</code> runs cartog as a <a href="https://modelcontextprotocol.io">Model Context Protocol</a> server over stdio, exposing the code graph as 13 tools any MCP-compatible client (Claude Code, Cursor, VS Code, Codex CLI, …) can call. No HTTP port, no daemon to manage — the client launches <code>cartog serve</code> as a subprocess and talks JSON-RPC over stdin/stdout.</p>
+        <p><code>cartog serve</code> runs cartog as a <a href="https://modelcontextprotocol.io">Model Context Protocol</a> server over stdio, exposing the code graph as 16 tools any MCP-compatible client (Claude Code, Cursor, VS Code, Codex CLI, …) can call. No HTTP port, no daemon to manage — the client launches <code>cartog serve</code> as a subprocess and talks JSON-RPC over stdin/stdout.</p>
         <pre>cartog serve                  <span class="comment"># MCP server only</span>
 cartog serve --watch          <span class="comment"># + background file watcher (auto re-index)</span>
 cartog serve --watch --rag    <span class="comment"># + watcher + deferred semantic embedding</span></pre>
         <p>Most users never run <code>cartog serve</code> by hand: <a href="#mcp-quickstart"><code>cartog ide</code></a> writes it into your editor's MCP config and the editor spawns it on demand. Run it directly only when wiring a client cartog doesn't know about, or to debug the JSON-RPC stream.</p>
 
-        <h3 id="mcp-tools">The 13 tools</h3>
-        <p>11 are read-only (safe to run without an approval prompt); 2 mutate the index. Each ships with a description telling the agent <em>when</em> to reach for it.</p>
+        <h3 id="mcp-tools">The 16 tools</h3>
+        <p>13 are read-only (safe to run without an approval prompt); 2 mutate the index and 1 arms a deferred self-update. Each ships with a description telling the agent <em>when</em> to reach for it.</p>
         <table>
           <thead>
             <tr><th>Tool</th><th>Kind</th><th>Description</th></tr>
@@ -315,22 +317,25 @@ cartog serve --watch --rag    <span class="comment"># + watcher + deferred seman
           <tbody>
             <tr><td><code>cartog_index</code></td><td>write</td><td>Build/update the code graph</td></tr>
             <tr><td><code>cartog_map</code></td><td>read</td><td>Codebase orientation: file list + top symbols (call first in a new repo)</td></tr>
+            <tr><td><code>cartog_context</code></td><td>read</td><td>One-shot task bundle: relevant symbols + bodies for a task</td></tr>
             <tr><td><code>cartog_search</code></td><td>read</td><td>Find symbols by partial name</td></tr>
             <tr><td><code>cartog_outline</code></td><td>read</td><td>File structure (symbols, line ranges)</td></tr>
             <tr><td><code>cartog_refs</code></td><td>read</td><td>All references to a symbol</td></tr>
             <tr><td><code>cartog_callees</code></td><td>read</td><td>What a symbol calls</td></tr>
             <tr><td><code>cartog_impact</code></td><td>read</td><td>Transitive impact analysis</td></tr>
+            <tr><td><code>cartog_trace</code></td><td>read</td><td>Shortest call path between two symbols, bodies inline</td></tr>
             <tr><td><code>cartog_hierarchy</code></td><td>read</td><td>Inheritance tree</td></tr>
             <tr><td><code>cartog_deps</code></td><td>read</td><td>File-level imports</td></tr>
             <tr><td><code>cartog_stats</code></td><td>read</td><td>Index summary</td></tr>
             <tr><td><code>cartog_changes</code></td><td>read</td><td>Symbols affected by recent git changes</td></tr>
             <tr><td><code>cartog_rag_index</code></td><td>write</td><td>Build embedding index</td></tr>
             <tr><td><code>cartog_rag_search</code></td><td>read</td><td>Semantic search</td></tr>
+            <tr><td><code>cartog_update</code></td><td>write</td><td>Arm a deferred self-update</td></tr>
           </tbody>
         </table>
 
         <h3 id="mcp-tool-shape">Tool metadata &amp; output</h3>
-        <p>Every tool ships with MCP <strong>annotations</strong> (a human-readable <code>title</code> and behavior <em>hints</em>), and the 11 read-only tools declare an <code>outputSchema</code>. Clients use these to label tools in their picker and to skip approval prompts for tools that can't change anything.</p>
+        <p>Every tool ships with MCP <strong>annotations</strong> (a human-readable <code>title</code> and behavior <em>hints</em>), and the 13 read-only tools declare an <code>outputSchema</code>. Clients use these to label tools in their picker and to skip approval prompts for tools that can't change anything.</p>
 
         <table>
           <thead>
@@ -603,6 +608,29 @@ ExpiredTokenError auth/tokens.py:50</pre>
     calls  auth_required.wrapper     auth/middleware.py:21
     calls  get_current_user          auth/middleware.py:61</pre>
         <p>Answers "what breaks if I change this?".</p>
+
+        <h2 id="cmd-trace"><code>cartog trace &lt;from&gt; &lt;to&gt; [--depth N]</code></h2>
+        <p>Find the shortest call path between two symbols, with each hop's body inline — answers "how does A reach B?". Follows only statically-resolved <code>calls</code> edges (dynamic dispatch is not traced); default depth 8.</p>
+        <pre>cartog trace handle_request validate_token</pre>
+        <p class="example-label">Example output</p>
+        <pre class="example-output">handle_request → authenticate  api/routes.py:31
+    def handle_request(req):
+        return authenticate(req.user, req.token)
+authenticate → validate_token  auth/service.py:18
+    def authenticate(user, token):
+        return validate_token(token)</pre>
+
+        <h2 id="cmd-context"><code>cartog context &lt;task&gt; [--tokens N]</code></h2>
+        <p>Build a one-shot context bundle for a task: semantic-search seeds, their 1-hop call neighbors, and high-centrality definitions in the same files — bodies inline, trimmed to a token budget (default 6000). The single call an agent makes to scope a task.</p>
+        <pre>cartog context "validate an auth token" --tokens 6000</pre>
+        <p class="example-label">Example output</p>
+        <pre class="example-output">Context for 'validate an auth token' (5 symbols, ~520 tokens)
+
+[Seed] function validate_token  auth/tokens.py:10
+    def validate_token(token: str) -&gt; bool:
+        ...
+[Neighbor] function generate_token  auth/tokens.py:20
+[Central] class AuthService  auth/service.py:1</pre>
 
         <h2 id="cmd-hierarchy"><code>cartog hierarchy &lt;class&gt; [--mermaid]</code></h2>
         <p>Show inheritance relationships — both parents and children. Add <code>--mermaid</code> for a <code>graph TD</code> diagram you can paste into a PR description, doc, or mermaid.live.</p>


### PR DESCRIPTION
## Summary

Tier 1 of the CodeGraph competitive analysis (`docs/competitive-analysis.md`): two new agent-facing tools, watch-time staleness signalling, and lower onboarding friction. No dependencies added; 16 MCP tools / 25 CLI commands now.

## What's new

- **`cartog_trace` (CLI + MCP)** — shortest `calls` path between two symbols, each hop's body inline. Bounded BFS (visited `HashSet`, O(V+E)); hop bodies resolved by exact symbol id. `--json` returns `{from, to, found, hops}` so an empty path (`from == to`) is distinguishable from no path.
- **`cartog_context` (CLI + MCP)** — one-shot task bundle fusing hybrid-search seeds + 1-hop call neighbors (calls edges only) + seed-file centrality, ranked and hydrated within a token budget. Routes through semantic search.
- **Staleness banners** — `cartog serve --watch` publishes a lock-light `StaleState` (monotonic seq counters, exact across same-second change/reindex). The MCP response layer prepends a `⚠️` banner to affected read-tool responses; gated on a live watcher (read-only peers / watcherless serve show nothing), banner bytes reserved under the size cap.
- **Onboarding** — index/rag-index progress now visible under `--json` (stderr, self-gated on TTY/`CARTOG_PROGRESS`); shared `render_index_summary` for CLI + MCP; `cartog ide` detects installed clients via PATH (PATHEXT-aware) or config dir, auto-wiring only detected user clients while an explicit `--client` always wires.

## Quality

- Adversarial pre-commit review surfaced 16 findings (incl. a `UNION ALL` exponential blowup in the original trace CTE — empirically 57M rows on a 13-node graph); **all 16 fixed** with regression tests. The trace CTE was rewritten as a bounded Rust BFS.
- `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` clean · `cargo test --workspace` **1191 passed**, 1 pre-existing ignored (+9 new regression tests).
- Docs synced: AGENTS.md, docs/usage.md, docs/structure.md, both crate READMEs, and the Astro site usage page.

## Test plan

- New unit/integration tests cover: trace shortest-path/cycle-termination/comma-in-id/exact-source-id, context neighbor-kind-filtering/budget-priority/dedup, staleness seq semantics + banner cap, IDE PATH detection.
- End-to-end smoke: `cartog trace`, `cartog context`, `--json` shapes, and the `--watch` staleness banner all verified against fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cartog trace` command to discover shortest call paths between two symbols.
  * Added `cartog context` command for building token-budgeted task-aware context bundles.
  * MCP server now exposes 16 tools (up from 14), including new trace and context tools.
  * Added staleness awareness in watch mode—responses display a banner when catching up to changes.

* **Documentation**
  * Updated CLI and MCP documentation for 25 commands and expanded tool set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->