### PR TITLE
feat(rag): allow capping ONNX intra-op threads for local provider

### DIFF
--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -935,7 +935,8 @@ impl CartogServer {
             .map_err(|e| anyhow::anyhow!("failed to load embedding model: {e}"))?;
         db.reconcile_embedding_fingerprint(&rag::fingerprint_of(provider.as_ref()))
             .map_err(|e| anyhow::anyhow!("failed to reconcile embedding fingerprint: {e}"))?;
-        let reranker = rag::create_reranker_provider(&rag_config.reranker_provider);
+        let reranker =
+            rag::create_reranker_provider(&rag_config.reranker_provider, rag_config.intra_threads);
         Self::from_parts(db, provider, reranker, redact, Role::Primary)
     }
 
@@ -954,7 +955,8 @@ impl CartogServer {
             .map_err(|e| anyhow::anyhow!("failed to open database read-only: {e}"))?;
         let provider = rag::create_embedding_provider(&rag_config)
             .map_err(|e| anyhow::anyhow!("failed to load embedding model: {e}"))?;
-        let reranker = rag::create_reranker_provider(&rag_config.reranker_provider);
+        let reranker =
+            rag::create_reranker_provider(&rag_config.reranker_provider, rag_config.intra_threads);
         Self::from_parts(db, provider, reranker, redact, Role::ReadOnly)
     }
 

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -51,6 +51,9 @@ pub struct EmbeddingProviderConfig {
     pub base_url: Option<String>,
     /// Reranker provider: "local" (default) or "none".
     pub reranker_provider: String,
+    /// Optional cap on ONNX intra-op threads for the local provider. None =
+    /// fastembed's default (all cores). `CARTOG_ONNX_THREADS` overrides this.
+    pub intra_threads: Option<usize>,
 }
 
 impl Default for EmbeddingProviderConfig {
@@ -63,6 +66,7 @@ impl Default for EmbeddingProviderConfig {
             document_prefix: None,
             base_url: None,
             reranker_provider: "local".to_string(),
+            intra_threads: None,
         }
     }
 }
@@ -88,6 +92,7 @@ pub fn create_embedding_provider(
                 config.model.as_deref(),
                 config.query_prefix.clone(),
                 config.document_prefix.clone(),
+                config.intra_threads,
             )?;
             Ok(Box::new(provider))
         }
@@ -143,11 +148,16 @@ pub fn create_default_embedding_provider() -> anyhow::Result<Box<dyn provider::E
 /// Returns `None` if re-ranking is disabled, the model is unavailable, or the feature is off.
 pub fn create_reranker_provider(
     reranker_provider: &str,
+    intra_threads: Option<usize>,
 ) -> Option<Box<dyn provider::RerankerProvider>> {
+    // `intra_threads` is only consumed by the local provider; without that
+    // feature it would trip `-D unused-variables`.
+    #[cfg(not(feature = "provider-local"))]
+    let _ = intra_threads;
     match reranker_provider {
         "none" => None,
         #[cfg(feature = "provider-local")]
-        "local" => match providers::local::LocalRerankerProvider::load() {
+        "local" => match providers::local::LocalRerankerProvider::load(intra_threads) {
             Ok(r) => Some(Box::new(r)),
             Err(e) => {
                 tracing::warn!(error = %e, "Cross-encoder not available, skipping re-ranking");
@@ -166,7 +176,7 @@ pub fn create_reranker_provider(
 
 /// Create the default local reranker provider (BGE-reranker-base).
 pub fn create_default_reranker_provider() -> Option<Box<dyn provider::RerankerProvider>> {
-    create_reranker_provider("local")
+    create_reranker_provider("local", None)
 }
 
 // ── Local ONNX model cache management (provider-local only) ──

--- a/crates/cartog-rag/src/providers/local.rs
+++ b/crates/cartog-rag/src/providers/local.rs
@@ -7,6 +7,37 @@ use crate::provider::{EmbeddingProvider, RerankerProvider};
 
 const EMBED_BATCH_SIZE: usize = 64;
 
+/// Optional cap on ONNX intra-op threads. `None` leaves fastembed's default
+/// (all cores); `Some(n)` caps it. Precedence: `CARTOG_ONNX_THREADS` env >
+/// `configured` (`[embedding.local] intra_threads`). Read at provider load.
+fn onnx_intra_threads(configured: Option<usize>) -> Option<usize> {
+    resolve_intra_threads(
+        std::env::var("CARTOG_ONNX_THREADS").ok().as_deref(),
+        configured,
+    )
+}
+
+/// Pure resolver for [`onnx_intra_threads`], split out so tests don't mutate the
+/// process environment. A `Some(0)` or unparseable env/config value is ignored.
+fn resolve_intra_threads(env: Option<&str>, configured: Option<usize>) -> Option<usize> {
+    if let Some(n) = env.and_then(|v| v.trim().parse::<usize>().ok()) {
+        if n >= 1 {
+            return Some(n);
+        }
+    }
+    configured.filter(|&n| n >= 1)
+}
+
+/// Apply an optional intra-op thread cap to a fastembed init builder.
+macro_rules! with_optional_threads {
+    ($opts:expr, $cap:expr) => {
+        match $cap {
+            Some(n) => $opts.with_intra_threads(n),
+            None => $opts,
+        }
+    };
+}
+
 /// Local ONNX embedding provider via fastembed.
 pub struct LocalEmbeddingProvider {
     model: TextEmbedding,
@@ -25,6 +56,7 @@ impl LocalEmbeddingProvider {
         model_name: Option<&str>,
         query_prefix: Option<String>,
         document_prefix: Option<String>,
+        intra_threads: Option<usize>,
     ) -> Result<Self> {
         let embedding_model = match model_name {
             Some(name) => name
@@ -51,12 +83,12 @@ impl LocalEmbeddingProvider {
             info!("Downloading embedding model (first time only)...");
         }
 
-        let model = TextEmbedding::try_new(
-            TextInitOptions::new(embedding_model)
-                .with_cache_dir(model_cache_dir())
-                .with_show_download_progress(true),
-        )
-        .context("Failed to initialize embedding model")?;
+        let opts = with_optional_threads!(
+            TextInitOptions::new(embedding_model).with_cache_dir(model_cache_dir()),
+            onnx_intra_threads(intra_threads)
+        );
+        let model = TextEmbedding::try_new(opts.with_show_download_progress(true))
+            .context("Failed to initialize embedding model")?;
 
         Ok(Self {
             model,
@@ -140,19 +172,31 @@ pub struct LocalRerankerProvider {
 }
 
 impl LocalRerankerProvider {
-    pub fn load() -> Result<Self> {
+    /// Load the local ONNX cross-encoder re-ranker (BGE-reranker-base), fetching
+    /// the weights into the model cache on first use.
+    ///
+    /// `intra_threads` is an optional cap on the ONNX intra-op thread count. The
+    /// effective cap is resolved as `CARTOG_ONNX_THREADS` env var > this argument
+    /// (the TOML `[embedding.local] intra_threads`); when neither is set the
+    /// session is left uncapped (fastembed's default — all available cores).
+    ///
+    /// Returns `Err` if the model weights cannot be downloaded or the ONNX
+    /// session fails to initialize; callers treat this as "re-ranking
+    /// unavailable" and fall back to RRF-only ordering.
+    pub fn load(intra_threads: Option<usize>) -> Result<Self> {
         if crate::is_reranker_model_cached() {
             info!("Loading reranker model...");
         } else {
             info!("Downloading reranker model (~1.1GB, first time only)...");
         }
 
-        let model = fastembed::TextRerank::try_new(
+        let opts = with_optional_threads!(
             fastembed::RerankInitOptions::new(fastembed::RerankerModel::BGERerankerBase)
-                .with_cache_dir(model_cache_dir())
-                .with_show_download_progress(true),
-        )
-        .context("Failed to initialize cross-encoder model")?;
+                .with_cache_dir(model_cache_dir()),
+            onnx_intra_threads(intra_threads)
+        );
+        let model = fastembed::TextRerank::try_new(opts.with_show_download_progress(true))
+            .context("Failed to initialize cross-encoder model")?;
 
         Ok(Self { model })
     }
@@ -220,5 +264,25 @@ mod tests {
             info.model_code, debug_repr,
             "model_code must be the HF path, not the Rust variant name"
         );
+    }
+
+    #[test]
+    fn intra_threads_resolves_env_over_toml_else_none() {
+        // Pure resolver — no process-env mutation, so this is parallel-safe.
+        // None means "leave fastembed's default" (all cores), the desired baseline.
+        assert_eq!(resolve_intra_threads(None, None), None);
+
+        // TOML cap used when env is unset.
+        assert_eq!(resolve_intra_threads(None, Some(4)), Some(4));
+        // 0 / invalid TOML is ignored -> no cap.
+        assert_eq!(resolve_intra_threads(None, Some(0)), None);
+
+        // Env caps and overrides TOML.
+        assert_eq!(resolve_intra_threads(Some("3"), Some(8)), Some(3));
+        assert_eq!(resolve_intra_threads(Some(" 2 "), None), Some(2));
+
+        // Invalid / zero env falls back to TOML, then None.
+        assert_eq!(resolve_intra_threads(Some("0"), Some(8)), Some(8));
+        assert_eq!(resolve_intra_threads(Some("garbage"), None), None);
     }
 }

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1229,7 +1229,8 @@ pub fn cmd_rag_search(
         None
     } else {
         let name = provider_config.reranker_provider.clone();
-        Some(move || rag::create_reranker_provider(&name))
+        let threads = provider_config.intra_threads;
+        Some(move || rag::create_reranker_provider(&name, threads))
     };
     let search_result = rag::search::hybrid_search_tuned_lazy(
         &db,
@@ -1312,7 +1313,10 @@ pub fn cmd_context(
         let mut reranker = if provider_config.reranker_provider == "none" {
             None
         } else {
-            rag::create_reranker_provider(&provider_config.reranker_provider)
+            rag::create_reranker_provider(
+                &provider_config.reranker_provider,
+                provider_config.intra_threads,
+            )
         };
         let opts = rag::context::ContextOptions {
             tuning: *tuning,

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -204,6 +204,10 @@ pub struct LocalEmbeddingConfig {
     pub query_prefix: Option<String>,
     /// Prefix prepended to text during indexing (e.g. "search_document: ").
     pub document_prefix: Option<String>,
+    /// Optional cap on ONNX intra-op threads for indexing/reranking. None =
+    /// all cores (fastembed default). `CARTOG_ONNX_THREADS` overrides; read at
+    /// provider load (restart `serve` to change it).
+    pub intra_threads: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -256,9 +260,13 @@ pub fn to_redaction_config(config: &CartogConfig) -> cartog_indexer::RedactionCo
 pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProviderConfig {
     match &config.embedding {
         Some(embed) => {
-            let (query_prefix, document_prefix) = match &embed.local {
-                Some(local) => (local.query_prefix.clone(), local.document_prefix.clone()),
-                None => (None, None),
+            let (query_prefix, document_prefix, intra_threads) = match &embed.local {
+                Some(local) => (
+                    local.query_prefix.clone(),
+                    local.document_prefix.clone(),
+                    local.intra_threads,
+                ),
+                None => (None, None, None),
             };
             let ollama = embed.ollama.as_ref();
             cartog_rag::EmbeddingProviderConfig {
@@ -276,6 +284,7 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
                     .as_ref()
                     .map(|r| r.provider().to_string())
                     .unwrap_or_else(|| DEFAULT_RERANKER_PROVIDER.to_string()),
+                intra_threads,
             }
         }
         None => cartog_rag::EmbeddingProviderConfig::default(),

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,7 +131,14 @@ model = "BAAI/bge-base-en-v1.5"    # any fastembed built-in model
 [embedding.local]
 query_prefix = "search_query: "     # for asymmetric models
 document_prefix = "search_document: "
+intra_threads = 4                   # cap ONNX CPU threads (default: all cores)
 ```
+
+`intra_threads` **caps** the ONNX Runtime threads used while embedding
+(`rag index`) and reranking. Default: **all cores** (fastembed's default); set
+this to leave headroom on a busy machine (e.g. `intra_threads = 4`). The
+`CARTOG_ONNX_THREADS` env var overrides it (e.g. `CARTOG_ONNX_THREADS=1`); env >
+TOML > uncapped. Read at provider load, so restart `cartog serve` to change it.
 
 **Disable re-ranking** (saves ~1.1GB model download):
 
@@ -167,6 +174,21 @@ cargo install cartog                                    # default: LSP + S3 sync
 cargo install cartog --no-default-features              # minimal: drops LSP, S3 sync, and Ollama
 cargo install cartog --no-default-features --features lsp  # selective: LSP only
 ```
+
+### Environment variables
+
+Runtime overrides (per-machine / per-invocation), in addition to `.cartog.toml`:
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `CARTOG_DB` | auto-detect | Database path (same as `--db`). |
+| `CARTOG_ONNX_THREADS` | all cores | Caps ONNX CPU threads for `rag index` + reranking. Overrides `[embedding.local] intra_threads`. `1` forces single-core. |
+| `CARTOG_SINGLE_WRITER` | `1` | `0` disables MCP single-writer election (every `cartog serve` opens read-write). |
+| `CARTOG_MCP_MAX_BYTES` | `65536` | Max bytes per MCP tool response before truncation. |
+| `CARTOG_NO_UPDATE_CHECK` | unset | Set to skip the background self-update check. |
+| `CARTOG_UPDATE_CHECK` | unset | Force an update check regardless of cadence. |
+| `CARTOG_INSTALL_DIR` | `~/.local/bin` | Install location used by `install.sh`. |
+| `CARTOG_VERSION` | latest | Pin the version `install.sh` fetches. |
 
 ---
 

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -186,6 +186,24 @@ path = "~/.local/share/cartog/myproject.db"
 provider = "ollama"              <span class="comment"># default is "local"</span></pre>
         <p>Database path resolution priority: <code>--db</code> flag / <code>CARTOG_DB</code> env > <code>.cartog.toml</code> > git root auto-detection > cwd fallback.</p>
 
+        <h3 id="config-env">Environment variables</h3>
+        <p>Runtime overrides (per-machine / per-invocation), in addition to <code>.cartog.toml</code>:</p>
+        <table class="config-table">
+          <thead>
+            <tr><th>Variable</th><th>Default</th><th>Effect</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>CARTOG_DB</code></td><td>auto-detect</td><td>Database path (same as <code>--db</code>).</td></tr>
+            <tr><td><code>CARTOG_ONNX_THREADS</code></td><td>all cores</td><td>Caps ONNX CPU threads for <code>rag index</code> + reranking. Overrides <code>[embedding.local] intra_threads</code>; <code>1</code> forces single-core.</td></tr>
+            <tr><td><code>CARTOG_SINGLE_WRITER</code></td><td><code>1</code></td><td><code>0</code> disables MCP single-writer election (every <code>serve</code> opens read-write).</td></tr>
+            <tr><td><code>CARTOG_MCP_MAX_BYTES</code></td><td><code>65536</code></td><td>Max bytes per MCP tool response before truncation.</td></tr>
+            <tr><td><code>CARTOG_NO_UPDATE_CHECK</code></td><td>unset</td><td>Set to skip the background self-update check.</td></tr>
+            <tr><td><code>CARTOG_UPDATE_CHECK</code></td><td>unset</td><td>Force an update check regardless of cadence.</td></tr>
+            <tr><td><code>CARTOG_INSTALL_DIR</code></td><td><code>~/.local/bin</code></td><td>Install location used by <code>install.sh</code>.</td></tr>
+            <tr><td><code>CARTOG_VERSION</code></td><td>latest</td><td>Pin the version <code>install.sh</code> fetches.</td></tr>
+          </tbody>
+        </table>
+
         <details class="mcp-client">
           <summary><strong>Example <code>.cartog.toml</code></strong> — every section, with defaults annotated (read it, don't copy it wholesale)</summary>
           <pre><span class="comment"># Every key below shows its DEFAULT value. Delete any line you don't</span>
@@ -198,6 +216,9 @@ path = ".cartog/db.sqlite"        <span class="comment"># DEFAULT (relative to g
 provider = "local"               <span class="comment"># DEFAULT — "local" (ONNX) or "ollama"</span>
 model = "BAAI/bge-small-en-v1.5" <span class="comment"># DEFAULT for the local provider</span>
 # dimension = 384                <span class="comment"># auto-detected for built-in models</span>
+
+[embedding.local]                <span class="comment"># only used when provider = "local"</span>
+# intra_threads = 4              <span class="comment"># cap ONNX CPU threads (DEFAULT: all cores); CARTOG_ONNX_THREADS overrides</span>
 
 [embedding.ollama]               <span class="comment"># only used when provider = "ollama"</span>
 base_url = "http://localhost:11434"


### PR DESCRIPTION
## What

Add an optional **cap** on the ONNX Runtime intra-op threads used by the local embedding and reranker models (`rag index` + reranking), so users can leave CPU headroom on a busy machine.

- Cap via `[embedding.local] intra_threads` (TOML) or the `CARTOG_ONNX_THREADS` env var.
- Precedence: **env > TOML > uncapped**.
- **Default is unchanged**: when unset, fastembed's default (all cores) is left intact, so out-of-the-box throughput is not affected.

## Why

fastembed 5.x already defaults to all cores. There was no way to *reduce* ONNX CPU usage when indexing a large repo on a shared/laptop machine. This adds that knob without touching the fast default path.

## How

- New `intra_threads: Option<usize>` on `EmbeddingProviderConfig` and `[embedding.local]`, plumbed to both `LocalEmbeddingProvider` and `LocalRerankerProvider`.
- `resolve_intra_threads(env, configured) -> Option<usize>`: pure resolver (testable without mutating process env). `Some(0)`/unparseable values are ignored → uncapped.
- The cap is applied with a small `with_optional_threads!` macro: `Some(n)` → `.with_intra_threads(n)`, `None` → leave the builder untouched.
- `create_reranker_provider` gains the param; cfg-gated so `--no-default-features` (no `provider-local`) stays warning-clean.
- Cap is read at provider load → restart `serve` to change it (documented).

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` ✅
- `cargo clippy --no-default-features -p cartog-rag -- -D warnings` and `--features provider-ollama` ✅ (no unused-var)
- `cargo test -p cartog-rag -p cartog -p cartog-mcp` ✅
- Manual A/B on a ~3.3k-symbol index: default ≈ unchanged vs `main` (all cores); `CARTOG_ONNX_THREADS=4` demonstrably runs on fewer cores.
- `npm run build` in `site/` ✅

## Docs

- `docs/usage.md`: new env-var table + `intra_threads` under `[embedding.local]`.
- `site/src/pages/usage.astro`: mirrored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable ONNX intra-operation thread control for local embedding and reranking. Users can now set thread limits via configuration or override with the `CARTOG_ONNX_THREADS` environment variable.

* **Documentation**
  * Added comprehensive environment variables documentation section listing all runtime overrides and defaults.
  * Added configuration guidance for ONNX thread limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->