### PR TITLE
fix(db): harden migration ladder + fix Swift extension FK crash

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -540,6 +540,41 @@ fn migrate(conn: &Connection) {
         return;
     }
 
+    // Fresh-DB fast path: the SCHEMA bootstrap just created every table at the
+    // current shape, so all columns/tables exist but no schema_version row is
+    // stamped yet (current was read as 1 via unwrap_or). Stamp the version and
+    // skip the ladder, avoiding the needless v2→3 wipe and the
+    // resolution_source "duplicate column" WARN on every fresh open.
+    // Require an empty symbols table AND all four probes: a real pre-versioning
+    // v1 DB has rows, and a crash-mid-migration DB is missing a column, so
+    // neither is misclassified as fresh.
+    let no_version_row = conn
+        .query_row(
+            "SELECT 1 FROM metadata WHERE key = 'schema_version'",
+            [],
+            |_| Ok(()),
+        )
+        .is_err();
+    let symbols_empty = conn
+        .query_row("SELECT COUNT(*) FROM symbols", [], |r| r.get::<_, i64>(0))
+        .map(|c| c == 0)
+        .unwrap_or(false);
+    if no_version_row
+        && symbols_empty
+        && has_hash_cols
+        && has_resolution_state
+        && has_query_log
+        && has_resolution_source
+    {
+        if let Err(e) = conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?1)",
+            params![SCHEMA_VERSION.to_string()],
+        ) {
+            warn!(error = %e, "failed to stamp fresh-DB schema version");
+        }
+        return;
+    }
+
     // Migration 1 → 2: add in_degree column for centrality ranking
     if current < 2 {
         let _ = conn.execute(
@@ -3738,6 +3773,107 @@ mod tests {
             backups.is_empty(),
             "fresh DB should not create a backup file"
         );
+    }
+
+    #[test]
+    fn fresh_db_stamps_version_without_running_ladder() {
+        // A fresh DB takes the fast-path stamp and skips the destructive v2→3
+        // wipe. Regression guard for the duplicate-column WARN: the ladder must
+        // not re-fire the additive ALTERs against the bootstrapped v6 shape.
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("fresh.db");
+        let db = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        // The destructive branch deletes the 'last_commit' row; the fast path
+        // never enters it, so a marker written before re-open survives.
+        db.set_metadata("last_commit", "deadbeef").unwrap();
+        drop(db);
+        let db = Database::open(&db_path, DEFAULT_EMBEDDING_DIM).unwrap();
+        let last_commit: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'last_commit'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(
+            last_commit,
+            Some("deadbeef".to_string()),
+            "fresh re-open must not run the v2→3 wipe"
+        );
+
+        let version: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn populated_v1_db_runs_full_ladder_to_v6() {
+        // Negative guard for the fresh-DB fast path: a real pre-versioning v1 DB
+        // (no schema_version row, narrow v1 columns, but SEEDED with rows) must
+        // NOT be misclassified as fresh. It runs the full v1→v6 ladder including
+        // the intentional v2→3 stable-id wipe and lands at schema_version=6 with
+        // every later column present.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("v1.sqlite");
+        {
+            let conn = Connection::open(&path).unwrap();
+            // True v1 shape: symbols end at docstring, edges end at line, no
+            // query_log, no schema_version row.
+            conn.execute_batch(
+                "CREATE TABLE symbols (
+                    id TEXT PRIMARY KEY, name TEXT, kind TEXT, file_path TEXT,
+                    start_line INTEGER, end_line INTEGER, start_byte INTEGER, end_byte INTEGER,
+                    parent_id TEXT, signature TEXT, visibility TEXT, is_async BOOLEAN, docstring TEXT);
+                 CREATE TABLE edges (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id TEXT NOT NULL, target_name TEXT NOT NULL, target_id TEXT,
+                    kind TEXT NOT NULL, file_path TEXT NOT NULL, line INTEGER);
+                 CREATE TABLE files (path TEXT PRIMARY KEY);
+                 CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+                 INSERT INTO symbols (id, name, kind, file_path) VALUES ('s:1', 'foo', 'function', 'a.py');
+                 INSERT INTO edges (source_id, target_name, target_id, kind, file_path, line)
+                   VALUES ('s:1', 'foo', 's:1', 'calls', 'a.py', 1);",
+            )
+            .unwrap();
+        }
+
+        let db = Database::open(&path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        // Ladder reached v6.
+        let version: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+
+        // v5→6 column exists (the fast path would have skipped this ALTER).
+        assert!(
+            db.conn
+                .prepare("SELECT resolution_source FROM edges LIMIT 0")
+                .is_ok(),
+            "resolution_source must be added by the real upgrade"
+        );
+
+        // The intentional v2→3 wipe cleared the seeded rows for the stable-id
+        // rebuild — proving the fresh-DB fast path was NOT taken.
+        let symbol_count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM symbols", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(symbol_count, 0, "v2→3 wipe must run for a populated v1 DB");
     }
 
     #[test]

--- a/crates/cartog-languages/src/swift.rs
+++ b/crates/cartog-languages/src/swift.rs
@@ -131,9 +131,8 @@ fn extract_type_like(
         SymbolKind::Class
     };
     // An `extension X` is not a definition of X — X is defined elsewhere — so it
-    // does not emit its own type symbol (two extensions of X would otherwise
-    // collide on `file:class:X` and overwrite each other). Its members and
-    // conformances attach to X's qualified name.
+    // emits a placeholder symbol (below) rather than a real type symbol. Its
+    // members and conformances attach to X's class id.
     let is_extension = kw == "extension";
 
     let qname = qualified(parent.qname, &name);
@@ -163,6 +162,23 @@ fn extract_type_like(
     } else {
         id
     };
+
+    // The extended type is defined elsewhere, so emit a placeholder Class symbol
+    // when none exists yet, mirroring Rust's impl-block handling: conformance
+    // edges and member parent_ids need a local symbol with `owner_id`. The guard
+    // keeps two `extension X` in one file collapsing onto a single placeholder.
+    if is_extension && !symbols.iter().any(|s| s.id == owner_id) {
+        symbols.push(Symbol::new(
+            &name,
+            SymbolKind::Class,
+            file_path,
+            node.start_position().row as u32 + 1,
+            node.end_position().row as u32 + 1,
+            node.start_byte() as u32,
+            node.end_byte() as u32,
+            parent.qname,
+        ));
+    }
 
     // class → first specifier inherits, rest conform; others (incl. extension
     // conformances) → all conform.
@@ -983,9 +999,9 @@ mod tests {
     #[test]
     fn extension_members_attach_to_extended_type() {
         let r = extract("extension Greeter { func shout() -> Greeter { return self } }");
-        // An extension does not define its target, so it emits no type symbol;
-        // its members attach to the extended type's class id.
-        assert!(!r.symbols.iter().any(|s| s.name == "Greeter"));
+        // The extended type is defined elsewhere, so the extension emits one
+        // placeholder Class symbol; members attach to its class id.
+        assert_eq!(r.symbols.iter().filter(|s| s.name == "Greeter").count(), 1);
         assert_eq!(
             sym(&r, "shout").parent_id.as_deref(),
             Some("test.swift:class:Greeter")
@@ -993,11 +1009,11 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_extensions_do_not_collide_or_emit_type_symbol() {
+    fn duplicate_extensions_emit_single_placeholder_and_share_scope() {
         let r = extract("extension X { func a() {} }\nextension X { func b() {} }");
-        // Neither extension emits an `X` type symbol (would collide on id), and
-        // both members survive under X's scope.
-        assert!(!r.symbols.iter().any(|s| s.name == "X"));
+        // Two extensions of X collapse onto one placeholder (no id collision),
+        // and both members survive under X's scope.
+        assert_eq!(r.symbols.iter().filter(|s| s.name == "X").count(), 1);
         assert_eq!(
             sym(&r, "a").parent_id.as_deref(),
             Some("test.swift:class:X")
@@ -1012,6 +1028,23 @@ mod tests {
     fn extension_adds_conformance() {
         let r = extract("extension Foo: Bar {}");
         assert!(has_edge(&r, EdgeKind::Implements, "Bar"));
+    }
+
+    #[test]
+    fn extension_conformance_edge_has_local_source_symbol() {
+        // Regression for the cross-file FK crash: the conformance edge's source_id
+        // must match a symbol emitted by this extraction, not a dangling id.
+        let r = extract("extension Foo: Bar {}");
+        let edge = r
+            .edges
+            .iter()
+            .find(|e| e.kind == EdgeKind::Implements && e.target_name == "Bar")
+            .expect("implements edge");
+        assert!(
+            r.symbols.iter().any(|s| s.id == edge.source_id),
+            "conformance edge source_id {} has no matching local symbol",
+            edge.source_id
+        );
     }
 
     #[test]

--- a/crates/cartog/tests/remote_integration.rs
+++ b/crates/cartog/tests/remote_integration.rs
@@ -557,18 +557,20 @@ fn pull_refuses_non_cartog_sqlite_with_valid_sha() {
         .unwrap();
         conn.close().expect("close foreign.sqlite cleanly");
     }
-    // Belt-and-braces: ensure the OS page cache is flushed to disk before
-    // we hand the file to `aws s3 cp`. Without this we have observed sha256
-    // mismatches in CI where `aws` read stale bytes that didn't match what
-    // our subsequent `std::fs::read` returned. `fsync` on the file handle
-    // forces a durable write barrier.
-    std::fs::File::open(&foreign_db)
+    // Read the live SQLite file once, then FREEZE those exact bytes into an
+    // inert upload file. We hash and upload the SAME frozen file, so the bytes
+    // `aws s3 cp` reads can never diverge from the bytes we hashed. (Earlier
+    // attempts that hashed `foreign.sqlite` and separately let `aws` re-read it
+    // still flaked in CI: the two independent reads of the live file raced.)
+    let bytes = std::fs::read(&foreign_db).unwrap();
+    let upload_db = work.path().join("upload.sqlite");
+    std::fs::write(&upload_db, &bytes).unwrap();
+    std::fs::File::open(&upload_db)
         .unwrap()
         .sync_all()
-        .expect("fsync foreign.sqlite");
-    let bytes = std::fs::read(&foreign_db).unwrap();
-    // Compute the matching sha256 so we attest the bytes correctly — the
-    // guard must still refuse this on schema-version grounds.
+        .expect("fsync upload.sqlite");
+    // Compute the matching sha256 over the frozen bytes — the guard must still
+    // refuse this on "not a cartog database" grounds despite the valid sha.
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
     h.update(&bytes);
@@ -591,7 +593,7 @@ fn pull_refuses_non_cartog_sqlite_with_valid_sha() {
             &endpoint,
             "s3",
             "cp",
-            &foreign_db.to_string_lossy(),
+            &upload_db.to_string_lossy(),
             "s3://cartog-foreign-sqlite/index.sqlite",
             "--metadata",
             &format!("sha256={sha},schema-version={claimed_v}"),


### PR DESCRIPTION
Two independent indexing/DB correctness fixes, both pre-existing on `main`.

## 1. `fix(db)` — skip the migration ladder on a freshly-bootstrapped DB

**Symptom:** every fresh DB open logged `WARN cartog_db: failed to add edges.resolution_source column error=duplicate column name`.

**Root cause:** `Database::open` runs the `CREATE TABLE` bootstrap (already the current v6 shape) and then `migrate()`. A fresh DB has no `schema_version` row, so `migrate()` read `current = 1` and re-ran the whole v1→v6 ladder against already-complete tables — firing the destructive v2→3 wipe needlessly and the v5→6 `ALTER ... ADD resolution_source` (which warns, unlike the other additive ALTERs that swallow silently).

**Fix:** a fast path in `migrate()` — when there is no `schema_version` row, the `symbols` table is empty, **and** all four column/table probes pass, stamp `schema_version` and return before any ALTER/DELETE. The empty-symbols + four-probe guard is essential so neither a real populated v1 DB (has rows) nor a crash-mid-first-migration DB (missing a column) is misclassified as fresh — both still run the self-healing ladder.

## 2. `fix(languages)` — placeholder symbol for a Swift extension of an external type

**Symptom:** `cartog index` aborted with `FOREIGN KEY constraint failed` (SQLite 787) on a repo that defines a type in one file and extends it in another (surfaced via CocoaPods Swift sources in a Flutter app's `ios/Pods/`).

**Root cause:** `extension Foo: Bar {}` where `Foo` is defined elsewhere emitted an `Implements` edge sourced at `<file>:class:Foo` but pushed **no symbol** for it. With `PRAGMA foreign_keys=ON` and the edges `source_id REFERENCES symbols(id)` constraint, inserting that dangling edge aborted the pass. Rust's `impl`-block handling already emits a placeholder symbol for this case; Swift didn't.

**Fix:** when extracting a Swift `extension`, push a placeholder `Class` symbol for the extended type if no local symbol with that id exists yet (the guard collapses two `extension X` in one file onto a single placeholder — no id collision).

## Test plan

- New: `fresh_db_stamps_version_without_running_ladder` (fresh DB skips the v2→3 wipe).
- New: `populated_v1_db_runs_full_ladder_to_v6` — a real v1-shape DB upgrades **sequentially v1→v6**, runs the intended wipe, ends at `schema_version = 6` with `resolution_source` added. This guards the risky fresh-DB predicate and the full upgrade path.
- New: `extension_conformance_edge_has_local_source_symbol` (Swift edge `source_id` resolves to a local symbol).
- Updated two existing Swift extension tests to assert exactly one placeholder symbol.
- End-to-end on real repos: fresh index → no WARN, `schema_version = 6`; the previously-crashing multi-language repo now indexes **874 files with no FK error**.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `--no-default-features` clippy, and the **full workspace test suite** all pass (0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized database migrations for new databases by eliminating redundant migration steps.
  * Improved Swift extension symbol handling to ensure correct member and conformance relationships.

* **Tests**
  * Added regression tests for database migration paths and Swift language features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->