### PR TITLE
feat(site): horizontal feature cards + fix mobile overflow

### DIFF
--- a/site/public/style.css
+++ b/site/public/style.css
@@ -544,6 +544,30 @@ section + section {
   line-height: 1.6;
 }
 
+/* Horizontal variant: icon left, title + copy right (see #features). */
+.feature-card--row {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.feature-card--row .feature-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  border-radius: 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+}
+
+.feature-card--row h3 {
+  margin-bottom: 6px;
+}
+
 .feature-card code {
   font-size: 12px;
   background: var(--bg-tertiary);
@@ -635,7 +659,8 @@ section + section {
   margin-top: 32px;
   border: 1px solid var(--border);
   border-radius: 12px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 table {
@@ -941,7 +966,29 @@ td .badge {
 
   .install-widget code {
     font-size: 12px;
+    white-space: normal;
     word-break: break-all;
+  }
+
+  /* Wide comparison tables scroll sideways within their box. Always show the
+     scrollbar so the swipe affordance is visible (cell backgrounds occlude a
+     background-fade, so the scrollbar is the honest cue). */
+  .table-wrapper {
+    scrollbar-width: thin;
+    scrollbar-color: var(--accent) var(--bg-tertiary);
+  }
+
+  .table-wrapper::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  .table-wrapper::-webkit-scrollbar-track {
+    background: var(--bg-tertiary);
+  }
+
+  .table-wrapper::-webkit-scrollbar-thumb {
+    background: var(--accent);
+    border-radius: 8px;
   }
 
   .stats-bar .container {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -183,29 +183,47 @@ import { withBase } from "../lib/url";
       <p class="section-subtitle">Single binary, zero config, zero dependencies.</p>
 
       <div class="features-grid" style="margin-top: 40px;">
-        <div class="feature-card" data-reveal style="--reveal-delay: 0s;">
-          <h3><span class="feature-icon">⚡</span> Zero dependencies</h3>
-          <p>Single binary + SQLite file. No Docker, no language servers required, no graph databases. <code>cargo install</code> and you're done.</p>
+        <div class="feature-card feature-card--row" data-reveal style="--reveal-delay: 0s;">
+          <span class="feature-icon">⚡</span>
+          <div>
+            <h3>Zero dependencies</h3>
+            <p>Single binary + SQLite file. No Docker, no language servers required, no graph databases. <code>cargo install</code> and you're done.</p>
+          </div>
         </div>
-        <div class="feature-card" data-reveal style="--reveal-delay: 0.06s;">
-          <h3><span class="feature-icon">🔄</span> Live index</h3>
-          <p><code>cartog watch</code> auto re-indexes on file changes. Debounced, incremental, near-instant. Always query fresh data.</p>
+        <div class="feature-card feature-card--row" data-reveal style="--reveal-delay: 0.06s;">
+          <span class="feature-icon">🔄</span>
+          <div>
+            <h3>Live index</h3>
+            <p><code>cartog watch</code> auto re-indexes on file changes. Debounced, incremental, near-instant. Always query fresh data.</p>
+          </div>
         </div>
-        <div class="feature-card" data-reveal style="--reveal-delay: 0.12s;">
-          <h3><span class="feature-icon">🔍</span> Dual search</h3>
-          <p>Keyword search (sub-ms, symbol names) + semantic search (natural language). Local embeddings with optional GPU acceleration via Ollama.</p>
+        <div class="feature-card feature-card--row" data-reveal style="--reveal-delay: 0.12s;">
+          <span class="feature-icon">🔍</span>
+          <div>
+            <h3>Dual search</h3>
+            <p>Keyword search (sub-ms, symbol names) + semantic search (natural language). Local embeddings with optional GPU acceleration via Ollama.</p>
+          </div>
         </div>
-        <div class="feature-card" data-reveal style="--reveal-delay: 0.18s;">
-          <h3><span class="feature-icon">🎯</span> Impact analysis</h3>
-          <p><code>cartog impact --depth 3</code> traces callers-of-callers instantly. Know the blast radius before you change anything.</p>
+        <div class="feature-card feature-card--row" data-reveal style="--reveal-delay: 0.18s;">
+          <span class="feature-icon">🎯</span>
+          <div>
+            <h3>Impact analysis</h3>
+            <p><code>cartog impact --depth 3</code> traces callers-of-callers instantly. Know the blast radius before you change anything.</p>
+          </div>
         </div>
-        <div class="feature-card" data-reveal style="--reveal-delay: 0.24s;">
-          <h3><span class="feature-icon">🔬</span> LSP precision, built in</h3>
-          <p>Auto-detects language servers on PATH. Boosts edge resolution from ~25% to ~44–81%. Works without them, better with them.</p>
+        <div class="feature-card feature-card--row" data-reveal style="--reveal-delay: 0.24s;">
+          <span class="feature-icon">🔬</span>
+          <div>
+            <h3>LSP precision, built in</h3>
+            <p>Auto-detects language servers on PATH. Boosts edge resolution from ~25% to ~44–81%. Works without them, better with them.</p>
+          </div>
         </div>
-        <div class="feature-card" data-reveal style="--reveal-delay: 0.3s;">
-          <h3><span class="feature-icon">🔒</span> 100% local</h3>
-          <p>tree-sitter parsing, SQLite storage, local embeddings. No API keys, no telemetry. Secrets are redacted and sensitive files (.env, keys) skipped before they reach the index. Works in air-gapped environments.</p>
+        <div class="feature-card feature-card--row" data-reveal style="--reveal-delay: 0.3s;">
+          <span class="feature-icon">🔒</span>
+          <div>
+            <h3>100% local</h3>
+            <p>tree-sitter parsing, SQLite storage, local embeddings. No API keys, no telemetry. Secrets are redacted and sensitive files (.env, keys) skipped before they reach the index. Works in air-gapped environments.</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Redesign the landing-page **Features** cards to a horizontal icon-left / text-right layout (matching a reference design), and fix pre-existing **mobile horizontal-overflow** bugs found along the way.

## Changes

**Feature cards (`#features`)**
- Restructured the 6 cards to icon-left / title+description-right.
- Emoji icons kept, now in a 44×44 bordered/tinted box (`.feature-card--row`).
- Existing `.feature-card` (How-it-works / MCP cards) untouched.

**Mobile overflow fixes** (the page scrolled sideways on mobile — three separate pre-existing causes)
- **Comparison tables** (`.table-wrapper`): `overflow: hidden` → `overflow-x: auto` so the table scrolls *inside its box* instead of widening the page. Text stays full-size and legible.
- **Install widgets** (`.install-widget code`): added `white-space: normal` so the long `curl … | sh` command wraps (`word-break: break-all` alone was suppressed by the base `white-space: nowrap`).
- **Scroll affordance**: accent-green scrollbar on mobile tables so the swipe cue is visible (the table's opaque cell backgrounds occlude a background-fade).

## Verification

| Viewport | Page horizontal overflow | Notes |
|----------|--------------------------|-------|
| 375px (mobile) | **0** | tables scroll in-box w/ accent scrollbar; install widgets wrap; feature cards single-column |
| 1280px (desktop) | **0** | tables fit (no scrollbar); 6 feature cards in row layout |

- `npm run build` passes.
- Verified in-browser at both breakpoints (no element bleeds past the viewport).

## Notes

- `.astro` source + `site/public/style.css` edited only; the Pages workflow rebuilds `site/dist`.
- Pure presentation change — no docs/facts/counts affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned feature cards to display in a horizontal layout with optimized spacing and icon positioning
  * Improved comparison table scrolling behavior with visible scrollbars for better mobile and responsive experiences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->