### PR TITLE
feat(edges): record resolution provenance per edge

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -92,9 +92,9 @@ const SQL_INSERT_SYMBOL: &str = "INSERT OR REPLACE INTO symbols
       parent_id, signature, visibility, is_async, docstring, content_hash, subtree_hash)
      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)";
 
-const SQL_INSERT_EDGE: &str =
-    "INSERT INTO edges (source_id, target_name, target_id, kind, file_path, line, resolution_source)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
+const SQL_INSERT_EDGE: &str = "INSERT INTO edges
+     (source_id, target_name, target_id, kind, file_path, line, resolution_state, resolution_source)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
 
 const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS symbols (
@@ -611,7 +611,12 @@ fn migrate(conn: &Connection) {
     // tier, so they stay NULL ("unknown / pre-provenance") rather than guess a sentinel.
     if current < 6 || !has_resolution_source {
         info!("schema v6: adding edges.resolution_source column");
-        let _ = conn.execute("ALTER TABLE edges ADD COLUMN resolution_source TEXT", []);
+        // Surface a failed ALTER (matches the schema-version write below): the
+        // probe guard re-runs the migration on the next open, so this is logged
+        // rather than fatal, consistent with the other additive migrations.
+        if let Err(e) = conn.execute("ALTER TABLE edges ADD COLUMN resolution_source TEXT", []) {
+            warn!(error = %e, "failed to add edges.resolution_source column");
+        }
     }
 
     // Store the new schema version
@@ -4598,9 +4603,33 @@ mod tests {
         edge.target_id = Some(target.id.clone());
         edge.provenance = Some(EdgeProvenance::Lsp);
         db.insert_edge(&edge).unwrap();
+        let eid = db.conn.last_insert_rowid();
 
         let callees = db.callees("process").unwrap();
         assert_eq!(callees[0].provenance, Some(EdgeProvenance::Lsp));
+        // An inserted edge that already has a target must persist resolution_state=1,
+        // not the column default 0 — else stats()/unresolved_edges() misreport it.
+        assert_eq!(resolution_state_of(&db, eid), 1);
+        assert!(
+            !db.unresolved_edges()
+                .unwrap()
+                .iter()
+                .any(|e| e.edge_id == eid),
+            "a resolved insert must not resurface as unresolved"
+        );
+    }
+
+    #[test]
+    fn insert_edge_without_target_is_unresolved() {
+        // The extraction path inserts edges with no target_id; they must land at
+        // resolution_state=0 so resolve_edges()/LSP pick them up.
+        let db = Database::open_memory().unwrap();
+        let src = test_symbol("src", SymbolKind::Function, "a.py", 1);
+        db.insert_symbols(std::slice::from_ref(&src)).unwrap();
+        db.insert_edge(&Edge::new(&src.id, "missing", EdgeKind::Calls, "a.py", 1))
+            .unwrap();
+        let eid = db.conn.last_insert_rowid();
+        assert_eq!(resolution_state_of(&db, eid), 0);
     }
 
     #[test]

--- a/crates/cartog-db/src/store/crud.rs
+++ b/crates/cartog-db/src/store/crud.rs
@@ -411,6 +411,7 @@ impl Database {
             edge.kind.as_str(),
             edge.file_path,
             edge.line,
+            i64::from(edge.target_id.is_some()),
             edge.provenance.map(|p| p.as_str()),
         ])?;
         Ok(())
@@ -436,6 +437,7 @@ impl Database {
                 edge.kind.as_str(),
                 edge.file_path,
                 edge.line,
+                i64::from(edge.target_id.is_some()),
                 edge.provenance.map(|p| p.as_str()),
             ])?;
         }

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -250,7 +250,8 @@ The database is a regenerable index — crash-recovery safety is traded for thro
 │   file_path, lines,    target_name,   hash,    value)    │
 │   signature,           target_id,     lang)              │
 │   content_hash,        kind, line,                       │
-│   subtree_hash, ...)   resolution_state)                 │
+│   subtree_hash, ...)   resolution_state,                 │
+│                        resolution_source)                │
 ├──────────────────────────────────────────────────────────┤
 │ RAG tables                                               │
 │                                                          │


### PR DESCRIPTION
## Summary

Tag each resolved edge with **which tier/source resolved it**, surfaced as `provenance` in `--json`/MCP output (refs/callees/impact/deps). A finer-grained trust signal than CodeGraph's coarse `provenance:'heuristic'`: cartog names the exact heuristic tier or LSP outcome.

## What's in it

- **`EdgeProvenance` enum** (cartog-core): `same_file` / `import_path` / `same_dir` / `parent_scope` / `unique_global` / `kind_disambig` + `lsp` / `lsp_external` / `lsp_unresolvable`. `as_str`/`FromStr`/`Display` mirror `EdgeKind`; persisted as the `edges.resolution_source` TEXT column.
- **Schema v6**: additive, nullable, probe-guarded migration; pre-v6 rows stay `NULL`.
- **Tagging**: tier 5/6 returns `(id, provenance)` from one match so the label can't drift from the decision; LSP overwrites the heuristic tag; deletion/invalidate/reset paths clear the source so a re-resolved edge re-tags cleanly.
- **Read-back** via a shared `edge_from_row(row, base)` helper used by all edge mappers, with warn-on-unknown decode for both kind and provenance.

## Fix included (dbcaae8)

`SQL_INSERT_EDGE` wrote `resolution_source` but **not** `resolution_state`, so edges inserted with a `target_id` (LSP / reconstruction path) fell back to the column default `0` (unresolved) and would resurface in `unresolved_edges()`/`stats()`. Now binds `resolution_state` explicitly from `target_id.is_some()` on both insert paths. Also logs a failed `resolution_source` ALTER instead of swallowing it, matching the other additive migrations.

## Tests

enum round-trip, per-tier tagging (incl. parent_scope), LSP outcomes + overwrite, deletion/reset clearing, callees/impact read-back, insert round-trip (resolved → state 1, in/out of `unresolved_edges()`), unresolved insert → state 0, v5→v6 migration + self-heal, and JSON present/omitted.

## Verification

- `cargo test -p cartog-db` — 168 passed
- `cargo fmt --check` — clean
- `cargo clippy -p cartog-db --all-targets -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database migration failures now logged instead of silently ignored for better error visibility

* **New Features**
  * Edges now explicitly track resolution state and source during insertion

* **Documentation**
  * Updated schema documentation to reflect edge resolution metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->