### PR TITLE
feat(rag)!: default reranker → jina-turbo + configurable [reranker] model

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ base_url = "http://localhost:11434"
 
 [reranker]
 provider = "none"            # "local" (default) or "none"
+# model  = "BAAI/bge-reranker-base"   # default: jinaai/jina-reranker-v1-turbo-en (~150MB)
 ```
 
 ## Privacy

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -935,8 +935,11 @@ impl CartogServer {
             .map_err(|e| anyhow::anyhow!("failed to load embedding model: {e}"))?;
         db.reconcile_embedding_fingerprint(&rag::fingerprint_of(provider.as_ref()))
             .map_err(|e| anyhow::anyhow!("failed to reconcile embedding fingerprint: {e}"))?;
-        let reranker =
-            rag::create_reranker_provider(&rag_config.reranker_provider, rag_config.intra_threads);
+        let reranker = rag::create_reranker_provider(
+            &rag_config.reranker_provider,
+            rag_config.reranker_model.as_deref(),
+            rag_config.intra_threads,
+        );
         Self::from_parts(db, provider, reranker, redact, Role::Primary)
     }
 
@@ -955,8 +958,11 @@ impl CartogServer {
             .map_err(|e| anyhow::anyhow!("failed to open database read-only: {e}"))?;
         let provider = rag::create_embedding_provider(&rag_config)
             .map_err(|e| anyhow::anyhow!("failed to load embedding model: {e}"))?;
-        let reranker =
-            rag::create_reranker_provider(&rag_config.reranker_provider, rag_config.intra_threads);
+        let reranker = rag::create_reranker_provider(
+            &rag_config.reranker_provider,
+            rag_config.reranker_model.as_deref(),
+            rag_config.intra_threads,
+        );
         Self::from_parts(db, provider, reranker, redact, Role::ReadOnly)
     }
 

--- a/crates/cartog-rag/README.md
+++ b/crates/cartog-rag/README.md
@@ -19,7 +19,7 @@ Configurable via `.cartog.toml` `[embedding]` section. Supports pluggable provid
 | **local** (default) | `provider-local` | Any fastembed built-in (BGE, all-MiniLM, nomic, etc.) | ONNX Runtime via fastembed, auto-downloaded from HuggingFace |
 | **ollama** | `provider-ollama` | Any Ollama model (nomic-embed-text, mxbai-embed-large, etc.) | HTTP client, auto-detects dimension |
 
-**Reranker**: BGE-reranker-base — cross-encoder that scores (query, document) pairs jointly (~1.1GB, optional, local only).
+**Reranker**: jina-reranker-v1-turbo-en (default, ~150MB) — cross-encoder that scores (query, document) pairs jointly (optional, local only). Configurable via `[reranker] model` (any fastembed reranker repo path); unset uses the default.
 
 Local models cached in `~/.cache/cartog/models/` (respects `FASTEMBED_CACHE_DIR` and `XDG_CACHE_HOME`). Ollama models are managed by the Ollama server.
 
@@ -58,7 +58,7 @@ The Ollama provider maps transport failures to actionable errors instead of raw 
 | Export | Description |
 |--------|-------------|
 | `create_embedding_provider()` | Create a provider from config |
-| `create_reranker_provider()` | Create a reranker from config ("local" or "none") |
+| `create_reranker_provider()` | Create a reranker from config (provider "local"/"none" + a model repo path) |
 | `EmbeddingProviderConfig` | Configuration for provider selection |
 | `provider::EmbeddingProvider` | Trait for embedding backends |
 | `provider::RerankerProvider` | Trait for reranker backends |

--- a/crates/cartog-rag/src/embeddings.rs
+++ b/crates/cartog-rag/src/embeddings.rs
@@ -25,7 +25,7 @@ impl EmbeddingEngine {
     /// for non-TTY environments like AI editors).
     /// Models are cached in the shared directory (see [`super::model_cache_dir`]).
     pub fn new() -> Result<Self> {
-        if super::is_embedding_model_cached() {
+        if super::is_embedding_model_cached(None) {
             info!("Loading embedding model...");
         } else {
             info!("Downloading embedding model (~80MB, first time only)...");

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -19,6 +19,10 @@ pub mod search;
 #[cfg(feature = "provider-local")]
 pub mod setup;
 
+/// Default reranker model (HuggingFace repo path). Small, fast, higher BEIR NDCG@10
+/// than the former bge-reranker-base default. Resolved when `[reranker] model` is unset.
+pub const DEFAULT_RERANKER_MODEL: &str = "jinaai/jina-reranker-v1-turbo-en";
+
 /// Default embedding dimension (re-exported from cartog-db for convenience).
 pub const EMBEDDING_DIM: usize = cartog_db::DEFAULT_EMBEDDING_DIM;
 
@@ -51,6 +55,9 @@ pub struct EmbeddingProviderConfig {
     pub base_url: Option<String>,
     /// Reranker provider: "local" (default) or "none".
     pub reranker_provider: String,
+    /// Reranker model as a fastembed HF repo path (e.g. `BAAI/bge-reranker-base`).
+    /// None = [`DEFAULT_RERANKER_MODEL`]. Mirrors `model` for embeddings.
+    pub reranker_model: Option<String>,
     /// Optional cap on ONNX intra-op threads for the local provider. None =
     /// fastembed's default (all cores). `CARTOG_ONNX_THREADS` overrides this.
     pub intra_threads: Option<usize>,
@@ -66,6 +73,7 @@ impl Default for EmbeddingProviderConfig {
             document_prefix: None,
             base_url: None,
             reranker_provider: "local".to_string(),
+            reranker_model: None,
             intra_threads: None,
         }
     }
@@ -145,19 +153,23 @@ pub fn create_default_embedding_provider() -> anyhow::Result<Box<dyn provider::E
 /// - `"local"` — loads the local ONNX cross-encoder (requires `provider-local` feature)
 /// - `"none"` — disables re-ranking
 ///
+/// `model` is the fastembed reranker HF repo path; `None` = [`DEFAULT_RERANKER_MODEL`].
+/// Ignored for `"none"`.
+///
 /// Returns `None` if re-ranking is disabled, the model is unavailable, or the feature is off.
 pub fn create_reranker_provider(
     reranker_provider: &str,
+    model: Option<&str>,
     intra_threads: Option<usize>,
 ) -> Option<Box<dyn provider::RerankerProvider>> {
-    // `intra_threads` is only consumed by the local provider; without that
-    // feature it would trip `-D unused-variables`.
+    // `model`/`intra_threads` are only consumed by the local provider; without that
+    // feature they would trip `-D unused-variables`.
     #[cfg(not(feature = "provider-local"))]
-    let _ = intra_threads;
+    let _ = (model, intra_threads);
     match reranker_provider {
         "none" => None,
         #[cfg(feature = "provider-local")]
-        "local" => match providers::local::LocalRerankerProvider::load(intra_threads) {
+        "local" => match providers::local::LocalRerankerProvider::load(model, intra_threads) {
             Ok(r) => Some(Box::new(r)),
             Err(e) => {
                 tracing::warn!(error = %e, "Cross-encoder not available, skipping re-ranking");
@@ -174,21 +186,12 @@ pub fn create_reranker_provider(
     }
 }
 
-/// Create the default local reranker provider (BGE-reranker-base).
+/// Create the default local reranker provider ([`DEFAULT_RERANKER_MODEL`]).
 pub fn create_default_reranker_provider() -> Option<Box<dyn provider::RerankerProvider>> {
-    create_reranker_provider("local", None)
+    create_reranker_provider("local", None, None)
 }
 
 // ── Local ONNX model cache management (provider-local only) ──
-
-#[cfg(feature = "provider-local")]
-const EMBEDDING_MODEL_CODE: &str = "Qdrant/bge-small-en-v1.5-onnx-Q";
-#[cfg(feature = "provider-local")]
-const EMBEDDING_MODEL_FILE: &str = "model_optimized.onnx";
-#[cfg(feature = "provider-local")]
-const RERANKER_MODEL_CODE: &str = "BAAI/bge-reranker-base";
-#[cfg(feature = "provider-local")]
-const RERANKER_MODEL_FILE: &str = "onnx/model.onnx";
 
 /// Check if a model is already downloaded in the hf-hub cache (no network access).
 ///
@@ -211,14 +214,89 @@ fn is_model_cached(model_code: &str, model_file: &str) -> bool {
     model_path.exists()
 }
 
+/// Check whether every file of an `(model_code, model_file, additional_files)` triple
+/// is present in the hf-hub cache. The `additional_files` cover models with a separate
+/// weights sidecar (e.g. `model.onnx.data`).
 #[cfg(feature = "provider-local")]
-pub fn is_embedding_model_cached() -> bool {
-    is_model_cached(EMBEDDING_MODEL_CODE, EMBEDDING_MODEL_FILE)
+fn are_model_files_cached(model_code: &str, model_file: &str, additional_files: &[String]) -> bool {
+    is_model_cached(model_code, model_file)
+        && additional_files
+            .iter()
+            .all(|f| is_model_cached(model_code, f))
 }
 
+/// Resolve an embedding `model` name (None = the default BGE-small) to its fastembed
+/// variant. Errors on an unknown name, mirroring [`resolve_reranker_model`].
 #[cfg(feature = "provider-local")]
-pub fn is_reranker_model_cached() -> bool {
-    is_model_cached(RERANKER_MODEL_CODE, RERANKER_MODEL_FILE)
+pub(crate) fn resolve_embedding_model(
+    model: Option<&str>,
+) -> anyhow::Result<fastembed::EmbeddingModel> {
+    match model {
+        Some(name) => name
+            .parse::<fastembed::EmbeddingModel>()
+            .map_err(|e| anyhow::anyhow!("{e}")),
+        None => Ok(fastembed::EmbeddingModel::BGESmallENV15Q),
+    }
+}
+
+/// Check if `model`'s embedding weights are already in the hf-hub cache (no network).
+///
+/// Derives the cache identity from fastembed so a configured non-default `[embedding]
+/// model` is checked against its own cache dir, not the default's. An unknown/unparseable
+/// `model` is treated as "not cached" (the loader surfaces the error).
+#[cfg(feature = "provider-local")]
+pub fn is_embedding_model_cached(model: Option<&str>) -> bool {
+    let Ok(em) = resolve_embedding_model(model) else {
+        return false;
+    };
+    let Ok(info) = fastembed::TextEmbedding::get_model_info(&em) else {
+        return false;
+    };
+    are_model_files_cached(&info.model_code, &info.model_file, &info.additional_files)
+}
+
+/// Resolve a reranker `model` repo path (None = [`DEFAULT_RERANKER_MODEL`]) to its
+/// fastembed variant. Errors on an unknown repo path. Mirrors embedding's model parse.
+#[cfg(feature = "provider-local")]
+pub fn resolve_reranker_model(model: Option<&str>) -> anyhow::Result<fastembed::RerankerModel> {
+    model
+        .unwrap_or(DEFAULT_RERANKER_MODEL)
+        .parse::<fastembed::RerankerModel>()
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// Check if a already-resolved reranker model's weights are in the hf-hub cache.
+/// Takes the resolved variant so the caller (which already parsed it) avoids re-parsing.
+#[cfg(feature = "provider-local")]
+pub fn is_reranker_resolved_cached(rm: &fastembed::RerankerModel) -> bool {
+    let info = fastembed::TextRerank::get_model_info(rm);
+    are_model_files_cached(&info.model_code, &info.model_file, &info.additional_files)
+}
+
+/// hf-hub cache directory for the former default reranker (`bge-reranker-base`).
+///
+/// Derives the `models--<org>--<name>` dir from fastembed's model code (the same
+/// transform [`is_model_cached`] uses) rather than hardcoding the literal, so it tracks
+/// any fastembed repo-path change. Used by `cartog doctor` to offer a reclaim hint when
+/// the now-orphaned ~1.1GB model lingers under the new default.
+#[cfg(feature = "provider-local")]
+pub fn legacy_bge_reranker_cache_dir() -> std::path::PathBuf {
+    let code = fastembed::TextRerank::get_model_info(&fastembed::RerankerModel::BGERerankerBase)
+        .model_code;
+    model_cache_dir().join(format!("models--{}", code.replace('/', "--")))
+}
+
+/// Check if `model`'s reranker weights are already in the hf-hub cache (no network).
+///
+/// Convenience wrapper over [`is_reranker_resolved_cached`] for callers holding a config
+/// string. An unknown/unparseable `model` is treated as "not cached"; callers that need to
+/// distinguish "invalid" from "uncached" should call [`resolve_reranker_model`] first.
+#[cfg(feature = "provider-local")]
+pub fn is_reranker_model_cached(model: Option<&str>) -> bool {
+    match resolve_reranker_model(model) {
+        Ok(rm) => is_reranker_resolved_cached(&rm),
+        Err(_) => false,
+    }
 }
 
 /// Shared model cache directory for ONNX models (embedding + reranker).
@@ -340,7 +418,44 @@ mod tests {
         assert!(config.query_prefix.is_none());
         assert!(config.document_prefix.is_none());
         assert!(config.base_url.is_none());
+        assert_eq!(config.reranker_provider, "local");
+        assert!(config.reranker_model.is_none());
         assert_eq!(config.resolved_dimension(), 384);
+    }
+
+    #[cfg(feature = "provider-local")]
+    #[test]
+    fn test_resolve_reranker_model_default_and_known_and_unknown() {
+        // None resolves to the default; a known repo path parses; an unknown errors.
+        assert_eq!(
+            resolve_reranker_model(None).unwrap(),
+            fastembed::RerankerModel::JINARerankerV1TurboEn
+        );
+        assert_eq!(
+            resolve_reranker_model(Some("BAAI/bge-reranker-base")).unwrap(),
+            fastembed::RerankerModel::BGERerankerBase
+        );
+        let err = resolve_reranker_model(Some("nope/not-real")).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("unknown"));
+    }
+
+    #[cfg(feature = "provider-local")]
+    #[test]
+    fn test_default_reranker_model_const_resolves() {
+        // DEFAULT_RERANKER_MODEL must be a real fastembed repo path.
+        assert!(DEFAULT_RERANKER_MODEL
+            .parse::<fastembed::RerankerModel>()
+            .is_ok());
+    }
+
+    #[cfg(feature = "provider-local")]
+    #[test]
+    fn test_resolve_embedding_model_default_and_unknown() {
+        assert_eq!(
+            resolve_embedding_model(None).unwrap(),
+            fastembed::EmbeddingModel::BGESmallENV15Q
+        );
+        assert!(resolve_embedding_model(Some("not-a-real-embedding-model")).is_err());
     }
 
     #[test]

--- a/crates/cartog-rag/src/providers/local.rs
+++ b/crates/cartog-rag/src/providers/local.rs
@@ -76,7 +76,7 @@ impl LocalEmbeddingProvider {
         // path is wire-stable across fastembed releases.
         let model_code = model_info.model_code.clone();
 
-        let is_cached = crate::is_embedding_model_cached();
+        let is_cached = crate::is_embedding_model_cached(model_name);
         if is_cached {
             info!("Loading embedding model...");
         } else {
@@ -171,34 +171,43 @@ pub struct LocalRerankerProvider {
     model: fastembed::TextRerank,
 }
 
+/// Load a fastembed `TextRerank` for the given reranker model, fetching the weights
+/// into the shared model cache on first use. The single place the fastembed reranker
+/// variant is loaded — both [`LocalRerankerProvider::load`] and
+/// [`crate::reranker::CrossEncoderEngine::load`] route through here.
+///
+/// `intra_threads` caps the ONNX intra-op thread count: `CARTOG_ONNX_THREADS` env var >
+/// this argument (`[embedding.local] intra_threads`); neither set leaves it uncapped
+/// (fastembed's default — all cores).
+///
+/// Returns `Err` if the weights cannot be downloaded or the ONNX session fails to
+/// initialize; callers treat this as "re-ranking unavailable" and fall back to RRF-only.
+pub(crate) fn load_text_rerank(
+    model: Option<&str>,
+    intra_threads: Option<usize>,
+) -> Result<fastembed::TextRerank> {
+    let rm = crate::resolve_reranker_model(model)?;
+    if crate::is_reranker_resolved_cached(&rm) {
+        info!("Loading reranker model...");
+    } else {
+        let code = fastembed::TextRerank::get_model_info(&rm).model_code;
+        info!("Downloading reranker model ({code}, first time only)...");
+    }
+
+    let opts = with_optional_threads!(
+        fastembed::RerankInitOptions::new(rm).with_cache_dir(model_cache_dir()),
+        onnx_intra_threads(intra_threads)
+    );
+    fastembed::TextRerank::try_new(opts.with_show_download_progress(true))
+        .context("Failed to initialize cross-encoder model")
+}
+
 impl LocalRerankerProvider {
-    /// Load the local ONNX cross-encoder re-ranker (BGE-reranker-base), fetching
-    /// the weights into the model cache on first use.
-    ///
-    /// `intra_threads` is an optional cap on the ONNX intra-op thread count. The
-    /// effective cap is resolved as `CARTOG_ONNX_THREADS` env var > this argument
-    /// (the TOML `[embedding.local] intra_threads`); when neither is set the
-    /// session is left uncapped (fastembed's default — all available cores).
-    ///
-    /// Returns `Err` if the model weights cannot be downloaded or the ONNX
-    /// session fails to initialize; callers treat this as "re-ranking
-    /// unavailable" and fall back to RRF-only ordering.
-    pub fn load(intra_threads: Option<usize>) -> Result<Self> {
-        if crate::is_reranker_model_cached() {
-            info!("Loading reranker model...");
-        } else {
-            info!("Downloading reranker model (~1.1GB, first time only)...");
-        }
-
-        let opts = with_optional_threads!(
-            fastembed::RerankInitOptions::new(fastembed::RerankerModel::BGERerankerBase)
-                .with_cache_dir(model_cache_dir()),
-            onnx_intra_threads(intra_threads)
-        );
-        let model = fastembed::TextRerank::try_new(opts.with_show_download_progress(true))
-            .context("Failed to initialize cross-encoder model")?;
-
-        Ok(Self { model })
+    /// Load the local ONNX cross-encoder re-ranker for `model`. See [`load_text_rerank`].
+    pub fn load(model: Option<&str>, intra_threads: Option<usize>) -> Result<Self> {
+        Ok(Self {
+            model: load_text_rerank(model, intra_threads)?,
+        })
     }
 }
 

--- a/crates/cartog-rag/src/reranker.rs
+++ b/crates/cartog-rag/src/reranker.rs
@@ -1,12 +1,9 @@
 use anyhow::{Context, Result};
-use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
-use tracing::info;
-
-use super::model_cache_dir;
+use fastembed::TextRerank;
 
 /// Cross-encoder re-ranker for scoring (query, document) pairs.
 ///
-/// Uses ONNX Runtime via fastembed for inference. The BGE-reranker-base model
+/// Uses ONNX Runtime via fastembed for inference. The configured reranker model
 /// processes query and document jointly through all transformer layers,
 /// producing a relevance score for each pair.
 pub struct CrossEncoderEngine {
@@ -14,27 +11,15 @@ pub struct CrossEncoderEngine {
 }
 
 impl CrossEncoderEngine {
-    /// Load the cross-encoder re-ranker model.
-    ///
-    /// Downloads the model from HuggingFace on first use (~1.1GB).
-    /// Progress is always enabled (visible in TTY via indicatif, logged via tracing
-    /// for non-TTY environments like AI editors).
-    /// Models are cached in the shared directory (see [`super::model_cache_dir`]).
-    pub fn load() -> Result<Self> {
-        if super::is_reranker_model_cached() {
-            info!("Loading reranker model...");
-        } else {
-            info!("Downloading reranker model (~1.1GB, first time only)...");
-        }
-
-        let model = TextRerank::try_new(
-            RerankInitOptions::new(RerankerModel::BGERerankerBase)
-                .with_cache_dir(model_cache_dir())
-                .with_show_download_progress(true),
-        )
-        .context("Failed to initialize cross-encoder model")?;
-
-        Ok(Self { model })
+    /// Load the cross-encoder re-ranker for `model`, downloading the weights from
+    /// HuggingFace on first use. Routes through
+    /// [`super::providers::local::load_text_rerank`] so the fastembed variant is selected
+    /// in exactly one place. Models are cached in the shared directory
+    /// (see [`super::model_cache_dir`]).
+    pub fn load(model: Option<&str>, intra_threads: Option<usize>) -> Result<Self> {
+        Ok(Self {
+            model: super::providers::local::load_text_rerank(model, intra_threads)?,
+        })
     }
 
     /// Score multiple documents against a single query.

--- a/crates/cartog-rag/src/setup.rs
+++ b/crates/cartog-rag/src/setup.rs
@@ -24,14 +24,18 @@ pub fn download_model() -> Result<SetupResult> {
     })
 }
 
-/// Download the cross-encoder re-ranker model.
+/// Download the cross-encoder re-ranker `model`.
 ///
 /// fastembed automatically downloads the ONNX model from HuggingFace on first use.
 /// Progress and download status are logged via tracing (visible in non-TTY environments).
-pub fn download_cross_encoder() -> Result<SetupResult> {
+pub fn download_cross_encoder(
+    model: Option<&str>,
+    intra_threads: Option<usize>,
+) -> Result<SetupResult> {
     let cache_dir = model_cache_dir();
 
-    let _engine = CrossEncoderEngine::load().context("Failed to download cross-encoder model")?;
+    let _engine = CrossEncoderEngine::load(model, intra_threads)
+        .context("Failed to download cross-encoder model")?;
 
     Ok(SetupResult {
         model_dir: cache_dir.display().to_string(),

--- a/crates/cartog/src/commands/doctor.rs
+++ b/crates/cartog/src/commands/doctor.rs
@@ -148,7 +148,8 @@ fn parse_host_port(url: &str) -> Option<String> {
 fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResult {
     match config.provider.as_str() {
         "local" => {
-            if rag::is_embedding_model_cached() {
+            let model = config.model.as_deref();
+            if rag::is_embedding_model_cached(model) {
                 CheckResult {
                     name: "embedding".into(),
                     status: CheckStatus::Ok,
@@ -220,32 +221,55 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
 }
 
 fn check_reranker(config: &rag::EmbeddingProviderConfig) -> CheckResult {
+    let model = config.reranker_model.as_deref();
+    let name = model.unwrap_or(rag::DEFAULT_RERANKER_MODEL);
     match config.reranker_provider.as_str() {
         "none" => CheckResult {
             name: "reranker".into(),
             status: CheckStatus::Ok,
             message: "disabled".into(),
         },
-        "local" => {
-            if rag::is_reranker_model_cached() {
-                CheckResult {
-                    name: "reranker".into(),
-                    status: CheckStatus::Ok,
-                    message: "local model cached".into(),
-                }
-            } else {
-                CheckResult {
-                    name: "reranker".into(),
-                    status: CheckStatus::Warn,
-                    message: "local model not downloaded, run 'cartog rag setup'".into(),
+        "local" => match rag::resolve_reranker_model(model) {
+            // Unparseable model = config error, not a missing download.
+            Err(e) => CheckResult {
+                name: "reranker".into(),
+                status: CheckStatus::Error,
+                message: format!("unknown reranker model '{name}': {e}"),
+            },
+            Ok(rm) => {
+                if rag::is_reranker_resolved_cached(&rm) {
+                    CheckResult {
+                        name: "reranker".into(),
+                        status: CheckStatus::Ok,
+                        message: format!("{name} cached{}", orphan_bge_hint(name)),
+                    }
+                } else {
+                    CheckResult {
+                        name: "reranker".into(),
+                        status: CheckStatus::Warn,
+                        message: format!("{name} not downloaded, run 'cartog rag setup'"),
+                    }
                 }
             }
-        }
+        },
         other => CheckResult {
             name: "reranker".into(),
             status: CheckStatus::Error,
             message: format!("unknown provider '{other}'"),
         },
+    }
+}
+
+/// Reclaim hint when the old bge-base weights are orphaned under the new default.
+fn orphan_bge_hint(active: &str) -> String {
+    let orphan = rag::legacy_bge_reranker_cache_dir();
+    if active == rag::DEFAULT_RERANKER_MODEL && orphan.is_dir() {
+        format!(
+            " (old bge-reranker-base ~1.1GB reclaimable: rm -rf {})",
+            orphan.display()
+        )
+    } else {
+        String::new()
     }
 }
 
@@ -765,9 +789,37 @@ mod tests {
     fn test_check_reranker_local() {
         let config = rag::EmbeddingProviderConfig::default();
         let result = check_reranker(&config);
-        // Either Ok (cached) or Warn (not cached) — never Error for "local"
+        // Either Ok (cached) or Warn (not cached) — never Error for "local".
         assert_ne!(result.status, CheckStatus::Error);
         assert_eq!(result.name, "reranker");
+        // The message names the resolved default model regardless of cache state.
+        assert!(result.message.contains(rag::DEFAULT_RERANKER_MODEL));
+    }
+
+    #[test]
+    fn test_check_reranker_local_custom_model() {
+        let config = rag::EmbeddingProviderConfig {
+            reranker_model: Some("BAAI/bge-reranker-base".into()),
+            ..Default::default()
+        };
+        let result = check_reranker(&config);
+        assert_ne!(result.status, CheckStatus::Error);
+        assert!(result.message.contains("BAAI/bge-reranker-base"));
+    }
+
+    #[test]
+    fn test_check_reranker_invalid_model_is_error_not_missing_download() {
+        // An unparseable model must surface as an Error naming the bad value, not a
+        // misleading "not downloaded, run 'cartog rag setup'" (setup would also fail).
+        let config = rag::EmbeddingProviderConfig {
+            reranker_model: Some("totally/not-a-real-reranker".into()),
+            ..Default::default()
+        };
+        let result = check_reranker(&config);
+        assert_eq!(result.status, CheckStatus::Error);
+        assert!(result.message.contains("unknown reranker model"));
+        assert!(result.message.contains("totally/not-a-real-reranker"));
+        assert!(!result.message.contains("rag setup"));
     }
 
     // ── check_embedding_provider ollama with bad URL ──

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1113,19 +1113,23 @@ pub fn cmd_changes(
 // ── RAG Commands ──
 
 /// Download the embedding model.
-pub fn cmd_rag_setup(json: bool) -> Result<()> {
+pub fn cmd_rag_setup(json: bool, provider_config: &rag::EmbeddingProviderConfig) -> Result<()> {
+    let reranker_model = provider_config.reranker_model.as_deref();
     let spinner = if json {
         None
     } else {
         // One-time notice so the multi-hundred-MB download isn't a silent wait.
-        // Size matches docs/usage.md (embedding ~80MB + reranker ~1.1GB).
-        eprintln!("Downloading embedding + re-ranker models (~1.2GB, one-time)…");
+        eprintln!(
+            "Downloading embedding (~80MB) + re-ranker ({}) models, one-time…",
+            reranker_model.unwrap_or(rag::DEFAULT_RERANKER_MODEL)
+        );
         Spinner::start("Downloading models")
     };
     // Download bi-encoder (embeddings)
     let embed_result = rag::setup::download_model();
-    // Download cross-encoder (re-ranking)
-    let rerank_result = rag::setup::download_cross_encoder();
+    // Download cross-encoder (re-ranking) — the configured model, not always the default.
+    let rerank_result =
+        rag::setup::download_cross_encoder(reranker_model, provider_config.intra_threads);
     if let Some(s) = spinner {
         s.stop();
     }
@@ -1229,8 +1233,9 @@ pub fn cmd_rag_search(
         None
     } else {
         let name = provider_config.reranker_provider.clone();
+        let model = provider_config.reranker_model.clone();
         let threads = provider_config.intra_threads;
-        Some(move || rag::create_reranker_provider(&name, threads))
+        Some(move || rag::create_reranker_provider(&name, model.as_deref(), threads))
     };
     let search_result = rag::search::hybrid_search_tuned_lazy(
         &db,
@@ -1320,6 +1325,7 @@ pub fn cmd_context(
         } else {
             rag::create_reranker_provider(
                 &provider_config.reranker_provider,
+                provider_config.reranker_model.as_deref(),
                 provider_config.intra_threads,
             )
         };

--- a/crates/cartog/src/config.rs
+++ b/crates/cartog/src/config.rs
@@ -235,6 +235,9 @@ impl OllamaConfig {
 pub struct RerankerConfig {
     /// Provider type: "local" (default) or "none".
     pub provider: Option<String>,
+    /// Reranker model as a fastembed HF repo path (e.g. `BAAI/bge-reranker-base`).
+    /// None = [`cartog_rag::DEFAULT_RERANKER_MODEL`]. Mirrors `[embedding] model`.
+    pub model: Option<String>,
 }
 
 pub const DEFAULT_RERANKER_PROVIDER: &str = "local";
@@ -258,6 +261,15 @@ pub fn to_redaction_config(config: &CartogConfig) -> cartog_indexer::RedactionCo
 
 /// Convert the embedding config section into an `EmbeddingProviderConfig` for cartog-rag.
 pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProviderConfig {
+    // The reranker section is independent of the embedding section — honor it even
+    // when `[embedding]` is absent (otherwise a lone `[reranker]` block is dropped).
+    let reranker_provider = config
+        .reranker
+        .as_ref()
+        .map(|r| r.provider().to_string())
+        .unwrap_or_else(|| DEFAULT_RERANKER_PROVIDER.to_string());
+    let reranker_model = config.reranker.as_ref().and_then(|r| r.model.clone());
+
     match &config.embedding {
         Some(embed) => {
             let (query_prefix, document_prefix, intra_threads) = match &embed.local {
@@ -279,15 +291,16 @@ pub fn to_provider_config(config: &CartogConfig) -> cartog_rag::EmbeddingProvide
                 query_prefix,
                 document_prefix,
                 base_url: ollama.map(|o| o.base_url().to_string()),
-                reranker_provider: config
-                    .reranker
-                    .as_ref()
-                    .map(|r| r.provider().to_string())
-                    .unwrap_or_else(|| DEFAULT_RERANKER_PROVIDER.to_string()),
+                reranker_provider,
+                reranker_model,
                 intra_threads,
             }
         }
-        None => cartog_rag::EmbeddingProviderConfig::default(),
+        None => cartog_rag::EmbeddingProviderConfig {
+            reranker_provider,
+            reranker_model,
+            ..Default::default()
+        },
     }
 }
 
@@ -1146,6 +1159,45 @@ provider = "none"
 "#;
         let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(cfg.reranker.unwrap().provider(), "none");
+    }
+
+    #[test]
+    fn test_reranker_model_defaults_to_none_in_config() {
+        let cfg = RerankerConfig::default();
+        assert!(cfg.model.is_none());
+    }
+
+    #[test]
+    fn test_to_provider_config_reranker_model_from_toml() {
+        let toml_str = r#"
+[reranker]
+model = "BAAI/bge-reranker-base"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.reranker_model.as_deref(), Some("BAAI/bge-reranker-base"));
+    }
+
+    #[test]
+    fn test_to_provider_config_reranker_model_default_is_none() {
+        // Unset model maps to None; cartog-rag resolves None to DEFAULT_RERANKER_MODEL.
+        let cfg = CartogConfig::default();
+        let pc = to_provider_config(&cfg);
+        assert!(pc.reranker_model.is_none());
+    }
+
+    #[test]
+    fn test_reranker_provider_none_keeps_model_inert() {
+        // A model alongside provider="none" parses fine; the model is simply never loaded.
+        let toml_str = r#"
+[reranker]
+provider = "none"
+model = "BAAI/bge-reranker-base"
+"#;
+        let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+        let pc = to_provider_config(&cfg);
+        assert_eq!(pc.reranker_provider, "none");
+        assert_eq!(pc.reranker_model.as_deref(), Some("BAAI/bge-reranker-base"));
     }
 
     #[test]

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -346,7 +346,7 @@ fn main() -> Result<()> {
             ))
         }
         Command::Rag(rag_cmd) => match rag_cmd {
-            RagCommand::Setup => commands::cmd_rag_setup(cli.json),
+            RagCommand::Setup => commands::cmd_rag_setup(cli.json, &provider_config),
             RagCommand::Index { path, force } => {
                 commands::cmd_rag_index(&db_path, &path, force, cli.json, &provider_config, redact)
             }

--- a/crates/cartog/tests/rag_relevancy.rs
+++ b/crates/cartog/tests/rag_relevancy.rs
@@ -198,7 +198,7 @@ fn rag_relevancy_benchmark() {
     ];
 
     // Try loading the cross-encoder to check availability.
-    let reranker_active = cartog::rag::reranker::CrossEncoderEngine::load().is_ok();
+    let reranker_active = cartog::rag::reranker::CrossEncoderEngine::load(None, None).is_ok();
 
     println!();
     println!(
@@ -354,7 +354,7 @@ fn java_rag_relevancy_benchmark() {
         },
     ];
 
-    let reranker_active = cartog::rag::reranker::CrossEncoderEngine::load().is_ok();
+    let reranker_active = cartog::rag::reranker::CrossEncoderEngine::load(None, None).is_ok();
 
     println!();
     println!("  Java fixture:");

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -172,7 +172,7 @@ BERT attention is **O(n²) in sequence length**. Keeping input short is the sing
 
 This drives two key decisions:
 
-1. **Small embedding model** — BGE-small-en-v1.5 quantized (default, 384 dimensions). 2-3x faster than full precision with negligible quality loss for code symbol matching. Outputs are L2-normalized, enabling L2 distance in sqlite-vec (equivalent to cosine ranking). Model and dimension are configurable via `.cartog.toml`. Trade-off: English-only model — non-English identifiers/comments get degraded embeddings.
+1. **Small embedding model** — BGE-small-en-v1.5 quantized (`Qdrant/bge-small-en-v1.5-onnx-Q`, default, 384 dimensions). 2-3x faster than full precision with negligible quality loss for code symbol matching. Outputs are L2-normalized, enabling L2 distance in sqlite-vec (equivalent to cosine ranking). Model and dimension are configurable via `.cartog.toml`. Trade-off: English-only model — non-English identifiers/comments get degraded embeddings.
 
 2. **AST-aware embedding text** — For code: header + signature + significant body lines (skipping blanks, comments, closing braces) up to ~200 tokens (~800 bytes):
    ```
@@ -218,7 +218,7 @@ Query
   │     Over-retrieval: max(limit × 3, 20) per source
   │
   └─→ Cross-encoder re-ranking (optional)
-        BGE-reranker-base, scores (query, full_content) pairs jointly
+        jina-reranker-v1-turbo-en (`jinaai/jina-reranker-v1-turbo-en`, default; configurable via `[reranker] model`), scores (query, full_content) pairs jointly
         Capped at 50 candidates to bound latency
         Graceful degradation: tri-state cache (not attempted / failed / ready)
         If model unavailable → search works with RRF-only ordering

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -186,6 +186,22 @@ The Ollama provider ships in every default build (install.sh, GitHub Releases,
 `--no-default-features`. Rebuild with default features, or add
 `--features ollama-embedding`.
 
+### Reclaiming the old `bge-reranker-base` model after the reranker default changed
+
+The default reranker is now `jinaai/jina-reranker-v1-turbo-en` (~150MB). If you
+ran an older cartog, the former default `BAAI/bge-reranker-base` (~1.1GB) may still
+sit in the shared model cache. `cartog doctor` flags it; nothing depends on it once
+you're on the new default, so it's safe to delete:
+
+```bash
+rm -rf "${FASTEMBED_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/cartog/models}/models--BAAI--bge-reranker-base"
+```
+
+The cache dir resolves in order: `$FASTEMBED_CACHE_DIR`, else
+`$XDG_CACHE_HOME/cartog/models`, else `~/.cache/cartog/models`. To keep the old
+model instead, pin `[reranker] model = "BAAI/bge-reranker-base"` (it reuses the
+already-downloaded weights, no re-download).
+
 ## Queries
 
 ### `cartog refs X` returns fewer hits than I expect

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,7 +101,7 @@ cartog --db /tmp/x.db map
 Configure the embedding provider in `.cartog.toml`:
 
 ```toml
-# Default: local ONNX model (no config needed)
+# Default: BGE-small-en-v1.5 quantized embedding + jina-turbo reranker (no config needed)
 
 # Use Ollama instead of local ONNX
 [embedding]
@@ -116,8 +116,22 @@ base_url = "http://localhost:11434"
 
 | Provider | Config | Setup | Notes |
 |----------|--------|-------|-------|
-| `local` (default) | No config needed | `cartog rag setup` to download models | ONNX Runtime via fastembed, ~1.2GB models |
+| `local` (default) | No config needed | `cartog rag setup` to download models | ONNX Runtime via fastembed, ~230MB models |
 | `ollama` | `provider = "ollama"` | Ollama server running with model pulled | No model download needed, dimension auto-detected. Compiled into every default build; **local ONNX stays the default provider** — set `provider = "ollama"` to use it. |
+
+**Default models (local provider):**
+
+| Role | Config value | HuggingFace repo (downloaded) | Dim | Size |
+|------|-------------|-------------------------------|-----|------|
+| Embedding | `BAAI/bge-small-en-v1.5` | `Qdrant/bge-small-en-v1.5-onnx-Q` (ONNX-quantized) | 384 | ~80MB |
+| Reranker | `jinaai/jina-reranker-v1-turbo-en` (default) | `jinaai/jina-reranker-v1-turbo-en` | — | ~150MB |
+
+The embedding config value is the fastembed model code you set under `[embedding]
+model`; cartog downloads the matching ONNX-quantized repo from HuggingFace into the
+shared model cache (`$FASTEMBED_CACHE_DIR`, else `$XDG_CACHE_HOME/cartog/models`, else
+`~/.cache/cartog/models`). English-only — non-English identifiers/comments get
+degraded embeddings. Override the embedding model with any fastembed built-in via
+`[embedding] model = "..."`.
 
 An unknown `provider` value (embedding: `local`, `ollama`; reranker: `local`, `none`) is rejected when `.cartog.toml` is loaded, with an error naming the bad value — a typo like `provider = "ollma"` fails fast instead of silently falling back to the default.
 
@@ -140,7 +154,27 @@ this to leave headroom on a busy machine (e.g. `intra_threads = 4`). The
 `CARTOG_ONNX_THREADS` env var overrides it (e.g. `CARTOG_ONNX_THREADS=1`); env >
 TOML > uncapped. Read at provider load, so restart `cartog serve` to change it.
 
-**Disable re-ranking** (saves ~1.1GB model download):
+**Reranker model** — the cross-encoder is configurable, mirroring `[embedding]
+model`. The value is a fastembed reranker HuggingFace repo path; unset uses the
+default (`jinaai/jina-reranker-v1-turbo-en`, ~150MB — small, fast, and higher
+BEIR NDCG@10 than the older `bge-reranker-base`):
+
+```toml
+[reranker]
+provider = "local"                              # "local" (default) | "none"
+model    = "BAAI/bge-reranker-base"             # opt back to the former default (~1.1GB)
+# model  = "jinaai/jina-reranker-v2-base-multilingual"  # multilingual (~300MB)
+```
+
+The reranker is not persisted, so switching models needs no re-index — the change
+takes effect on the next search (a new model downloads once; a previously-used one
+is reused from cache). Existing users who never pinned `model` are switched to the
+new default automatically; pin `model = "BAAI/bge-reranker-base"` to keep the old
+one (it reuses the already-downloaded weights). See
+[troubleshooting](troubleshooting.md) to reclaim the orphaned `bge-reranker-base`
+cache.
+
+**Disable re-ranking** (skips the ~150MB reranker download):
 
 ```toml
 [reranker]
@@ -202,7 +236,7 @@ Download embedding and re-ranker models from HuggingFace. Run once before using 
 cartog rag setup
 ```
 
-**First-time download**: ~1.2GB of ONNX models (embedding ~80MB + reranker ~1.1GB). May take a few minutes depending on network speed. Models are cached in `~/.cache/cartog/models/` and reused across all projects — subsequent runs are instant.
+**First-time download**: ~230MB of ONNX models (embedding ~80MB + reranker `jinaai/jina-reranker-v1-turbo-en` ~150MB). Models are cached in `~/.cache/cartog/models/` and reused across all projects — subsequent runs are instant. `rag setup` downloads the configured reranker, so pinning `[reranker] model` fetches that one instead.
 
 Note: `rag setup` downloads models for the **local** provider only. When using Ollama, models are managed by the Ollama server — run `ollama pull nomic-embed-text` instead.
 
@@ -941,7 +975,7 @@ cartog doctor
   [+] config: loaded from /home/user/project/.cartog.toml
   [+] database: 42 files, 387 symbols at /home/user/project/.cartog/db.sqlite
   [+] embedding: local model cached
-  [+] reranker: local model cached
+  [+] reranker: jinaai/jina-reranker-v1-turbo-en cached
 
 All 5 checks passed
 ```
@@ -954,7 +988,7 @@ All 5 checks passed
 | config | `.cartog.toml` found and parsed | No config file (using defaults) | — |
 | database | DB exists with indexed data | DB empty or missing | DB cannot be opened |
 | embedding | Local model cached / Ollama reachable | Local model not downloaded | Ollama unreachable / unknown provider |
-| reranker | Local model cached / disabled | Local model not downloaded | Unknown provider |
+| reranker | Model cached / disabled | Model not downloaded | Unknown provider |
 
 Exits with code 1 if any check is an error. Supports `--json` for structured output.
 
@@ -1170,7 +1204,7 @@ cartog index .          # 6. re-index after code changes
 For semantic search, add the RAG pipeline:
 
 ```text
-cartog rag setup        # one-time model download (~1.2GB, may take a few minutes)
+cartog rag setup        # one-time model download (~230MB)
 cartog rag index        # embed symbols
 cartog rag search "..."  # natural language queries
 ```

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -167,7 +167,7 @@ import { withBase } from "../lib/url";
 <span class="highlight">[+]</span> <span class="output">config: loaded from .cartog.toml</span>
 <span class="highlight">[+]</span> <span class="output">database: 142 files, 3891 symbols</span>
 <span class="highlight">[+]</span> <span class="output">embedding: local model cached</span>
-<span class="highlight">[+]</span> <span class="output">reranker: local model cached</span>
+<span class="highlight">[+]</span> <span class="output">reranker: jina-reranker-v1-turbo-en cached</span>
 
 <span class="comment">All 5 checks passed</span></div>
         </div>

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -110,7 +110,7 @@ cartog ide                   <span class="comment"># Cursor, VS Code, Claude Des
         <p>Two commands to start: <code>init</code> writes <code>.cartog.toml</code>, <code>index</code> builds the graph. Add <code>cartog ide</code> only if you want MCP wired into an editor — CLI users can skip it.</p>
 
         <h3>Add semantic search (optional, still fully local)</h3>
-        <pre>cartog rag setup             <span class="comment"># download models (~1.2GB, one-time)</span>
+        <pre>cartog rag setup             <span class="comment"># download models (~230MB, one-time)</span>
 cartog rag index .           <span class="comment"># embed all symbols + documents</span>
 cartog rag search "authentication token validation"</pre>
         <p>Indexes both <strong>code</strong> (functions, classes, methods) and <strong>Markdown documents</strong> (READMEs, design docs, API docs). Models are downloaded once to <code>~/.cache/cartog/models/</code> and run locally via ONNX Runtime. No API keys needed.</p>
@@ -140,7 +140,7 @@ provider = "ollama"</pre>
             <tr>
               <td>Natural language</td>
               <td><code>cartog rag search "error handling"</code></td>
-              <td>~150-500ms</td>
+              <td>~100-400ms</td>
               <td>You know the behavior</td>
             </tr>
             <tr>
@@ -171,7 +171,7 @@ cartog index .          <span class="comment"># 6. re-index after changes</span>
           <tbody>
             <tr><td><code>[database]</code></td><td><code>.cartog/db.sqlite</code> (git-root relative)</td><td>you want the DB elsewhere</td></tr>
             <tr><td><code>[embedding]</code></td><td><code>provider = "local"</code> (ONNX, CPU)</td><td>using Ollama / a different model — see <a href="#config-providers">Embedding Providers</a></td></tr>
-            <tr><td><code>[reranker]</code></td><td><code>provider = "local"</code> (cross-encoder)</td><td>disabling rerank (<code>"none"</code>) to skip its model download</td></tr>
+            <tr><td><code>[reranker]</code></td><td><code>provider = "local"</code>, <code>model = "jinaai/jina-reranker-v1-turbo-en"</code> (default)</td><td>picking a different cross-encoder, or disabling rerank (<code>"none"</code>)</td></tr>
             <tr><td><code>[rag]</code></td><td>tuned retrieval/rerank pools</td><td>tuning hybrid-search recall vs. cost</td></tr>
             <tr><td><code>[remote]</code></td><td>unset (no sync)</td><td>sharing an index over S3 — see <a href="#config-remote">Remote Storage</a></td></tr>
             <tr><td><code>[security]</code></td><td><code>redact_secrets = true</code></td><td>opting out of pattern redaction — see <a href="#config-secrets">Secret Redaction</a></td></tr>
@@ -253,7 +253,7 @@ url        = "s3://my-team-bucket/cartog/main"
               <td><strong>local</strong> (default)</td>
               <td>No config needed</td>
               <td><code>cartog rag setup</code></td>
-              <td>ONNX Runtime via fastembed. ~1.2GB model download. Runs on CPU.</td>
+              <td>ONNX Runtime via fastembed. ~230MB model download. Runs on CPU.</td>
             </tr>
             <tr>
               <td><strong>ollama</strong></td>
@@ -263,6 +263,44 @@ url        = "s3://my-team-bucket/cartog/main"
             </tr>
           </tbody>
         </table>
+
+        <h3>Default models (local provider)</h3>
+        <table>
+          <thead>
+            <tr><th>Role</th><th>Config value</th><th>HuggingFace repo (downloaded)</th><th>Dim</th><th>Size</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Embedding</strong></td>
+              <td><code>BAAI/bge-small-en-v1.5</code></td>
+              <td><code>Qdrant/bge-small-en-v1.5-onnx-Q</code> (ONNX-quantized)</td>
+              <td>384</td>
+              <td>~80MB</td>
+            </tr>
+            <tr>
+              <td><strong>Reranker</strong></td>
+              <td><code>jinaai/jina-reranker-v1-turbo-en</code> (default)</td>
+              <td><code>jinaai/jina-reranker-v1-turbo-en</code></td>
+              <td>—</td>
+              <td>~150MB</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          The embedding config value is the fastembed model code you set under
+          <code>[embedding] model</code>; cartog downloads the matching ONNX-quantized repo from
+          HuggingFace into the shared model cache (<code>$FASTEMBED_CACHE_DIR</code>, else
+          <code>$XDG_CACHE_HOME/cartog/models</code>, else <code>~/.cache/cartog/models</code>).
+          English-only — non-English identifiers and comments get degraded embeddings. Override the
+          embedding model with any fastembed built-in via <code>[embedding] model = "..."</code>.
+        </p>
+        <p>
+          The reranker is configurable the same way via <code>[reranker] model</code> (a fastembed
+          reranker repo path). The default <code>jina-reranker-v1-turbo-en</code> is small, fast, and
+          scores higher on BEIR than the older <code>BAAI/bge-reranker-base</code> (~1.1GB), which you
+          can opt back into. Switching needs no re-index — the reranker runs at query time and isn't
+          persisted.
+        </p>
 
         <h3>Example: Ollama with GPU acceleration</h3>
         <pre><span class="comment"># 1. Install cartog (Ollama provider is included by default)</span>
@@ -300,7 +338,7 @@ cartog rag index .
 cartog rag search "error handling"</pre>
 
         <h3>Example: Disable re-ranking</h3>
-        <pre><span class="comment"># Skip the 1.1GB reranker model download</span>
+        <pre><span class="comment"># Skip the ~150MB reranker model download</span>
 cat > .cartog.toml &lt;&lt;EOF
 [reranker]
 provider = "none"
@@ -382,7 +420,7 @@ cartog index .                    <span class="comment"># toggling redact_secret
         <h2 id="rag-setup"><code>cartog rag setup</code></h2>
         <p>Download embedding and re-ranker models from HuggingFace. Run once before using semantic search with the <strong>local</strong> provider.</p>
         <pre>cartog rag setup</pre>
-        <p>Downloads ~1.2GB of ONNX models (embedding ~80MB + reranker ~1.1GB). Cached in <code>~/.cache/cartog/models/</code>.</p>
+        <p>Downloads ~230MB of ONNX models (embedding <code>Qdrant/bge-small-en-v1.5-onnx-Q</code> ~80MB + reranker <code>jinaai/jina-reranker-v1-turbo-en</code> ~150MB). Cached in <code>~/.cache/cartog/models/</code>. Pinning <code>[reranker] model</code> fetches that reranker instead.</p>
         <p><strong>Note:</strong> When using Ollama, skip this — models are managed by the Ollama server.</p>
         <pre><span class="comment"># To also skip the reranker download:</span>
 [reranker]
@@ -884,7 +922,7 @@ cartog --json doctor          <span class="comment"># structured JSON output</sp
   [+] config: loaded from /your/repo/.cartog.toml
   [+] database: 70 files, 697 symbols at .cartog/db.sqlite
   [+] embedding: local model cached
-  [+] reranker: local model cached
+  [+] reranker: jinaai/jina-reranker-v1-turbo-en cached
   [+] remote: not configured (local-only)
 
 All 6 checks passed</pre>

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -121,7 +121,7 @@ All examples below use CLI syntax. MCP tool names and parameters:
 
 Before first use, ensure cartog is installed and indexed.
 
-If the project uses Ollama (check `.cartog.toml` for `[embedding] provider = "ollama"`), Ollama manages the **embedding** model itself — but `cartog rag setup` still downloads the cross-encoder **reranker** (~100MB, provider-agnostic). Skip `rag setup` only if you also disable the reranker; otherwise run it once.
+If the project uses Ollama (check `.cartog.toml` for `[embedding] provider = "ollama"`), Ollama manages the **embedding** model itself — but `cartog rag setup` still downloads the cross-encoder **reranker** (~150MB default, provider-agnostic). Skip `rag setup` only if you also disable the reranker; otherwise run it once.
 
 The plugin's SessionStart hook handles install + indexing automatically:
 
@@ -150,7 +150,7 @@ the background pipeline completes.
 
 **How to tell which tier you're on**: inspect the result tags in `cartog rag search` output. `[fts5+vector]` means tier 3, `[fts5]` means tier 1 or 2, `rerank=...` scores appear from tier 2 onward. See `references/query_cookbook.md` → "Interpreting results" for the full decoder.
 
-> **First run**: tier 2 downloads ~1.2GB of ONNX models (cached in `~/.cache/cartog/models/`)
+> **First run**: tier 2 downloads ~230MB of ONNX models (cached in `~/.cache/cartog/models/`)
 > in the background. Search keeps working at tier 1 in the meantime; logs go to
 > `~/.cache/cartog/session.log`. Subsequent runs are instant.
 
@@ -543,5 +543,5 @@ For the full 3-phase workflow (heuristic → LSP upgrade → verify), see `refer
 - **No substring matching**: `"valid"` does NOT match `validate_token`. FTS5 is token-based. If `rag search` returns no results for a known symbol name, fall back to `cartog search` which supports substring matching.
 - **Graceful degradation**: `rag search` works without `rag setup` or `rag index` (FTS5-only). Quality improves with each setup tier (see Search quality tiers above).
 - **Scores are relative**: `rrf_score` and `rerank_score` values are only meaningful for ranking within a single query — don't compare scores across different queries.
-- **Re-ranking latency**: cross-encoder scores all candidates in a single batch ONNX call (up to 50 candidates). Expect ~150-500ms total overhead depending on candidate count.
+- **Re-ranking latency**: cross-encoder scores all candidates in a single batch ONNX call (up to 50 candidates). Expect ~50-300ms total overhead depending on candidate count (the default jina-turbo reranker is ~3x faster than the older bge-reranker-base).
 - **Auto re-embed**: when cartog upgrades its embedding format (e.g., AST-aware chunking), `cartog rag index` automatically detects the change and re-embeds all symbols. No `--force` needed.

--- a/skills/cartog/references/query_cookbook.md
+++ b/skills/cartog/references/query_cookbook.md
@@ -159,7 +159,7 @@ cartog rag index .                  # embed with Ollama
 cartog rag search "error handling"  # search works the same
 ```
 
-Ollama manages only the embedding model. The reranker (~100MB cross-encoder) is provider-agnostic and still comes from HuggingFace via `cartog rag setup`. Skip `rag setup` only if you intentionally disable the reranker.
+Ollama manages only the embedding model. The reranker (~150MB cross-encoder, default `jinaai/jina-reranker-v1-turbo-en`) is provider-agnostic and still comes from HuggingFace via `cartog rag setup`. Skip `rag setup` only if you intentionally disable the reranker.
 
 #### Troubleshooting
 

--- a/skills/cartog/scripts/ensure_indexed.sh
+++ b/skills/cartog/scripts/ensure_indexed.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 #   F4. `cartog index .` (incremental, typically <1s for unchanged trees).
 #
 # Background (forked into one subshell, logged to ~/.cache/cartog/session.log):
-#   B1. cartog rag setup — download cross-encoder reranker (~100MB, first time).
+#   B1. cartog rag setup — download cross-encoder reranker (~150MB, first time).
 #   B2. cartog rag index . — embed symbols for vector search.
 #
 # Failures during the background pipeline (or, separately, the foreground


### PR DESCRIPTION
## Summary

Flip the default RAG cross-encoder from `BAAI/bge-reranker-base` (~1.1GB) to **`jinaai/jina-reranker-v1-turbo-en` (~150MB)** — ~7× smaller, ~3× faster, and higher BEIR NDCG@10 — and make the reranker model selectable via `[reranker] model`, mirroring `[embedding] model`.

The reranker runs at query time and is never persisted, so the flip needs **no DB migration, no re-index**. Users who never pinned a model switch automatically on next search; pin `model = "BAAI/bge-reranker-base"` to keep the old one (reuses the cached weights). `cartog doctor` shows the active model and a reclaim hint for the orphaned bge-base cache.

> **BREAKING CHANGE**: the default downloaded reranker model changes for all users.

## What changed

**Behavior (`feat(rag)!` commit)**
- New `[reranker] model` config (free fastembed HF repo path, like `[embedding] model`); unset → `DEFAULT_RERANKER_MODEL` (jina-turbo).
- Default flipped via `EmbeddingProviderConfig::default()`.
- Unified the two duplicate reranker load paths into a single `load_text_rerank`.
- Threaded the model through `create_reranker_provider` / `download_cross_encoder` / `cartog rag setup` / MCP.
- Fixed a latent bug: `to_provider_config` dropped the `[reranker]` section when `[embedding]` was absent.

**Doc sync (`docs(rag)` commit)**
- usage.md, tech.md, troubleshooting.md, README, site (usage + index), and the cartog skill.
- Reconciled size figures to one value per model (combined first-run ~1.2GB → **~230MB**; fixed the skill's pre-existing reranker "~100MB" → ~150MB).
- Added a troubleshooting entry for reclaiming the orphaned bge-base cache.

## Review fixes folded in (extra-high-effort recall review)

- `cartog doctor` reports an **unparseable** `[reranker]`/`[embedding] model` as an *error* naming the bad value, instead of a misleading "not downloaded, run rag setup".
- `is_embedding_model_cached` now honors the **configured** embedding model (resolves via fastembed), symmetric with the reranker — fixes a pre-existing asymmetry the reranker work exposed.
- Resolve the reranker model **once** per load; derive the orphan cache dir from fastembed's `model_code` instead of a hardcoded path.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --workspace` — all green.
- `cargo check --no-default-features -p cartog-rag` and `--features provider-ollama` — green (cfg boundary holds).
- Site `npm run build` and `make check-skill` (40 tests) — green.
- jina-turbo size measured on disk: **147MB** (confirms ~150MB).
- E2E: default→jina-turbo cached + orphan hint; `model = "BAAI/bge-reranker-base"` reuses cache; invalid model → clear error.
- `make eval-skill` (28 LLM-judge routing scenarios) running; SKILL.md edits are size-wording only (no routing change) — will update if anything flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reranker and embedding models are now configurable via `.cartog.toml` `[reranker] model` and `[embedding] model` settings.
  * Default reranker changed to a smaller, faster model.

* **Improvements**
  * First-time RAG setup download reduced from ~1.2GB to ~230MB.
  * Cache detection now respects user-configured models.
  * `cartog doctor` command provides more accurate reporting for configured models.

* **Documentation**
  * Updated configuration examples, troubleshooting guides, and model sizing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->