### PR TITLE
docs(crates): render READMEs on docs.rs + sync them with code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,19 @@ The MCP config JSON has one canonical copy in `docs/mcp-setup.md`; other docs li
 
 Edit the `.astro` source (never `site/dist/`, which is gitignored and rebuilt by the Pages workflow). New brand marks go in `site/public/assets/*.svg` as `<img>`-referenced files (24×24 viewBox, white/brand fill legible on the dark theme), not inline SVG. Run `npm run build` in `site/` to verify before committing.
 
+### Per-crate docs.rs documentation
+
+Every published crate (`cartog` + the 9 `cartog-*`) renders its `README.md` as the docs.rs landing page. The wiring, per crate:
+
+- **`src/lib.rs`**: keep the curated `//!` header, then append the README via `#![doc = ""]` + `#![doc = include_str!("../README.md")]`. Feature-bearing crates (`cartog`, `-indexer`, `-mcp`, `-rag`) also carry `#![cfg_attr(docsrs, feature(doc_cfg))]` as the first attr, and gate visible feature badges with `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` on the relevant public item.
+- **`Cargo.toml`**: `[package.metadata.docs.rs]` with `all-features = true` (renders feature-gated modules) + `rustdoc-args = ["--cfg", "docsrs"]` (activates the badges). `docsrs` is set only by docs.rs (nightly); on stable CI the `cfg_attr` is inert, so this is stable-safe and has zero effect on `cargo build`/`publish`.
+
+Consequences to respect on every change:
+
+- **READMEs are now published API docs** — keep them code-accurate (correct fn/type names, signatures, counts, public exports). Stale README = stale docs.rs.
+- **Code fences become doctests.** A bare ` ``` ` fence or a ` ```rust ` fence in a wired README is compiled by `cargo test --doc`. Tag non-Rust examples ` ```text `/` ```toml `/` ```scheme `; tag illustrative-but-non-compiling Rust ` ```rust,ignore `; use ` ```rust,no_run ` for real, type-checked snippets that shouldn't execute. Run `cargo test --doc --workspace` (default **and** `--no-default-features`) after touching any README.
+- **Intra-doc links to private items** (`[`name`]` where `name` is private/out-of-scope) warn under `cargo doc`. Drop the brackets to plain `` `code` `` when the target is internal. `cargo doc --no-deps --workspace` must stay warning-clean.
+
 ## Current State
 
 - **Languages**: Python, TypeScript/JavaScript, Rust, Go, Ruby, Java, PHP, Dart, Swift, Kotlin, Markdown

--- a/crates/cartog-core/Cargo.toml
+++ b/crates/cartog-core/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/cartog-core/README.md
+++ b/crates/cartog-core/README.md
@@ -4,7 +4,7 @@ Core types and utilities for the cartog code graph indexer.
 
 ## Overview
 
-Foundation crate with zero internal dependencies. Defines the shared data model used by all other cartog crates: symbols, edges, and their metadata. Also provides pure utility functions like language detection.
+Foundation crate with no internal cartog dependencies. Defines the shared data model used by all other cartog crates: symbols, edges, and their metadata. Also provides pure utility functions like language detection.
 
 ## How it works
 
@@ -12,7 +12,7 @@ Foundation crate with zero internal dependencies. Defines the shared data model 
 
 Every symbol gets a deterministic ID built from its location in the code structure, not its position in the file:
 
-```
+```text
 file_path:kind:qualified_name
 ```
 
@@ -40,12 +40,13 @@ This ID is **invariant to line movements** within a file — renaming or moving 
 | `SymbolKind` | Function, Class, Method, Variable, Import, Interface, Enum, TypeAlias, Trait, Module, Document |
 | `Edge` | Relationship between symbols (source → target) |
 | `EdgeKind` | Calls, Imports, Inherits, References, Raises, Implements, TypeOf |
+| `EdgeProvenance` | Which tier/source resolved a `target_id` (heuristic tiers + LSP outcomes) |
 | `Visibility` | Public, Private, Protected |
 | `FileInfo` | Indexed file metadata (path, hash, language, symbol count) |
 | `ChangesResult` | Result of a git-changes query |
 | `symbol_id()` | Build a stable symbol ID from components |
-| `detect_language()` | Map file extension to language name |
+| `detect_language()` | Map file extension to language name (`None` for unrecognized extensions) |
 
 ## Crate dependencies
 
-None (this is the root of the dependency graph).
+No internal cartog crates (this is the root of the dependency graph). External: `serde`, `anyhow`, `schemars`.

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! Also provides [`detect_language`] for mapping file extensions to language names
 //! without pulling in tree-sitter grammar dependencies.
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 use std::path::Path;
 

--- a/crates/cartog-db/Cargo.toml
+++ b/crates/cartog-db/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/cartog-db/README.md
+++ b/crates/cartog-db/README.md
@@ -28,22 +28,22 @@ When edges are first inserted, `target_id` is `NULL`. The resolution algorithm r
 1. **Same file** — exact name match in the same source file
 2. **Import path** — follow already-resolved import edges
 3. **Same directory** — match symbols in sibling files
-4. **Parent scope** — prefer symbols sharing the same parent
+4. **Parent scope** — first symbol sharing the source's parent scope (sibling, `LIMIT 1`)
 5. **Project-wide unique** — exactly one match globally
-6. **Class over constructor** — when 2 matches remain, prefer `Class` kind
+6. **Kind disambiguation** — when exactly 2 matches remain, pick the higher-priority kind (type-like `class`/`interface`/`enum`/`type_alias`/`trait` > `function` > `method`); equal priorities stay unresolved
 
-Tiers 5 and 6 are evaluated together in a single project-wide query (capped at 3 candidates): a lone match resolves via tier 5, exactly two resolve via the tier-6 class preference, and 3+ stay unresolved.
+Tiers 5 and 6 are evaluated together in a single project-wide query (capped at 3 candidates): a lone match resolves via tier 5, exactly two resolve via the tier-6 kind disambiguation, and 3+ stay unresolved.
 
 ### Search ranking
 
 Symbol search uses a composite score:
 
-```
+```text
 rank = match_tier + kind_penalty
 ```
 
 - **match_tier**: exact match (0), prefix (1), substring (2)
-- **kind_penalty**: definitions like function/class (0), variable (3), import (6)
+- **kind_penalty**: definitions `function`/`method`/`class` (0), `variable` and all other kinds (3), `import` (6)
 - **tiebreaker**: `in_degree DESC` (most-referenced symbols first)
 
 ## Public API (key exports)

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -4,6 +4,8 @@
 //! Provides graph traversal queries (callees, refs, impact, hierarchy),
 //! full-text search via FTS5, vector KNN search via sqlite-vec, and a
 //! 6-tier heuristic edge resolution algorithm.
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 use anyhow::{Context, Result};
 use rusqlite::ffi::sqlite3_auto_extension;

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -398,7 +398,7 @@ pub fn register_sqlite_vec() {
 /// Current schema version. Increment when adding migrations.
 const SCHEMA_VERSION: u32 = 6;
 
-/// Public mirror of [`SCHEMA_VERSION`] for callers outside this crate
+/// Public mirror of the private `SCHEMA_VERSION` for callers outside this crate
 /// (e.g. `cartog pull` needs it to compare against a pulled DB and refuse
 /// to load a future-versioned file). Kept in sync by construction.
 pub const CURRENT_SCHEMA_VERSION: u32 = SCHEMA_VERSION;

--- a/crates/cartog-db/src/store/crud.rs
+++ b/crates/cartog-db/src/store/crud.rs
@@ -45,7 +45,7 @@ impl Database {
     ///   valid against whatever stack produced them; we just record the
     ///   identity going forward.
     ///
-    /// Writes use [`retry_busy`] so a concurrent writer on the same DB does
+    /// Writes use `retry_busy` so a concurrent writer on the same DB does
     /// not crash this caller with `SQLITE_BUSY`.
     pub fn reconcile_embedding_fingerprint(&self, fp: &EmbeddingFingerprint) -> Result<()> {
         let stored_provider: Option<String> = self.get_metadata(EMBED_PROVIDER_KEY)?;

--- a/crates/cartog-indexer/Cargo.toml
+++ b/crates/cartog-indexer/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 cartog-db = { workspace = true }

--- a/crates/cartog-indexer/README.md
+++ b/crates/cartog-indexer/README.md
@@ -20,7 +20,7 @@ Walks a directory tree, detects which files changed, extracts symbols and edges 
 
 Each symbol gets two hashes for fine-grained diff detection:
 
-```
+```text
 content_hash = SHA256(kind + ":" + name + ":" + signature + ":" + body_source)
 subtree_hash = SHA256(content_hash + sorted(children_subtree_hashes))
 ```
@@ -45,9 +45,12 @@ Edges that LSP classifies are persisted to `resolution_state` so future runs ski
 
 | Export | Description |
 |--------|-------------|
-| `index_directory()` | Main entry point — index a directory into the database. Optional `progress: Option<ProgressCallback>` fires at coarse phase boundaries (`Walking`, `Parsing`, `Storing`, `ResolvingLsp`); optional `cancel: Option<CancelProbe>` aborts cooperatively. Pass `None` for the no-op default. |
-| `IndexResult` | Summary: files indexed/skipped/removed, symbols added/modified/unchanged/removed, edges resolved (heuristic + `edges_lsp_resolved`, `edges_marked_unresolvable`, `edges_marked_external`), `dirty_files`, plus `files_unsupported` + `unsupported_by_ext` (files whose language isn't supported; cartog's own `.cartog.db*` / `db.sqlite*` sidecars are excluded from this tally) |
-| `ProgressUpdate` / `ProgressCallback` / `CancelProbe` | Type aliases for in-flight phase reporting and cooperative cancellation (`Fn` trait-object references, transport-agnostic) |
+| `index_directory()` | Main entry point — index a directory into the database. Takes `db`, `root`, `force`, `lsp`, `progress: Option<ProgressCallback>` (fires at coarse phase boundaries: `Walking`, `Parsing`, `Storing`, `ResolvingLsp`), `cancel: Option<CancelProbe>` (cooperative abort), and `redact: RedactionConfig` (secret scrubbing). Pass `None` for the no-op progress/cancel defaults. |
+| `IndexResult` | Summary: files indexed/skipped/removed, symbols added/modified/unchanged/removed, edges resolved (heuristic + `edges_lsp_resolved`, `edges_marked_unresolvable`, `edges_marked_external`), `dirty_files`, `files_unsupported` + `unsupported_by_ext` (files whose language isn't supported; cartog's own `.cartog.db*` / `db.sqlite*` sidecars are excluded), plus `files_redacted_skipped` (sensitive files never read/parsed) and `redaction_backfilled` (set when a first full re-index scrubs pre-redaction content) |
+| `render_index_summary()` | Render a human-readable one-block summary of an `IndexResult`; shared by `cartog index` CLI output and the `cartog_index` MCP tool |
+| `RedactionConfig` | Secret-redaction policy passed to `index_directory()` (default-on; `disabled()` for a verbatim no-op) |
+| `ProgressUpdate` | `pub enum` of in-flight phases (`Walking`, `Parsing { total }`, `Storing { total }`, `ResolvingLsp`) |
+| `ProgressCallback` / `CancelProbe` | Type aliases (`Fn` trait-object references) for phase reporting and cooperative cancellation (transport-agnostic) |
 | `is_ignored_dirname()` | Check if a directory name should be skipped (`.git`, `node_modules`, `target`, etc.) |
 | `git_recently_changed_files()` | List files changed in the last N git commits |
 

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -3,6 +3,9 @@
 //! Walks a directory tree, detects changed files (git diff, SHA-256 hash, or force),
 //! extracts symbols and edges via [`cartog_languages`], and writes results to
 //! [`cartog_db`]. Uses Merkle tree hashing for surgical symbol-level updates.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;

--- a/crates/cartog-indexer/src/redact.rs
+++ b/crates/cartog-indexer/src/redact.rs
@@ -26,7 +26,7 @@ pub(crate) const PLACEHOLDER: &str = "[REDACTED_SECRET]";
 #[derive(Debug, Clone, Copy)]
 pub struct RedactionConfig {
     /// When true, secret patterns in stored symbol text are replaced with
-    /// [`PLACEHOLDER`]. The sensitive-*file* deny-list is always enforced
+    /// a redaction placeholder. The sensitive-*file* deny-list is always enforced
     /// regardless of this flag.
     pub enabled: bool,
 }

--- a/crates/cartog-languages/Cargo.toml
+++ b/crates/cartog-languages/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/cartog-languages/README.md
+++ b/crates/cartog-languages/README.md
@@ -10,7 +10,7 @@ Parses source code using tree-sitter grammars and extracts symbols (functions, c
 
 ### Extractor trait
 
-```rust
+```rust,ignore
 pub trait Extractor: Send {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult>;
 }

--- a/crates/cartog-languages/src/lib.rs
+++ b/crates/cartog-languages/src/lib.rs
@@ -5,6 +5,8 @@
 //! queries for declarative AST pattern matching.
 //!
 //! Supported languages: Python, TypeScript, TSX, JavaScript, Rust, Go, Ruby, Java, PHP, Dart, Swift, Kotlin.
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 pub mod dart;
 pub mod go;

--- a/crates/cartog-lsp/Cargo.toml
+++ b/crates/cartog-lsp/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 cartog-db = { workspace = true }

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -3,6 +3,8 @@
 //! Resolves edges left unresolved by the heuristic resolver in [`cartog_db`],
 //! by querying real language servers (pyright, rust-analyzer, etc.) for
 //! `textDocument/definition` responses. Optional — gated behind the `lsp` feature.
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 pub mod client;
 pub mod manager;

--- a/crates/cartog-mcp/Cargo.toml
+++ b/crates/cartog-mcp/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 cartog-db = { workspace = true }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -3,6 +3,9 @@
 //! Exposes cartog's graph queries, indexing, semantic search, and deferred
 //! self-update as 16 MCP tools over stdio transport. Designed for Claude Code,
 //! Cursor, and other MCP clients.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};

--- a/crates/cartog-process-lock/Cargo.toml
+++ b/crates/cartog-process-lock/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 

--- a/crates/cartog-process-lock/README.md
+++ b/crates/cartog-process-lock/README.md
@@ -64,8 +64,8 @@ still matches what was observed, so a fresh writer landing in the gap is preserv
 | Export | Description |
 |--------|-------------|
 | `ProcessLock` | RAII handle for a held slot; `Drop` removes the PID file |
-| `ProcessLock::acquire(state_dir, slot)` | Atomically claim a slot; `Err(Held)` if a live peer owns it |
-| `ProcessLock::acquire_overwriting(state_dir, slot)` | Kill-switch acquire that always wins (no election) |
+| `ProcessLock::acquire(state_dir, slot)` | Atomically claim a slot; returns `Result<Self, AcquireError>` (`Err(Held)` if a live peer owns it) |
+| `ProcessLock::acquire_overwriting(state_dir, slot)` | Kill-switch acquire that always wins (no election); returns `io::Result<Self>` (no `Held` outcome) |
 | `ProcessLock::path()` | Path of the on-disk PID file |
 | `AcquireError` | `Held(ActiveLock)` (live peer owns the slot) or `Io(io::Error)` |
 | `ActiveLock` | A discovered live lock: `slot`, `pid`, `start_time: Option<u64>` |

--- a/crates/cartog-process-lock/src/lib.rs
+++ b/crates/cartog-process-lock/src/lib.rs
@@ -20,6 +20,8 @@
 //! by an unrelated process" from "same process is still running". When the
 //! start time is absent (legacy single-line file from an older cartog) we
 //! fall back to liveness-only checks.
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 use std::fs;
 use std::io;

--- a/crates/cartog-process-lock/src/lib.rs
+++ b/crates/cartog-process-lock/src/lib.rs
@@ -390,13 +390,13 @@ fn scan_locks(state_dir: &Path, cap: Option<usize>) -> Vec<ActiveLock> {
 }
 
 /// Reap stale PID files in `state_dir`. Opportunistic — capped at
-/// [`REAPER_SCAN_CAP`] entries per call to bound the cost on a state
+/// `REAPER_SCAN_CAP` entries per call to bound the cost on a state
 /// dir that has accumulated many cohabiting projects. Entries beyond
 /// the cap are reaped on a subsequent run.
 ///
 /// Each inspected `*.pid` whose recorded PID is dead (or whose recorded
 /// start_time disagrees with the live PID, i.e. PID-reuse) is unlinked
-/// via [`unlink_if_unchanged`] so a concurrent writer landing fresh
+/// via `unlink_if_unchanged` so a concurrent writer landing fresh
 /// content in the TOCTOU window is preserved. Malformed files
 /// (unreadable on two consecutive reads) are removed unconditionally
 /// because there is no holder identity to protect.

--- a/crates/cartog-rag/Cargo.toml
+++ b/crates/cartog-rag/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["provider-local"]
 provider-local = ["dep:fastembed"]

--- a/crates/cartog-rag/README.md
+++ b/crates/cartog-rag/README.md
@@ -18,6 +18,7 @@ Configurable via `.cartog.toml` `[embedding]` section. Supports pluggable provid
 |----------|-------------|--------|-------|
 | **local** (default) | `provider-local` | Any fastembed built-in (BGE, all-MiniLM, nomic, etc.) | ONNX Runtime via fastembed, auto-downloaded from HuggingFace |
 | **ollama** | `provider-ollama` | Any Ollama model (nomic-embed-text, mxbai-embed-large, etc.) | HTTP client, auto-detects dimension |
+| **openai** | `provider-openai` | Any OpenAI-compatible `/v1/embeddings` model (OpenAI, Mistral, Voyage, Jina, …) | HTTP client; switch vendors via `base_url`, API key from the env var named by `api_key_env` |
 
 **Reranker**: jina-reranker-v1-turbo-en (default, ~150MB) — cross-encoder that scores (query, document) pairs jointly (optional, local only). Configurable via `[reranker] model` (any fastembed reranker repo path); unset uses the default.
 
@@ -49,7 +50,7 @@ Over-retrieves `(limit * 3).max(20)` candidates from each source to improve fusi
 
 ### Provider lifecycle
 
-Providers are created per-command invocation via `create_embedding_provider(config)`. The caller passes an `EmbeddingProviderConfig` (from `.cartog.toml`) and receives a boxed `EmbeddingProvider` trait object. Reranker providers follow the same pattern with `create_reranker_provider(config)`.
+Providers are created per-command invocation via `create_embedding_provider(config)`. The caller passes an `EmbeddingProviderConfig` (from `.cartog.toml`) and receives a boxed `EmbeddingProvider` trait object. Reranker providers are created with `create_reranker_provider(reranker_provider, model, intra_threads)`, which returns `None` when re-ranking is disabled, the model is unavailable, or the `provider-local` feature is off.
 
 The Ollama provider maps transport failures to actionable errors instead of raw reqwest chains: a refused connection points at `ollama serve` and `[embedding.ollama].base_url`, and an HTTP 404 from `/api/embed` tells the user to run `ollama pull <model>`. The original error is preserved as the cause.
 
@@ -63,8 +64,8 @@ The Ollama provider maps transport failures to actionable errors instead of raw 
 | `provider::EmbeddingProvider` | Trait for embedding backends |
 | `provider::RerankerProvider` | Trait for reranker backends |
 | `search::hybrid_search()` | Run the full hybrid search pipeline |
-| `indexer::index_embeddings()` | Embed symbols and write vectors to DB. Optional `progress: Option<ProgressCallback>` fires per batch (`Preparing`, `Embedding{processed,total}`, `Storing`); pass `None` for no-op. |
-| `indexer::ProgressUpdate` / `indexer::ProgressCallback` | Phase enum + `Fn` trait-object type alias for in-flight reporting (transport-agnostic) |
+| `indexer::index_embeddings()` | Embed symbols and write vectors to DB. Optional `progress: Option<ProgressCallback>` fires per batch (`Preparing`, `Embedding{processed,total}`, `Storing`) and `cancel: Option<CancelProbe>` aborts cooperatively; pass `None` for no-op. |
+| `indexer::ProgressUpdate` / `indexer::ProgressCallback` / `indexer::CancelProbe` | Phase enum + `Fn` trait-object type aliases for in-flight reporting and cancellation (transport-agnostic) |
 | `setup::download_model()` | Download the embedding model (requires the `provider-local` feature) |
 | `EMBEDDING_DIM` | Default vector dimension (384) |
 

--- a/crates/cartog-rag/src/lib.rs
+++ b/crates/cartog-rag/src/lib.rs
@@ -7,6 +7,9 @@
 //! - **local** (default): ONNX models via fastembed (feature `provider-local`)
 //! - **ollama**: HTTP API to an Ollama server (feature `provider-ollama`)
 //! - **openai**: OpenAI-compatible `/v1/embeddings` endpoints (feature `provider-openai`)
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 pub mod context;
 #[cfg(feature = "provider-local")]

--- a/crates/cartog-watch/Cargo.toml
+++ b/crates/cartog-watch/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 cartog-db = { workspace = true }

--- a/crates/cartog-watch/README.md
+++ b/crates/cartog-watch/README.md
@@ -36,7 +36,7 @@ Both modes open their own `Database` connection (SQLite WAL allows concurrent re
 
 | Export | Description |
 |--------|-------------|
-| `WatchConfig` | Configuration: `root`, `debounce`, `rag_override: Option<bool>` (force RAG auto-embed on/off; `None` defers to live data), `rag_delay`, `rag_config` (provider config for embedding + reranker, threaded from `.cartog.toml`), `redact: RedactionConfig` (secret scrubbing on re-index), `json_events` (emit machine-readable event lines), `pid_lock_dir` + `pid_lock_slot` (PID-lock tracking; both must be set together or neither), `skip_migrations` |
+| `WatchConfig` | Configuration: `root`, `debounce`, `rag_override: Option<bool>` (force RAG auto-embed on/off; `None` defers to live data), `rag_delay`, `rag_config: rag::EmbeddingProviderConfig` (embedding + reranker config, threaded from `.cartog.toml`), `redact: RedactionConfig` (secret scrubbing on re-index), `json_events` (emit machine-readable event lines), `pid_lock_dir` + `pid_lock_slot` (PID-lock tracking; both must be set together or neither), `skip_migrations`, `stale: Option<Arc<StaleState>>` (shared staleness state for the MCP server; `None` disables publishing) |
 | `StaleSnapshot` / `StaleState` | Structural-staleness state (monotonic `change_seq` counters), written by the watch thread and read by the MCP server over an `Arc<StaleState>` to drive the `⚠️` staleness banners |
 | `WatchHandle` | Handle to stop a background watcher (via `stop()` or `Drop`) |
 | `WATCH_LOCK_SLOT` | Conventional PID-lock slot name (`"watch"`) |

--- a/crates/cartog-watch/README.md
+++ b/crates/cartog-watch/README.md
@@ -16,7 +16,7 @@ Events are filtered to **relevant paths only**: the file must have a supported e
 
 ### RAG timer
 
-When RAG embedding is enabled (`rag = true`):
+RAG auto-embed is on when the repo already has embeddings; `rag_override: Some(bool)` forces it on or off. When enabled:
 
 1. After each re-index, check if any symbols need embedding
 2. If yes, record `Instant::now()` and set `rag_pending = true`
@@ -36,7 +36,8 @@ Both modes open their own `Database` connection (SQLite WAL allows concurrent re
 
 | Export | Description |
 |--------|-------------|
-| `WatchConfig` | Configuration: `root`, `debounce`, `rag` toggle, `rag_delay`, `rag_config` (provider config for embedding + reranker, threaded from `.cartog.toml`), `json_events` (emit machine-readable event lines), `pid_lock_dir` + `pid_lock_slot` (PID-lock tracking; both must be set together or neither), `skip_migrations` |
+| `WatchConfig` | Configuration: `root`, `debounce`, `rag_override: Option<bool>` (force RAG auto-embed on/off; `None` defers to live data), `rag_delay`, `rag_config` (provider config for embedding + reranker, threaded from `.cartog.toml`), `redact: RedactionConfig` (secret scrubbing on re-index), `json_events` (emit machine-readable event lines), `pid_lock_dir` + `pid_lock_slot` (PID-lock tracking; both must be set together or neither), `skip_migrations` |
+| `StaleSnapshot` / `StaleState` | Structural-staleness state (monotonic `change_seq` counters), written by the watch thread and read by the MCP server over an `Arc<StaleState>` to drive the `⚠️` staleness banners |
 | `WatchHandle` | Handle to stop a background watcher (via `stop()` or `Drop`) |
 | `WATCH_LOCK_SLOT` | Conventional PID-lock slot name (`"watch"`) |
 | `spawn_watch(config, db_path)` | Start watching on a background thread |

--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -3,6 +3,8 @@
 //! Watches a directory for source file changes using debounced filesystem events,
 //! triggers incremental re-indexing, and optionally defers RAG embedding to batch
 //! changed symbols after a configurable quiet period.
+#![doc = ""]
+#![doc = include_str!("../README.md")]
 
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 keywords = ["code-analysis", "tree-sitter", "graph", "llm", "code-intelligence"]
 categories = ["development-tools", "command-line-utilities"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cartog-core = { workspace = true }
 cartog-db = { workspace = true }

--- a/crates/cartog/README.md
+++ b/crates/cartog/README.md
@@ -57,7 +57,7 @@ All log output goes to **stderr** (stdout is reserved for CLI output and MCP pro
 
 `lib.rs` re-exports all workspace crates for backward-compatible access:
 
-```rust
+```rust,ignore
 pub use cartog_db as db;
 pub use cartog_indexer as indexer;
 pub use cartog_languages as languages;
@@ -69,6 +69,36 @@ pub use cartog_process_lock as process_lock; // hidden from rustdoc
 ```
 
 This allows benches and integration tests to use `cartog::db::Database`, `cartog::indexer::index_directory`, etc.
+
+### Library usage
+
+Index a directory, then query the graph:
+
+```rust,no_run
+use cartog::db::{Database, DEFAULT_EMBEDDING_DIM};
+use cartog::indexer::{index_directory, RedactionConfig};
+
+# fn main() -> anyhow::Result<()> {
+let db = Database::open(".cartog/db.sqlite", DEFAULT_EMBEDDING_DIM)?;
+
+// Walk the tree, extract symbols + edges, store them.
+index_directory(
+    &db,
+    std::path::Path::new("."),
+    false,                      // force: reuse incremental cache
+    false,                      // lsp: heuristic edge resolution only
+    None,                       // progress callback
+    None,                       // cancellation probe
+    RedactionConfig::default(), // scrub secrets (default-on)
+)?;
+
+// Symbol search ranked by match tier + centrality.
+for sym in db.search("parse", None, None, 10)? {
+    println!("{} ({:?}) {}:{}", sym.name, sym.kind, sym.file_path, sym.start_line);
+}
+# Ok(())
+# }
+```
 
 ## Crate dependencies
 

--- a/crates/cartog/src/auto_check.rs
+++ b/crates/cartog/src/auto_check.rs
@@ -1,9 +1,9 @@
 //! Auto-check predicate and helpers for the daily background update probe.
 //!
 //! Two responsibilities:
-//! 1. The pure [`should_check`] predicate decides whether to fire the
+//! 1. The pure `should_check` predicate decides whether to fire the
 //!    background probe at all (env, TTY, command kind, interval).
-//! 2. [`run_check_once`] / [`spawn_check`] perform the actual probe:
+//! 2. `run_check_once` / `spawn_check` perform the actual probe:
 //!    fetch the latest release tag and update the on-disk state file.
 //!
 //! Both halves take their inputs as parameters so unit tests can exercise

--- a/crates/cartog/src/lib.rs
+++ b/crates/cartog/src/lib.rs
@@ -1,7 +1,5 @@
-//! Cartog — code graph indexer for LLM coding agents.
-//!
-//! This library facade re-exports all workspace crates under the `cartog::`
-//! namespace (e.g., `cartog::db`, `cartog::types`, `cartog::indexer`).
+#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use cartog_core as types;
 pub use cartog_db as db;
@@ -11,6 +9,7 @@ pub use cartog_rag as rag;
 pub use cartog_watch as watch;
 
 #[cfg(feature = "lsp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lsp")))]
 pub use cartog_lsp as lsp;
 
 /// PID-file locks used by long-lived commands (`serve`, `watch`) and

--- a/crates/cartog/src/lib.rs
+++ b/crates/cartog/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 
 pub use cartog_core as types;
 pub use cartog_db as db;


### PR DESCRIPTION
## Why

cartog's docs.rs pages showed only a 4-line `//!` header while the READMEs (which had the real content) weren't rendered. This wires every published crate's README as its docs.rs landing page and fixes the factual drift that surfaced once the READMEs became published API docs.

## What

**`ae99a38` — render READMEs on docs.rs + feature-flag badges**
- Each crate's `lib.rs` keeps its curated `//!` header, then appends the README via `#![doc = include_str!("../README.md")]`.
- `[package.metadata.docs.rs]` on all 10 crates: `all-features = true` (renders feature-gated modules) + `rustdoc-args = ["--cfg", "docsrs"]` (activates badges).
- Feature crates (`cartog`, `-indexer`, `-mcp`, `-rag`) gate `feature(doc_cfg)` on `docsrs`; facade `lsp` export gets a `doc(cfg)` badge.
- Facade README gains a runnable `no_run` library-usage example; illustrative non-compiling Rust fences marked `rust,ignore`.

**`d75813e` — sync crate READMEs with code, fix broken intra-doc links**
- cartog-core: "dependencies: None" was false; add `EdgeProvenance`, `detect_language` `Option` return.
- cartog-db: reword resolution tiers 4 & 6 to match code; complete the ranking penalties.
- cartog-indexer: add `redact` param, fix `ProgressUpdate` (enum, not alias), add redaction `IndexResult` fields + `RedactionConfig` + `render_index_summary`.
- cartog-rag: add the **missing `openai` provider**; correct `create_reranker_provider` / `index_embeddings` signatures + `CancelProbe`.
- cartog-watch: `rag_override`, `redact`, `StaleSnapshot`/`StaleState`.
- cartog-process-lock: note `acquire_overwriting` returns `io::Result`.
- Drop intra-doc-link brackets on private items → `cargo doc` warning-clean (was 12 warnings).

## No CI/release impact

`docsrs` cfg is set only by docs.rs (nightly); inert on stable, so CI, `cargo build`, and `cargo publish` are unaffected. No toolchain pin added. Also fixed a latent `--no-default-features` doctest break.

## Verification

- `cargo test --doc --workspace` — default **and** `--no-default-features` ✅
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` — default **and** `--no-default-features`, 0 warnings ✅
- `cargo doc --no-deps --workspace` — 0 warnings, all 10 crates generate ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced crate documentation on docs.rs with comprehensive README content across all crates.
  * Clarified public API documentation for key functions including redaction configuration, progress tracking, and RAG embedding behavior.
  * Updated edge-resolution and search ranking documentation for database functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->