### PR TITLE
fix(ide): add VS Code user scope, correct Antigravity path

### DIFF
--- a/crates/cartog/src/commands/ide.rs
+++ b/crates/cartog/src/commands/ide.rs
@@ -549,6 +549,12 @@ const CLIENT_CATALOGUE: &[CatalogueEntry] = &[
         args_kind: ArgsKind::Serve,
     },
     CatalogueEntry {
+        kind: ClientKind::Vscode,
+        scope: Scope::User,
+        strategy: MergeStrategy::VsCodeServers,
+        args_kind: ArgsKind::Serve,
+    },
+    CatalogueEntry {
         kind: ClientKind::ClaudeDesktop,
         scope: Scope::User,
         strategy: MergeStrategy::McpServers,
@@ -663,7 +669,9 @@ fn user_path(kind: ClientKind, home: &HomeDirs) -> Option<PathBuf> {
         ClientKind::Hermes => Some(home.hermes.clone()),
         ClientKind::Kiro => Some(home.kiro.clone()),
         // Project-only clients have no user-scope analogue.
-        ClientKind::Cursor | ClientKind::Vscode => None,
+        ClientKind::Vscode => Some(home.vscode.clone()),
+        // Cursor is project-scope only in cartog's catalogue.
+        ClientKind::Cursor => None,
     }
 }
 
@@ -717,6 +725,7 @@ pub struct HomeDirs {
     pub antigravity: PathBuf,
     pub hermes: PathBuf,
     pub kiro: PathBuf,
+    pub vscode: PathBuf,
 }
 
 impl Default for HomeDirs {
@@ -736,7 +745,8 @@ impl Default for HomeDirs {
             zed: stub.clone(),
             antigravity: stub.clone(),
             hermes: stub.clone(),
-            kiro: stub,
+            kiro: stub.clone(),
+            vscode: stub,
         }
     }
 }
@@ -768,6 +778,10 @@ impl HomeDirs {
             xdg_config.join("Claude/claude_desktop_config.json")
         };
 
+        // <config>/Code/User: Library/Application Support (macOS), %APPDATA%
+        // (Windows), ~/.config (Linux) — VS Code uses config_dir, not xdg_config.
+        let vscode = base.config_dir().join("Code/User/mcp.json");
+
         HomeDirs {
             claude_code: home.join(".claude/settings.json"),
             claude_desktop,
@@ -776,9 +790,10 @@ impl HomeDirs {
             windsurf: home.join(".codeium/windsurf/mcp_config.json"),
             opencode: xdg_config.join("opencode/opencode.json"),
             zed: xdg_config.join("zed/settings.json"),
-            antigravity: home.join(".gemini/antigravity/mcp_config.json"),
+            antigravity: home.join(".gemini/config/mcp_config.json"),
             hermes: home.join(".hermes/config.yaml"),
             kiro: home.join(".kiro/settings/mcp.json"),
+            vscode,
         }
     }
 }
@@ -1793,8 +1808,8 @@ mod tests {
         let specs = build_specs(None, IdeScope::All, false, &tmp, &homes);
         // Project: claude-code, cursor, vscode, kiro (4)
         // User: claude-code, claude-desktop, codex, gemini, opencode, windsurf, zed,
-        //       antigravity, kiro, hermes (10)
-        assert_eq!(specs.len(), 14);
+        //       antigravity, kiro, hermes, vscode (11)
+        assert_eq!(specs.len(), 15);
     }
 
     #[test]
@@ -1822,6 +1837,45 @@ mod tests {
         let scopes: Vec<_> = specs.iter().map(|s| s.scope).collect();
         assert!(scopes.contains(&Scope::Project));
         assert!(scopes.contains(&Scope::User));
+    }
+
+    #[test]
+    fn build_specs_vscode_filter_returns_project_and_user() {
+        let tmp = std::env::temp_dir();
+        let homes = HomeDirs {
+            vscode: tmp.join("Code/User/mcp.json"),
+            ..HomeDirs::default()
+        };
+        let specs = build_specs(
+            Some(ClientKind::Vscode),
+            IdeScope::All,
+            false,
+            tmp.as_path(),
+            &homes,
+        );
+        let scopes: Vec<_> = specs.iter().map(|s| s.scope).collect();
+        assert!(
+            scopes.contains(&Scope::Project),
+            "vscode missing project scope"
+        );
+        assert!(scopes.contains(&Scope::User), "vscode missing user scope");
+        let user = specs
+            .iter()
+            .find(|s| s.scope == Scope::User)
+            .expect("vscode user spec");
+        assert!(user.path.ends_with("Code/User/mcp.json"));
+        assert_eq!(user.strategy, MergeStrategy::VsCodeServers);
+    }
+
+    #[test]
+    fn detect_vscode_user_path_under_config_dir() {
+        // VS Code's user mcp.json lives at <config>/Code/User/mcp.json on every OS.
+        let homes = HomeDirs::detect();
+        assert!(
+            homes.vscode.ends_with("Code/User/mcp.json"),
+            "unexpected vscode user path: {}",
+            homes.vscode.display()
+        );
     }
 
     #[test]
@@ -1853,7 +1907,8 @@ mod tests {
         assert!(kinds.contains(&ClientKind::Cursor));
         assert!(kinds.contains(&ClientKind::Vscode));
         assert!(kinds.contains(&ClientKind::Codex));
-        assert_eq!(chosen.len(), 3);
+        // Cursor (1) + VS Code project+user (2) + Codex (1) = 4.
+        assert_eq!(chosen.len(), 4);
     }
 
     #[test]
@@ -2013,8 +2068,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let homes = HomeDirs::default();
         let items = picker_items(tmp.path(), &homes);
-        // Claude Code and Kiro are the only dual-scope clients (project + user).
-        let dual_scope = [ClientKind::ClaudeCode, ClientKind::Kiro];
+        // Claude Code, Kiro and VS Code are the dual-scope clients (project + user).
+        let dual_scope = [ClientKind::ClaudeCode, ClientKind::Kiro, ClientKind::Vscode];
         for item in &items {
             if !dual_scope.contains(&item.kind) {
                 assert_eq!(

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -180,8 +180,14 @@ Edit `~/.gemini/settings.json`:
 
 ## VS Code (GitHub Copilot)
 
-Edit `.vscode/mcp.json` in your project root (per-workspace) — note that
-VS Code's top-level key is `servers` (no `Mcp` prefix):
+Two scopes — `cartog ide` (or `cartog install vscode`) writes both:
+
+- **Project**: `.vscode/mcp.json` in your repo root (per-workspace).
+- **User** (every workspace): `Code/User/mcp.json` under the VS Code config dir —
+  `~/Library/Application Support/Code/User/mcp.json` (macOS),
+  `~/.config/Code/User/mcp.json` (Linux), `%APPDATA%\Code\User\mcp.json` (Windows).
+
+Note that VS Code's top-level key is `servers` (no `Mcp` prefix):
 
 ```json
 {
@@ -195,10 +201,14 @@ VS Code's top-level key is `servers` (no `Mcp` prefix):
 }
 ```
 
+If VS Code is launched from Finder/Dock (not a terminal), it may not have your
+shell `PATH`, so a bare `"command": "cartog"` can fail to spawn. Use the absolute
+path (e.g. `"command": "/Users/you/.local/bin/cartog"`) if the server won't start.
+
 ## Antigravity
 
-Edit `~/.gemini/antigravity/mcp_config.json` (user-global; Antigravity has no
-per-project config):
+Edit `~/.gemini/config/mcp_config.json` (user-global, shared by Antigravity 2.0,
+IDE and CLI; no per-project config):
 
 ```json
 {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -324,10 +324,10 @@ cartog ide --dry-run                # preview without writing
 ```
 
 Supported clients (matches the per-client list below): `claude-code` (project
-+ user), `claude-desktop`, `codex`, `cursor`, `gemini`, `opencode`, `vscode`,
-`windsurf`, `zed`, `antigravity`, `kiro` (project + user), `hermes`. User-scope
-clients whose config directory does not exist are skipped (treated as "not
-installed").
++ user), `claude-desktop`, `codex`, `cursor`, `gemini`, `opencode`, `vscode`
+(project + user), `windsurf`, `zed`, `antigravity`, `kiro` (project + user),
+`hermes`. User-scope clients whose config directory does not exist are skipped
+(treated as "not installed").
 
 Codex stores all MCP servers in a single user-global `~/.codex/config.toml`,
 so cartog writes one per-project section named `cartog-<slug>-<hash8>` (slug
@@ -1039,7 +1039,7 @@ Dry run only. Re-run without --dry-run to apply.
 
 For `cartog ide --client claude-code --dry-run`, both project (`.mcp.json`) and user (`~/.claude/settings.json`) entries are previewed, and `args` includes `--watch` by default ([see why](#claude-code-watch-default)).
 
-Supported clients: `claude-code` (project + user), `claude-desktop`, `codex`, `cursor`, `gemini`, `opencode`, `vscode`, `windsurf`, `zed`, `antigravity`, `kiro` (project + user), `hermes`. User-scope clients whose config dir is missing are skipped. See [Per-editor wiring: `cartog ide`](#per-editor-wiring-cartog-ide) for the flag and troubleshooting tables.
+Supported clients: `claude-code` (project + user), `claude-desktop`, `codex`, `cursor`, `gemini`, `opencode`, `vscode` (project + user), `windsurf`, `zed`, `antigravity`, `kiro` (project + user), `hermes`. User-scope clients whose config dir is missing are skipped. See [Per-editor wiring: `cartog ide`](#per-editor-wiring-cartog-ide) for the flag and troubleshooting tables.
 
 ### `cartog install [client ...] [--scope ...] [--dry-run] [--no-watch]`
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -422,7 +422,7 @@ import { withBase } from "../lib/url";
             <img class="editor-mark" src={withBase("assets/cursor.svg?v=2")} alt="">
             Cursor
           </span>
-          <span class="lang-tag" title="VS Code — project-scoped (.vscode/mcp.json)">
+          <span class="lang-tag" title="VS Code — project (.vscode/mcp.json) + user (Code/User/mcp.json)">
             <img class="editor-mark" src={withBase("assets/visualstudiocode.svg?v=2")} alt="">
             VS Code
           </span>
@@ -450,7 +450,7 @@ import { withBase } from "../lib/url";
             <img class="editor-mark" src={withBase("assets/zedindustries.svg?v=2")} alt="">
             Zed
           </span>
-          <span class="lang-tag" title="Antigravity — user-scope (~/.gemini/antigravity/mcp_config.json)">
+          <span class="lang-tag" title="Antigravity — user-scope (~/.gemini/config/mcp_config.json)">
             <img class="editor-mark" src={withBase("assets/antigravity.svg?v=2")} alt="">
             Antigravity
           </span>
@@ -465,7 +465,7 @@ import { withBase } from "../lib/url";
         </div>
 
         <p style="font-size: 13px; color: var(--text-tertiary); margin-top: 16px; text-align: center;">
-          Claude Code, Cursor, VS Code, and Kiro get project-scoped MCP files in your repo; the rest get user-scope configs in your home directory. Only editors actually installed are touched.
+          Claude Code, VS Code, and Kiro get both project-scoped MCP files in your repo and user-scope configs; Cursor is project-scoped; the rest get user-scope configs in your home directory. Only editors actually installed are touched.
         </p>
       </div>
 
@@ -532,7 +532,7 @@ import { withBase } from "../lib/url";
       </div>
 
       <p style="margin-top: 16px; font-size: 14px; color: var(--text-secondary);">
-        See <a href={withBase("usage.html#mcp-server")}>MCP Server docs</a> and <a href={withBase("usage.html#agent-skill")}>Agent Skill docs</a> for per-client setup. Supported clients: Claude Code (project + user), Claude Desktop, Codex CLI, Cursor, Gemini CLI, OpenCode, VS Code, Windsurf, Zed, Antigravity, Kiro (project + user), Hermes Agent.
+        See <a href={withBase("usage.html#mcp-server")}>MCP Server docs</a> and <a href={withBase("usage.html#agent-skill")}>Agent Skill docs</a> for per-client setup. Supported clients: Claude Code (project + user), Claude Desktop, Codex CLI, Cursor, Gemini CLI, OpenCode, VS Code (project + user), Windsurf, Zed, Antigravity, Kiro (project + user), Hermes Agent.
       </p>
     </div>
   </section>

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -498,7 +498,7 @@ cartog ide --scope project          <span class="comment"># .mcp.json, .cursor/,
 cartog ide --scope user             <span class="comment"># user-scope clients only</span>
 cartog ide --client cursor          <span class="comment"># one client</span>
 cartog ide --dry-run                <span class="comment"># preview with before/after diff</span></pre>
-        <p>Clients: <code>claude-code</code> (project + user), <code>claude-desktop</code>, <code>codex</code>, <code>cursor</code>, <code>gemini</code>, <code>opencode</code>, <code>vscode</code>, <code>windsurf</code>, <code>zed</code>, <code>antigravity</code>, <code>kiro</code> (project + user), <code>hermes</code>. User-scope clients whose config directory is missing are skipped (treated as "not installed"). Codex stores all servers in one global <code>~/.codex/config.toml</code>, so cartog writes a per-project <code>[mcp_servers.cartog-&lt;slug&gt;-&lt;hash8&gt;]</code> section. Idempotent: existing servers in each file are preserved.</p>
+        <p>Clients: <code>claude-code</code> (project + user), <code>claude-desktop</code>, <code>codex</code>, <code>cursor</code>, <code>gemini</code>, <code>opencode</code>, <code>vscode</code> (project + user), <code>windsurf</code>, <code>zed</code>, <code>antigravity</code>, <code>kiro</code> (project + user), <code>hermes</code>. User-scope clients whose config directory is missing are skipped (treated as "not installed"). Codex stores all servers in one global <code>~/.codex/config.toml</code>, so cartog writes a per-project <code>[mcp_servers.cartog-&lt;slug&gt;-&lt;hash8&gt;]</code> section. Idempotent: existing servers in each file are preserved.</p>
         <p><strong>Known limitation:</strong> configs containing JSON-with-comments (JSONC) are left untouched and reported as skipped. Configure those clients manually using the snippets below.</p>
 
         <h3 id="mcp-ide">Bootstrap sequence</h3>
@@ -558,9 +558,9 @@ args = ["serve"]</pre>
         </details>
 
         <details class="mcp-client">
-          <summary><strong>VS Code (Copilot)</strong> — <code>.vscode/mcp.json</code></summary>
+          <summary><strong>VS Code (Copilot)</strong> — project <code>.vscode/mcp.json</code> + user <code>Code/User/mcp.json</code></summary>
           <pre>cartog ide --client vscode</pre>
-          <p>Note: top-level key is <code>servers</code>, not <code>mcpServers</code>.</p>
+          <p>Writes both scopes: project <code>.vscode/mcp.json</code> and the user file under VS Code's config dir (<code>~/Library/Application Support/Code/User/mcp.json</code> on macOS, <code>~/.config/Code/User/mcp.json</code> on Linux, <code>%APPDATA%\Code\User\mcp.json</code> on Windows). Top-level key is <code>servers</code>, not <code>mcpServers</code>.</p>
           <pre>&#123;
   "servers": &#123;
     "cartog": &#123; "type": "stdio", "command": "cartog", "args": ["serve"] &#125;
@@ -614,9 +614,9 @@ args = ["serve"]</pre>
         </details>
 
         <details class="mcp-client">
-          <summary><strong>Antigravity</strong> — <code>~/.gemini/antigravity/mcp_config.json</code></summary>
+          <summary><strong>Antigravity</strong> — <code>~/.gemini/config/mcp_config.json</code></summary>
           <pre>cartog ide --client antigravity</pre>
-          <p>User-global only (no per-project config).</p>
+          <p>User-global only, shared by Antigravity 2.0, IDE and CLI (no per-project config).</p>
           <pre>&#123;
   "mcpServers": &#123;
     "cartog": &#123; "command": "cartog", "args": ["serve"] &#125;


### PR DESCRIPTION
## Summary

Two `cartog ide` MCP-path bugs found while investigating why VS Code MCP didn't work despite a config file being present.

### 1. VS Code had no user scope
VS Code was **project-scope only**, so `cartog ide` never wrote a global MCP config — only `<repo>/.vscode/mcp.json`. Running it from a subdirectory (e.g. `site/`) put the entry somewhere VS Code never reads when you open the repo root.

**Fix:** added a `Scope::User` entry resolved via `BaseDirs::config_dir().join("Code/User/mcp.json")`, correct on every OS:
- macOS: `~/Library/Application Support/Code/User/mcp.json`
- Linux: `~/.config/Code/User/mcp.json`
- Windows: `%APPDATA%\Code\User\mcp.json`

### 2. Antigravity path was wrong
cartog wrote `~/.gemini/antigravity/mcp_config.json`, which Antigravity does **not** read. Corrected to `~/.gemini/config/mcp_config.json` (shared by Antigravity 2.0, IDE and CLI per official docs).

## Audit

While here, verified all other user-scope client paths against official docs — **no other changes needed**: OpenCode (`~/.config/opencode/opencode.json`), Codex, Gemini, Windsurf, Zed, Kiro, Claude Code/Desktop, Hermes all correct.

## Tests / verification

- New tests: VS Code dual-scope resolution + per-OS `Code/User/mcp.json` suffix.
- Updated 3 catalogue-count assertions (VS Code is now dual-scope).
- `cargo test -p cartog`: **287 pass**; `fmt` + `clippy -D warnings` clean.
- Verified live: `cartog ide --client vscode --scope all --dry-run` shows both scopes; Antigravity dry-run resolves to `~/.gemini/config/mcp_config.json`.

## Docs / site

`docs/mcp-setup.md`, `docs/usage.md`, `site/src/pages/{index,usage}.astro` updated: VS Code marked `project + user` (with per-OS user path + the GUI-launch PATH caveat), Antigravity path corrected. Site builds (`npm run build`).