### PR TITLE
test: property-based testing + symbol-ID injectivity fix (schema v6→7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
     # The default-feature suite is run (and gated) by the `coverage` job via
     # `cargo llvm-cov`, so it is not repeated here. This job covers only the
     # `--no-default-features` build, which `coverage` does not exercise.
+    env:
+      # Explore deeper than the local default (256) so proptest finds rare
+      # reachable failures in CI, where the shrunk case is saved to a
+      # proptest-regressions file and is reproducible — rather than surfacing
+      # randomly on an unrelated PR.
+      PROPTEST_CASES: 1024
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -91,6 +97,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    env:
+      # Deeper proptest exploration than the local default (256); see the `test`
+      # job. This job runs the default-feature property tests.
+      PROPTEST_CASES: 1024
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +324,7 @@ name = "cartog-core"
 version = "0.25.1"
 dependencies = [
  "anyhow",
+ "proptest",
  "schemars",
  "serde",
 ]
@@ -338,6 +354,7 @@ dependencies = [
  "cartog-languages",
  "cartog-lsp",
  "criterion",
+ "proptest",
  "rayon",
  "regex",
  "serde",
@@ -2539,6 +2556,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3026,6 +3077,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3987,6 +4050,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,6 +4198,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "directories",
  "flate2",
  "libc",
+ "proptest",
  "reqwest",
  "rusqlite",
  "rust-s3",
@@ -370,6 +371,7 @@ version = "0.25.1"
 dependencies = [
  "anyhow",
  "cartog-core",
+ "proptest",
  "streaming-iterator",
  "tracing",
  "tree-sitter",
@@ -419,6 +421,7 @@ dependencies = [
  "cartog-process-lock",
  "cartog-rag",
  "cartog-watch",
+ "proptest",
  "rmcp",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ url = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"
 serial_test = "3"
+proptest = "1"
 
 [workspace.lints.rust]
 # cartog-process-lock has unsafe libc/Win32 calls; require explicit unsafe

--- a/crates/cartog-core/Cargo.toml
+++ b/crates/cartog-core/Cargo.toml
@@ -16,5 +16,8 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
 
+[dev-dependencies]
+proptest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/cartog-core/proptest-regressions/lib.txt
+++ b/crates/cartog-core/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f3e5cb5fdd0683f16cf236341161c8d0d986d654f1e03673328cc1429c0c9d07 # shrinks to file = "", kind = Function, parent = "0", name = "a"

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -590,6 +590,23 @@ mod tests {
     }
 
     #[test]
+    fn symbol_id_escapes_colon_in_leaf() {
+        // A `:` in the leaf would otherwise blur the kind/qname boundary.
+        let escaped = symbol_id("f", SymbolKind::Import, "a:b", None);
+        assert_eq!(escaped, "f:import:a%3Ab");
+        assert_ne!(escaped, "f:import:a:b");
+    }
+
+    #[test]
+    fn symbol_id_escapes_percent_in_leaf() {
+        // `%` is escaped first so the mapping stays injective (a literal `%2E`
+        // must not be confused with an escaped `.`).
+        let escaped = symbol_id("f", SymbolKind::Import, "a%2Eb", None);
+        assert_eq!(escaped, "f:import:a%252Eb");
+        assert_ne!(escaped, "f:import:a%2Eb");
+    }
+
+    #[test]
     fn test_detect_language() {
         assert_eq!(detect_language(Path::new("src/main.py")), Some("python"));
         assert_eq!(detect_language(Path::new("lib.pyi")), Some("python"));

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -9,6 +9,7 @@
 #![doc = ""]
 #![doc = include_str!("../README.md")]
 
+use std::borrow::Cow;
 use std::path::Path;
 
 use serde::Serialize;
@@ -313,6 +314,27 @@ pub struct ChangesResult {
     pub symbols: Vec<Symbol>,
 }
 
+/// Percent-escape the ID separators (`%` first, then `.`/`:`) in a leaf-name
+/// segment so a name containing `.`/`:` can't be confused with a structural `.`
+/// join or a boundary `:`. Identity for any string free of `% . :` (every
+/// ordinary identifier), so common-case IDs stay byte-for-byte unchanged; only
+/// composite leaves (dotted imports, `.`/`:`-bearing markdown headings) differ.
+fn escape_segment(s: &str) -> Cow<'_, str> {
+    if !s.contains(['%', '.', ':']) {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        match c {
+            '%' => out.push_str("%25"),
+            '.' => out.push_str("%2E"),
+            ':' => out.push_str("%3A"),
+            other => out.push(other),
+        }
+    }
+    Cow::Owned(out)
+}
+
 /// Build a stable symbol ID: `file_path:kind:qualified_name`
 ///
 /// The qualified name encodes the parent chain using `.` separators:
@@ -322,6 +344,11 @@ pub struct ChangesResult {
 ///
 /// This ID is stable across line movements within a file. `kind` is typed so a
 /// mistyped kind fails to compile rather than silently mis-forming the ID.
+///
+/// The leaf `name` is separator-escaped so distinct logical symbols never share
+/// an ID (a collision is a silent DB overwrite). `parent_name` is emitted raw:
+/// its `.` separators are structural (built by the extractors from already-bare
+/// segments), so it carries no injected separators.
 #[must_use]
 pub fn symbol_id(
     file_path: &str,
@@ -330,6 +357,7 @@ pub fn symbol_id(
     parent_name: Option<&str>,
 ) -> String {
     let kind = kind.as_str();
+    let name = escape_segment(name);
     match parent_name {
         Some(pn) => format!("{file_path}:{kind}:{pn}.{name}"),
         None => format!("{file_path}:{kind}:{name}"),
@@ -449,6 +477,86 @@ mod tests {
                 "validate",
                 Some("TokenService")
             )
+        );
+    }
+
+    use proptest::prelude::*;
+
+    /// Strategy over every [`SymbolKind`] variant.
+    fn any_kind() -> impl Strategy<Value = SymbolKind> {
+        prop_oneof![
+            Just(SymbolKind::Function),
+            Just(SymbolKind::Class),
+            Just(SymbolKind::Method),
+            Just(SymbolKind::Variable),
+            Just(SymbolKind::Import),
+            Just(SymbolKind::Interface),
+            Just(SymbolKind::Enum),
+            Just(SymbolKind::TypeAlias),
+            Just(SymbolKind::Trait),
+            Just(SymbolKind::Module),
+            Just(SymbolKind::Document),
+        ]
+    }
+
+    /// Component string: mix of ordinary identifier chars and the `:`/`.`
+    /// separators so the generator probes separator-injection collisions.
+    fn component() -> impl Strategy<Value = String> {
+        proptest::string::string_regex("[A-Za-z0-9_.:/]{0,8}").unwrap()
+    }
+
+    proptest! {
+        /// Same logical tuple always yields the same ID.
+        #[test]
+        fn symbol_id_is_deterministic(
+            file in component(),
+            kind in any_kind(),
+            name in component(),
+            parent in proptest::option::of(component()),
+        ) {
+            let a = symbol_id(&file, kind, &name, parent.as_deref());
+            let b = symbol_id(&file, kind, &name, parent.as_deref());
+            prop_assert_eq!(a, b);
+        }
+
+        /// Distinct logical tuples must yield distinct IDs (a collision is a
+        /// silent DB overwrite). Drives the realistic vector directly: method
+        /// `name` of `parent` vs a top-level symbol named `parent.name`.
+        #[test]
+        fn symbol_id_is_injective(
+            file in component(),
+            kind in any_kind(),
+            parent in "[A-Za-z0-9_]{1,6}",
+            name in "[A-Za-z0-9_]{1,6}",
+        ) {
+            let id_a = symbol_id(&file, kind, &name, Some(&parent));
+            let merged = format!("{parent}.{name}");
+            let id_b = symbol_id(&file, kind, &merged, None);
+            prop_assert_ne!(id_a, id_b);
+        }
+    }
+
+    #[test]
+    fn symbol_id_separates_dotted_leaf_from_parent_join() {
+        // Regression for the proptest-found collision (silent DB overwrite).
+        let method = symbol_id("f", SymbolKind::Method, "a", Some("0"));
+        let dotted = symbol_id("f", SymbolKind::Method, "0.a", None);
+        assert_eq!(method, "f:method:0.a");
+        assert_eq!(dotted, "f:method:0%2Ea");
+        assert_ne!(method, dotted);
+    }
+
+    #[test]
+    fn symbol_id_is_identity_for_bare_identifiers() {
+        // Ordinary names stay byte-identical (existing DBs + extractor assertions).
+        assert_eq!(
+            symbol_id(
+                "src/auth.py",
+                SymbolKind::Method,
+                "validate",
+                Some("Outer.Inner")
+            ),
+            "src/auth.py:method:Outer.Inner.validate"
         );
     }
 

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -345,10 +345,14 @@ fn escape_segment(s: &str) -> Cow<'_, str> {
 /// This ID is stable across line movements within a file. `kind` is typed so a
 /// mistyped kind fails to compile rather than silently mis-forming the ID.
 ///
-/// The leaf `name` is separator-escaped so distinct logical symbols never share
-/// an ID (a collision is a silent DB overwrite). `parent_name` is emitted raw:
-/// its `.` separators are structural (built by the extractors from already-bare
-/// segments), so it carries no injected separators.
+/// The leaf `name` is separator-escaped so a leaf containing `.`/`:` cannot
+/// collide with a structural join or boundary (a collision is a silent DB
+/// overwrite). `parent_name` is emitted raw: its `.` separators are structural,
+/// and today every extractor builds it from bare-identifier segments, so it
+/// carries no injected separators. That invariant is assumed, not enforced here:
+/// a future extractor that nests children under a separator-bearing name would
+/// reopen the collision on the parent side. If that ever happens, escape each
+/// segment in `qualified()` (where the boundary is known) rather than only here.
 #[must_use]
 pub fn symbol_id(
     file_path: &str,
@@ -482,21 +486,46 @@ mod tests {
 
     use proptest::prelude::*;
 
+    /// Every [`SymbolKind`] variant. The exhaustive (wildcard-free) match in
+    /// `kind_is_listed` makes the compiler reject this list going stale when a
+    /// variant is added.
+    const ALL_KINDS: [SymbolKind; 11] = [
+        SymbolKind::Function,
+        SymbolKind::Class,
+        SymbolKind::Method,
+        SymbolKind::Variable,
+        SymbolKind::Import,
+        SymbolKind::Interface,
+        SymbolKind::Enum,
+        SymbolKind::TypeAlias,
+        SymbolKind::Trait,
+        SymbolKind::Module,
+        SymbolKind::Document,
+    ];
+
+    /// Compile-time guard: every variant must be present in [`ALL_KINDS`]. A new
+    /// variant added to the enum fails this non-wildcard match until listed.
+    #[allow(dead_code)]
+    fn kind_is_listed(k: SymbolKind) -> bool {
+        let present = |want| ALL_KINDS.contains(&want);
+        match k {
+            SymbolKind::Function => present(SymbolKind::Function),
+            SymbolKind::Class => present(SymbolKind::Class),
+            SymbolKind::Method => present(SymbolKind::Method),
+            SymbolKind::Variable => present(SymbolKind::Variable),
+            SymbolKind::Import => present(SymbolKind::Import),
+            SymbolKind::Interface => present(SymbolKind::Interface),
+            SymbolKind::Enum => present(SymbolKind::Enum),
+            SymbolKind::TypeAlias => present(SymbolKind::TypeAlias),
+            SymbolKind::Trait => present(SymbolKind::Trait),
+            SymbolKind::Module => present(SymbolKind::Module),
+            SymbolKind::Document => present(SymbolKind::Document),
+        }
+    }
+
     /// Strategy over every [`SymbolKind`] variant.
     fn any_kind() -> impl Strategy<Value = SymbolKind> {
-        prop_oneof![
-            Just(SymbolKind::Function),
-            Just(SymbolKind::Class),
-            Just(SymbolKind::Method),
-            Just(SymbolKind::Variable),
-            Just(SymbolKind::Import),
-            Just(SymbolKind::Interface),
-            Just(SymbolKind::Enum),
-            Just(SymbolKind::TypeAlias),
-            Just(SymbolKind::Trait),
-            Just(SymbolKind::Module),
-            Just(SymbolKind::Document),
-        ]
+        proptest::sample::select(ALL_KINDS.to_vec())
     }
 
     /// Component string: mix of ordinary identifier chars and the `:`/`.`

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -814,8 +814,10 @@ fn backup_before_destructive_migration(
         .prepare("SELECT content_hash FROM symbols LIMIT 0")
         .is_ok();
 
-    // Mirrors the condition in `migrate()` for the 2→3 wipe.
-    let will_wipe = current < 3 || !has_hash_cols;
+    // Mirrors the destructive conditions in `migrate()`: the 2→3 stable-id wipe
+    // (`current < 3 || !has_hash_cols`) and the 6→7 symbol-id-escaping wipe
+    // (`current < 7`). Either clears every indexed row, so back up first.
+    let will_wipe = current < 7 || !has_hash_cols;
     if !will_wipe {
         return Ok(());
     }
@@ -5128,6 +5130,19 @@ mod tests {
             )
             .unwrap();
         assert_eq!(bumped, SCHEMA_VERSION.to_string());
+
+        // The v7 wipe is destructive, so the pre-migration DB must be backed up
+        // first — same safety contract as the v2→3 wipe.
+        let backups = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("v6.sqlite.pre-v")
+            })
+            .count();
+        assert_eq!(backups, 1, "v6→7 wipe must back up the index first");
     }
 
     #[test]

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -822,10 +822,26 @@ fn backup_before_destructive_migration(
         return Ok(());
     }
 
-    let symbol_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))
-        .unwrap_or(0);
-    if symbol_count == 0 {
+    // Back up if ANY wiped table holds data, not just `symbols`: a partially
+    // indexed DB (e.g. edges/content written before symbols) would otherwise
+    // skip the backup and lose those rows to the wipe. A missing table errors
+    // the EXISTS probe, which `unwrap_or(false)` treats as empty.
+    let has_rows = |table: &str| -> bool {
+        conn.query_row(&format!("SELECT EXISTS(SELECT 1 FROM {table})"), [], |r| {
+            r.get::<_, bool>(0)
+        })
+        .unwrap_or(false)
+    };
+    let any_indexed = [
+        "symbols",
+        "edges",
+        "files",
+        "symbol_content",
+        "symbol_embedding_map",
+    ]
+    .iter()
+    .any(|t| has_rows(t));
+    if !any_indexed {
         return Ok(());
     }
 
@@ -852,6 +868,9 @@ fn backup_before_destructive_migration(
             source,
         })?;
 
+    let symbol_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))
+        .unwrap_or(0);
     info!(
         backup = %backup_path.display(),
         old_version = current,
@@ -5056,7 +5075,10 @@ mod tests {
     }
 
     /// Bootstrap a v6-shaped DB (all columns present, stamped at v6) with one
-    /// seeded symbol/file/edge and a `last_commit`, so the v6→7 wipe is testable.
+    /// seeded row in every table the v7 wipe clears, plus a `last_commit`, so the
+    /// wipe is observable per table. `symbol_content` uses the real shape and the
+    /// FTS5 vtable + insert/delete triggers so its row inserts (and the wipe's
+    /// delete) keep the external-content index consistent.
     fn bootstrap_v6_db(path: &std::path::Path) {
         let conn = Connection::open(path).unwrap();
         conn.execute_batch(
@@ -5072,7 +5094,22 @@ mod tests {
                 kind TEXT NOT NULL, file_path TEXT NOT NULL, line INTEGER,
                 resolution_state INTEGER NOT NULL DEFAULT 0, resolution_source TEXT);
              CREATE TABLE files (path TEXT PRIMARY KEY);
-             CREATE TABLE symbol_content (symbol_id TEXT PRIMARY KEY);
+             CREATE TABLE symbol_content (
+                symbol_id TEXT PRIMARY KEY, content TEXT NOT NULL, header TEXT NOT NULL,
+                normalized_name TEXT NOT NULL DEFAULT '');
+             CREATE VIRTUAL TABLE symbol_fts USING fts5(
+                symbol_name, normalized_name, content,
+                content=symbol_content, content_rowid=rowid);
+             CREATE TRIGGER symbol_content_ai AFTER INSERT ON symbol_content BEGIN
+                INSERT INTO symbol_fts(rowid, symbol_name, normalized_name, content)
+                VALUES (new.rowid, (SELECT name FROM symbols WHERE id = new.symbol_id),
+                        new.normalized_name, new.content);
+             END;
+             CREATE TRIGGER symbol_content_ad AFTER DELETE ON symbol_content BEGIN
+                INSERT INTO symbol_fts(symbol_fts, rowid, symbol_name, normalized_name, content)
+                VALUES ('delete', old.rowid, (SELECT name FROM symbols WHERE id = old.symbol_id),
+                        old.normalized_name, old.content);
+             END;
              CREATE TABLE symbol_embedding_map (symbol_id TEXT NOT NULL);
              CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
              CREATE TABLE query_log (id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -5081,6 +5118,9 @@ mod tests {
              INSERT INTO files (path) VALUES ('a.py');
              INSERT INTO edges (source_id, target_name, kind, file_path, line)
                 VALUES ('a.py:import:os.path', 'os', 'imports', 'a.py', 1);
+             INSERT INTO symbol_content (symbol_id, content, header)
+                VALUES ('a.py:import:os.path', 'body', 'sig');
+             INSERT INTO symbol_embedding_map (symbol_id) VALUES ('a.py:import:os.path');
              INSERT INTO metadata (key, value) VALUES ('schema_version', '6');
              INSERT INTO metadata (key, value) VALUES ('last_commit', 'deadbeef');",
         )
@@ -5106,6 +5146,12 @@ mod tests {
         assert_eq!(count("symbols"), 0, "symbols cleared");
         assert_eq!(count("edges"), 0, "edges cleared");
         assert_eq!(count("files"), 0, "files cleared");
+        assert_eq!(count("symbol_content"), 0, "symbol_content cleared");
+        assert_eq!(
+            count("symbol_embedding_map"),
+            0,
+            "symbol_embedding_map cleared"
+        );
 
         let last_commit: Option<String> = db
             .conn

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -396,7 +396,7 @@ pub fn register_sqlite_vec() {
 }
 
 /// Current schema version. Increment when adding migrations.
-const SCHEMA_VERSION: u32 = 6;
+const SCHEMA_VERSION: u32 = 7;
 
 /// Public mirror of the private `SCHEMA_VERSION` for callers outside this crate
 /// (e.g. `cartog pull` needs it to compare against a pulled DB and refuse
@@ -654,6 +654,21 @@ fn migrate(conn: &Connection) {
         if let Err(e) = conn.execute("ALTER TABLE edges ADD COLUMN resolution_source TEXT", []) {
             warn!(error = %e, "failed to add edges.resolution_source column");
         }
+    }
+
+    // Migration 6 → 7: symbol-ID leaf-name escaping for injectivity.
+    // The ID format gained separator-escaping for composite leaf names (dotted
+    // import paths, `.`/`:`-bearing markdown headings) so distinct symbols can no
+    // longer collide to one ID. Existing rows carry the old (collidable) IDs, so
+    // clear the index for a full rebuild — mirrors the v2→3 stable-ID wipe.
+    if current < 7 {
+        info!("schema v7: symbol-ID escaping — clearing index for full rebuild");
+        for table in &["symbol_content", "edges", "symbols", "files"] {
+            let _ = conn.execute(&format!("DELETE FROM {table}"), []);
+        }
+        let _ = conn.execute("DELETE FROM symbol_vec", []);
+        let _ = conn.execute("DELETE FROM symbol_embedding_map", []);
+        let _ = conn.execute("DELETE FROM metadata WHERE key = 'last_commit'", []);
     }
 
     // Store the new schema version
@@ -3887,12 +3902,12 @@ mod tests {
     }
 
     #[test]
-    fn populated_v1_db_runs_full_ladder_to_v6() {
+    fn populated_v1_db_runs_full_ladder_to_current() {
         // Negative guard for the fresh-DB fast path: a real pre-versioning v1 DB
         // (no schema_version row, narrow v1 columns, but SEEDED with rows) must
-        // NOT be misclassified as fresh. It runs the full v1→v6 ladder including
-        // the intentional v2→3 stable-id wipe and lands at schema_version=6 with
-        // every later column present.
+        // NOT be misclassified as fresh. It runs the full v1→current ladder
+        // including the intentional v2→3 stable-id wipe and lands at the current
+        // schema version with every later column present.
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("v1.sqlite");
         {
@@ -3919,7 +3934,7 @@ mod tests {
 
         let db = Database::open(&path, DEFAULT_EMBEDDING_DIM).unwrap();
 
-        // Ladder reached v6.
+        // Ladder reached the current version.
         let version: String = db
             .conn
             .query_row(
@@ -4578,27 +4593,24 @@ mod tests {
             .unwrap();
         }
 
-        // Re-open through the production path so migrate() runs.
+        // Re-open through the production path so migrate() runs the full ladder.
         let db = Database::open(&path, DEFAULT_EMBEDDING_DIM).unwrap();
 
-        let resolved_state: i64 = db
+        // The v3→4 migration adds the resolution_state column (schema transform);
+        // verify it is present and queryable. The v7 stable-ID-escaping migration
+        // clears the seeded rows, so the per-row backfill is no longer observable
+        // after a full chain — assert the durable column + cleared-index contract.
+        let has_resolution_state = db
             .conn
-            .query_row(
-                "SELECT resolution_state FROM edges WHERE target_id IS NOT NULL",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        let unresolved_state: i64 = db
+            .prepare("SELECT resolution_state FROM edges LIMIT 0")
+            .is_ok();
+        assert!(has_resolution_state, "v3→4 added resolution_state column");
+
+        let edge_count: i64 = db
             .conn
-            .query_row(
-                "SELECT resolution_state FROM edges WHERE target_id IS NULL",
-                [],
-                |r| r.get(0),
-            )
+            .query_row("SELECT COUNT(*) FROM edges", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(resolved_state, 1, "existing target_id NOT NULL → state=1");
-        assert_eq!(unresolved_state, 0, "existing target_id NULL → state=0");
+        assert_eq!(edge_count, 0, "v7 cleared the index for full rebuild");
 
         let bumped: String = db
             .conn
@@ -4991,33 +5003,28 @@ mod tests {
     }
 
     #[test]
-    fn migration_v5_to_v6_backfills_resolved_edges_to_null() {
+    fn migration_v5_to_v6_adds_resolution_source_column() {
         // A pre-v6 DB (resolution_state present, resolution_source absent) gains
-        // the column on open; pre-existing rows keep NULL provenance, and a
-        // migrated resolved edge reads back through the production path as None.
+        // the resolution_source column on open. The v7 stable-ID-escaping
+        // migration then clears the seeded rows, so assert the durable column +
+        // cleared-index contract rather than the now-wiped per-row backfill.
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("v5.sqlite");
         bootstrap_pre_v6_db(&path, 5, true);
 
         let db = Database::open(&path, DEFAULT_EMBEDDING_DIM).unwrap();
 
-        let null_count: i64 = db
+        let has_resolution_source = db
             .conn
-            .query_row(
-                "SELECT COUNT(*) FROM edges WHERE resolution_source IS NULL",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(null_count, 2, "pre-v6 rows keep NULL provenance");
+            .prepare("SELECT resolution_source FROM edges LIMIT 0")
+            .is_ok();
+        assert!(has_resolution_source, "v5→6 added resolution_source column");
 
-        // Read a migrated resolved edge back through callees() (the real decode
-        // path) to prove a NULL column deserializes to provenance == None.
-        let callees = db.callees("foo").unwrap();
-        assert!(
-            callees.iter().all(|e| e.provenance.is_none()),
-            "migrated rows decode with no provenance"
-        );
+        let edge_count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM edges", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(edge_count, 0, "v7 cleared the index for full rebuild");
 
         let bumped: String = db
             .conn
@@ -5044,6 +5051,83 @@ mod tests {
             .prepare("SELECT resolution_source FROM edges LIMIT 0")
             .is_ok();
         assert!(has_col, "missing resolution_source column was re-added");
+    }
+
+    /// Bootstrap a v6-shaped DB (all columns present, stamped at v6) with one
+    /// seeded symbol/file/edge and a `last_commit`, so the v6→7 wipe is testable.
+    fn bootstrap_v6_db(path: &std::path::Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE symbols (
+                id TEXT PRIMARY KEY, name TEXT, kind TEXT, file_path TEXT,
+                start_line INTEGER, end_line INTEGER, start_byte INTEGER, end_byte INTEGER,
+                parent_id TEXT, signature TEXT, visibility TEXT, is_async BOOLEAN,
+                docstring TEXT, in_degree INTEGER DEFAULT 0,
+                content_hash TEXT, subtree_hash TEXT);
+             CREATE TABLE edges (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id TEXT NOT NULL, target_name TEXT NOT NULL, target_id TEXT,
+                kind TEXT NOT NULL, file_path TEXT NOT NULL, line INTEGER,
+                resolution_state INTEGER NOT NULL DEFAULT 0, resolution_source TEXT);
+             CREATE TABLE files (path TEXT PRIMARY KEY);
+             CREATE TABLE symbol_content (symbol_id TEXT PRIMARY KEY);
+             CREATE TABLE symbol_embedding_map (symbol_id TEXT NOT NULL);
+             CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+             CREATE TABLE query_log (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL, source TEXT NOT NULL, ts INTEGER NOT NULL);
+             INSERT INTO symbols (id, name, kind, file_path) VALUES ('a.py:import:os.path', 'os.path', 'import', 'a.py');
+             INSERT INTO files (path) VALUES ('a.py');
+             INSERT INTO edges (source_id, target_name, kind, file_path, line)
+                VALUES ('a.py:import:os.path', 'os', 'imports', 'a.py', 1);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '6');
+             INSERT INTO metadata (key, value) VALUES ('last_commit', 'deadbeef');",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn migration_v6_to_v7_clears_index_for_full_rebuild() {
+        // The v7 symbol-ID escaping changes the ID format, so old (collidable)
+        // rows must be wiped and last_commit cleared so the next index rebuilds
+        // every file from scratch.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("v6.sqlite");
+        bootstrap_v6_db(&path);
+
+        let db = Database::open(&path, DEFAULT_EMBEDDING_DIM).unwrap();
+
+        let count = |table: &str| -> i64 {
+            db.conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+                .unwrap()
+        };
+        assert_eq!(count("symbols"), 0, "symbols cleared");
+        assert_eq!(count("edges"), 0, "edges cleared");
+        assert_eq!(count("files"), 0, "files cleared");
+
+        let last_commit: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'last_commit'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(
+            last_commit, None,
+            "last_commit cleared to force full reindex"
+        );
+
+        let bumped: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(bumped, SCHEMA_VERSION.to_string());
     }
 
     #[test]

--- a/crates/cartog-indexer/Cargo.toml
+++ b/crates/cartog-indexer/Cargo.toml
@@ -27,6 +27,7 @@ cartog-lsp = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 criterion = { workspace = true }
+proptest = { workspace = true }
 
 [features]
 lsp = ["dep:cartog-lsp"]

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -1321,6 +1321,59 @@ mod tests {
     }
 
     #[test]
+    fn dotted_import_leaf_is_separator_escaped_in_stored_id() {
+        // Real-output guard for the symbol-ID escaping fix: a dotted import leaf
+        // (os.path) and a parented method (os.path) must keep distinct, escaped
+        // ids in the stored index, never colliding to one primary-key row.
+        use cartog_db::Database;
+
+        // TempDir names start with '.', which the walker prunes as hidden — nest
+        // a non-dot project dir so the walk descends into it.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("proj");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(
+            dir.join("a.py"),
+            "import os.path\n\nclass os:\n    def path(self):\n        return 1\n",
+        )
+        .unwrap();
+
+        let db = Database::open_memory().unwrap();
+        index_directory(
+            &db,
+            &dir,
+            true,
+            false,
+            None,
+            None,
+            crate::RedactionConfig::disabled(),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+
+        let ids: Vec<String> = db
+            .outline("a.py")
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+
+        assert!(
+            ids.contains(&"a.py:import:os%2Epath".to_string()),
+            "dotted import leaf must be escaped: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"a.py:method:os.path".to_string()),
+            "parented method keeps its raw structural id: {ids:?}"
+        );
+        // Both symbols survive — the pre-fix format would have risked one id.
+        assert_eq!(
+            ids.len(),
+            ids.iter().collect::<std::collections::HashSet<_>>().len()
+        );
+    }
+
+    #[test]
     fn test_index_directory_force() {
         use cartog_db::Database;
 

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -1323,8 +1323,11 @@ mod tests {
     #[test]
     fn dotted_import_leaf_is_separator_escaped_in_stored_id() {
         // Real-output guard for the symbol-ID escaping fix: a dotted import leaf
-        // (os.path) and a parented method (os.path) must keep distinct, escaped
-        // ids in the stored index, never colliding to one primary-key row.
+        // (os.path) is stored with its separator escaped (os%2Epath), not raw.
+        // The parented method (os.path) keeps its raw structural id; the two
+        // differ in the kind segment, so this checks escaping is applied in
+        // stored output — not a same-kind collision (that's the cartog-core
+        // injectivity unit test).
         use cartog_db::Database;
 
         // TempDir names start with '.', which the walker prunes as hidden — nest
@@ -1366,10 +1369,11 @@ mod tests {
             ids.contains(&"a.py:method:os.path".to_string()),
             "parented method keeps its raw structural id: {ids:?}"
         );
-        // Both symbols survive — the pre-fix format would have risked one id.
-        assert_eq!(
-            ids.len(),
-            ids.iter().collect::<std::collections::HashSet<_>>().len()
+        // The escaped import id is stored verbatim — the raw dotted form must not
+        // appear (that would mean escaping was skipped on the stored path).
+        assert!(
+            !ids.contains(&"a.py:import:os.path".to_string()),
+            "raw (unescaped) dotted import id must not be stored: {ids:?}"
         );
     }
 

--- a/crates/cartog-indexer/src/merkle.rs
+++ b/crates/cartog-indexer/src/merkle.rs
@@ -270,4 +270,60 @@ mod tests {
             }
         }
     }
+
+    /// A symbol spanning the whole `source`, named `name`, optionally parented.
+    fn span_sym(id: &str, name: &str, parent_id: Option<&str>, src: &str) -> Symbol {
+        let mut s = Symbol::new(
+            name,
+            SymbolKind::Function,
+            "f.rs",
+            0,
+            0,
+            0,
+            src.len() as u32,
+            None,
+        );
+        s.id = id.to_string();
+        s.parent_id = parent_id.map(str::to_string);
+        s
+    }
+
+    fn hashes(symbols: &[Symbol]) -> Vec<(Option<String>, Option<String>)> {
+        symbols
+            .iter()
+            .map(|s| (s.content_hash.clone(), s.subtree_hash.clone()))
+            .collect()
+    }
+
+    proptest! {
+        /// compute_merkle_hashes is deterministic: same symbols + source twice
+        /// yields identical content and subtree hashes.
+        #[test]
+        fn merkle_hashes_are_deterministic(src in ".{0,80}", names in proptest::collection::vec("[a-z]{1,4}", 1..6)) {
+            let mut a: Vec<Symbol> = names.iter().enumerate()
+                .map(|(i, n)| span_sym(&format!("s{i}"), n, None, &src)).collect();
+            let mut b = a.clone();
+            compute_merkle_hashes(&mut a, &src);
+            compute_merkle_hashes(&mut b, &src);
+            prop_assert_eq!(hashes(&a), hashes(&b));
+        }
+
+        /// subtree_hash is independent of sibling order: the children are sorted
+        /// before hashing, so reordering them must not change the parent's hash.
+        #[test]
+        fn subtree_hash_ignores_sibling_order(src in ".{1,40}") {
+            let parent = span_sym("p", "parent", None, &src);
+            let c1 = span_sym("c1", "a", Some("p"), &src);
+            let c2 = span_sym("c2", "b", Some("p"), &src);
+
+            let mut forward = vec![parent.clone(), c1.clone(), c2.clone()];
+            let mut reversed = vec![parent, c2, c1];
+            compute_merkle_hashes(&mut forward, &src);
+            compute_merkle_hashes(&mut reversed, &src);
+
+            let p_fwd = &forward[0].subtree_hash;
+            let p_rev = &reversed[0].subtree_hash;
+            prop_assert_eq!(p_fwd, p_rev);
+        }
+    }
 }

--- a/crates/cartog-indexer/src/merkle.rs
+++ b/crates/cartog-indexer/src/merkle.rs
@@ -145,3 +145,129 @@ pub(crate) fn merkle_diff(
 
     diff
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cartog_core::SymbolKind;
+    use proptest::prelude::*;
+
+    /// `id` + the two hashes are the only fields `merkle_diff` reads.
+    fn sym(id: &str, content: Option<&str>, subtree: Option<&str>) -> Symbol {
+        let mut s = Symbol::new("x", SymbolKind::Function, "f.rs", 0, 0, 0, 0, None);
+        s.id = id.to_string();
+        s.content_hash = content.map(str::to_string);
+        s.subtree_hash = subtree.map(str::to_string);
+        s
+    }
+
+    /// What happens to one symbol id between the old and new extraction.
+    #[derive(Debug, Clone)]
+    enum Fate {
+        Unchanged,
+        Modified,        // content_hash differs
+        ChildrenChanged, // content same, subtree differs
+        Removed,         // present in old only
+        Added,           // present in new only
+    }
+
+    fn fate() -> impl Strategy<Value = Fate> {
+        prop_oneof![
+            Just(Fate::Unchanged),
+            Just(Fate::Modified),
+            Just(Fate::ChildrenChanged),
+            Just(Fate::Removed),
+            Just(Fate::Added),
+        ]
+    }
+
+    /// Distinct ids, each with an independent fate.
+    fn scenario() -> impl Strategy<Value = Vec<(String, Fate)>> {
+        proptest::collection::hash_map("[a-z]{1,5}", fate(), 0..12)
+            .prop_map(|m| m.into_iter().collect())
+    }
+
+    proptest! {
+        /// Model-based: build old/new inputs from per-id fates, assert the diff
+        /// recovers exactly those fates.
+        #[test]
+        fn merkle_diff_recovers_fates(scn in scenario()) {
+            let mut old_hashes = Vec::new();
+            let mut new_symbols = Vec::new();
+
+            for (id, f) in &scn {
+                match f {
+                    Fate::Unchanged => {
+                        old_hashes.push((id.clone(), Some("c".into()), Some("s".into())));
+                        new_symbols.push(sym(id, Some("c"), Some("s")));
+                    }
+                    Fate::Modified => {
+                        old_hashes.push((id.clone(), Some("c_old".into()), Some("s_old".into())));
+                        new_symbols.push(sym(id, Some("c_new"), Some("s_new")));
+                    }
+                    Fate::ChildrenChanged => {
+                        old_hashes.push((id.clone(), Some("c".into()), Some("s_old".into())));
+                        new_symbols.push(sym(id, Some("c"), Some("s_new")));
+                    }
+                    Fate::Removed => {
+                        old_hashes.push((id.clone(), Some("c".into()), Some("s".into())));
+                    }
+                    Fate::Added => {
+                        new_symbols.push(sym(id, Some("c"), Some("s")));
+                    }
+                }
+            }
+
+            let diff = merkle_diff(&new_symbols, &old_hashes);
+
+            // Partition: buckets + unchanged account for every new symbol.
+            let bucketed = diff.added.len() + diff.modified.len() + diff.children_changed.len();
+            prop_assert_eq!(
+                bucketed + diff.unchanged,
+                new_symbols.len(),
+                "buckets + unchanged must account for every new symbol"
+            );
+
+            // Index buckets are disjoint sets of valid new-symbol indices.
+            let mut all_idx: Vec<usize> = diff.added.iter()
+                .chain(&diff.modified)
+                .chain(&diff.children_changed)
+                .copied()
+                .collect();
+            let total = all_idx.len();
+            all_idx.sort_unstable();
+            all_idx.dedup();
+            prop_assert_eq!(all_idx.len(), total, "index buckets overlap");
+            prop_assert!(all_idx.iter().all(|&i| i < new_symbols.len()), "index out of range");
+
+            // removed = exactly the old ids absent from new ids.
+            let new_ids: std::collections::HashSet<&str> =
+                new_symbols.iter().map(|s| s.id.as_str()).collect();
+            let mut expected_removed: Vec<&String> = scn.iter()
+                .filter(|(id, _)| !new_ids.contains(id.as_str()))
+                .map(|(id, _)| id)
+                .collect();
+            expected_removed.sort();
+            let mut got_removed = diff.removed.clone();
+            got_removed.sort();
+            prop_assert_eq!(&got_removed, &expected_removed.into_iter().cloned().collect::<Vec<_>>());
+
+            // Classification: each new symbol's bucket matches its fate.
+            let in_added: std::collections::HashSet<usize> = diff.added.iter().copied().collect();
+            let in_modified: std::collections::HashSet<usize> = diff.modified.iter().copied().collect();
+            let in_children: std::collections::HashSet<usize> = diff.children_changed.iter().copied().collect();
+            for (i, s) in new_symbols.iter().enumerate() {
+                let fate = &scn.iter().find(|(id, _)| id == &s.id).unwrap().1;
+                match fate {
+                    Fate::Added => prop_assert!(in_added.contains(&i)),
+                    Fate::Modified => prop_assert!(in_modified.contains(&i)),
+                    Fate::ChildrenChanged => prop_assert!(in_children.contains(&i)),
+                    Fate::Unchanged => prop_assert!(
+                        !in_added.contains(&i) && !in_modified.contains(&i) && !in_children.contains(&i)
+                    ),
+                    Fate::Removed => unreachable!("removed ids are not in new_symbols"),
+                }
+            }
+        }
+    }
+}

--- a/crates/cartog-indexer/src/merkle.rs
+++ b/crates/cartog-indexer/src/merkle.rs
@@ -181,9 +181,11 @@ mod tests {
         ]
     }
 
-    /// Distinct ids, each with an independent fate.
+    /// Distinct ids, each with an independent fate. A `btree_map` keeps the
+    /// materialized order deterministic so saved regression seeds replay the
+    /// same case (a `hash_map` would iterate in per-process order).
     fn scenario() -> impl Strategy<Value = Vec<(String, Fate)>> {
-        proptest::collection::hash_map("[a-z]{1,5}", fate(), 0..12)
+        proptest::collection::btree_map("[a-z]{1,5}", fate(), 0..12)
             .prop_map(|m| m.into_iter().collect())
     }
 
@@ -256,16 +258,19 @@ mod tests {
             let in_added: std::collections::HashSet<usize> = diff.added.iter().copied().collect();
             let in_modified: std::collections::HashSet<usize> = diff.modified.iter().copied().collect();
             let in_children: std::collections::HashSet<usize> = diff.children_changed.iter().copied().collect();
+            let fate_of: std::collections::HashMap<&str, &Fate> =
+                scn.iter().map(|(id, f)| (id.as_str(), f)).collect();
             for (i, s) in new_symbols.iter().enumerate() {
-                let fate = &scn.iter().find(|(id, _)| id == &s.id).unwrap().1;
-                match fate {
-                    Fate::Added => prop_assert!(in_added.contains(&i)),
-                    Fate::Modified => prop_assert!(in_modified.contains(&i)),
-                    Fate::ChildrenChanged => prop_assert!(in_children.contains(&i)),
-                    Fate::Unchanged => prop_assert!(
+                match fate_of.get(s.id.as_str()) {
+                    Some(Fate::Added) => prop_assert!(in_added.contains(&i)),
+                    Some(Fate::Modified) => prop_assert!(in_modified.contains(&i)),
+                    Some(Fate::ChildrenChanged) => prop_assert!(in_children.contains(&i)),
+                    Some(Fate::Unchanged) => prop_assert!(
                         !in_added.contains(&i) && !in_modified.contains(&i) && !in_children.contains(&i)
                     ),
-                    Fate::Removed => unreachable!("removed ids are not in new_symbols"),
+                    Some(Fate::Removed) | None => {
+                        prop_assert!(false, "new symbol {} has no non-removed fate", s.id)
+                    }
                 }
             }
         }
@@ -308,22 +313,29 @@ mod tests {
             prop_assert_eq!(hashes(&a), hashes(&b));
         }
 
-        /// subtree_hash is independent of sibling order: the children are sorted
-        /// before hashing, so reordering them must not change the parent's hash.
+        /// subtree_hash is independent of sibling order: children are sorted
+        /// before hashing, so reversing a variable-size child set must not change
+        /// the parent's hash. Varies the child set (the thing the property is
+        /// about), not just the source text.
         #[test]
-        fn subtree_hash_ignores_sibling_order(src in ".{1,40}") {
+        fn subtree_hash_ignores_sibling_order(
+            src in ".{1,40}",
+            child_names in proptest::collection::vec("[a-z]{1,4}", 2..6),
+        ) {
             let parent = span_sym("p", "parent", None, &src);
-            let c1 = span_sym("c1", "a", Some("p"), &src);
-            let c2 = span_sym("c2", "b", Some("p"), &src);
+            let children: Vec<Symbol> = child_names.iter().enumerate()
+                .map(|(i, n)| span_sym(&format!("c{i}"), n, Some("p"), &src))
+                .collect();
 
-            let mut forward = vec![parent.clone(), c1.clone(), c2.clone()];
-            let mut reversed = vec![parent, c2, c1];
+            let mut forward = vec![parent.clone()];
+            forward.extend(children.iter().cloned());
+            let mut reversed = vec![parent];
+            reversed.extend(children.into_iter().rev());
+
             compute_merkle_hashes(&mut forward, &src);
             compute_merkle_hashes(&mut reversed, &src);
 
-            let p_fwd = &forward[0].subtree_hash;
-            let p_rev = &reversed[0].subtree_hash;
-            prop_assert_eq!(p_fwd, p_rev);
+            prop_assert_eq!(&forward[0].subtree_hash, &reversed[0].subtree_hash);
         }
     }
 }

--- a/crates/cartog-indexer/src/redact.rs
+++ b/crates/cartog-indexer/src/redact.rs
@@ -432,21 +432,23 @@ mod tests {
             "[A-Za-z0-9]{36}".prop_map(|s| format!("ghp_{s}")),
             // Stripe live secret key: sk_live_ + 24 alnum.
             "[A-Za-z0-9]{24}".prop_map(|s| format!("sk_live_{s}")),
-            // JWT: three base64url segments.
+            // JWT: three base64url segments. The last segment ends on a word
+            // char so the regex's trailing `\b` anchors — a trailing `-`/`_`
+            // would leave the boundary unmatched and the token un-redacted.
             (
                 "[A-Za-z0-9_-]{12}",
                 "[A-Za-z0-9_-]{12}",
-                "[A-Za-z0-9_-]{12}"
+                "[A-Za-z0-9_-]{11}[A-Za-z0-9]"
             )
                 .prop_map(|(a, b, c)| format!("eyJ{a}.{b}.{c}")),
         ]
     }
 
-    /// Filler with no secret shape and no secret keyword: must pass through
-    /// unchanged. Alphabet excludes the digits/quotes a vendor shape or
-    /// `keyword="value"` assignment would need.
+    /// Filler that matches no secret pattern: must pass through unchanged. The
+    /// alphabet has no `-` (so it can't form a Slack `xox?-…` token), no digits
+    /// or vendor prefixes, and no `:`/`=`/quote (so no `keyword="value"` shape).
     fn benign_filler() -> impl Strategy<Value = String> {
-        "[a-z ()\\-+]{0,40}"
+        "[a-z ()+]{0,40}"
     }
 
     proptest! {

--- a/crates/cartog-indexer/src/redact.rs
+++ b/crates/cartog-indexer/src/redact.rs
@@ -420,4 +420,72 @@ mod tests {
         let cfg = RedactionConfig::enabled();
         assert!(cfg.redact("AKIAIOSFODNN7EXAMPLE").contains(PLACEHOLDER));
     }
+
+    use proptest::prelude::*;
+
+    /// A shape-valid secret of a known vendor pattern (never a real credential).
+    fn known_secret() -> impl Strategy<Value = String> {
+        prop_oneof![
+            // AWS access key id: AKIA + 16 upper-alnum.
+            "[A-Z0-9]{16}".prop_map(|s| format!("AKIA{s}")),
+            // GitHub PAT: ghp_ + 36 alnum (>= the 20-char minimum).
+            "[A-Za-z0-9]{36}".prop_map(|s| format!("ghp_{s}")),
+            // Stripe live secret key: sk_live_ + 24 alnum.
+            "[A-Za-z0-9]{24}".prop_map(|s| format!("sk_live_{s}")),
+            // JWT: three base64url segments.
+            (
+                "[A-Za-z0-9_-]{12}",
+                "[A-Za-z0-9_-]{12}",
+                "[A-Za-z0-9_-]{12}"
+            )
+                .prop_map(|(a, b, c)| format!("eyJ{a}.{b}.{c}")),
+        ]
+    }
+
+    /// Filler with no secret shape and no secret keyword: must pass through
+    /// unchanged. Alphabet excludes the digits/quotes a vendor shape or
+    /// `keyword="value"` assignment would need.
+    fn benign_filler() -> impl Strategy<Value = String> {
+        "[a-z ()\\-+]{0,40}"
+    }
+
+    proptest! {
+        /// A known-shape secret spliced into arbitrary surrounding text never
+        /// survives verbatim in the output, and the placeholder appears.
+        #[test]
+        fn known_secret_never_survives(
+            secret in known_secret(),
+            before in any::<String>(),
+            after in any::<String>(),
+        ) {
+            // Spaces around the secret so `\b` anchors fire (adjacent word chars
+            // would extend the token past the shape).
+            let input = format!("{before} {secret} {after}");
+            let out = redact_str(&input);
+            prop_assert!(!out.contains(secret.as_str()), "secret survived: {out}");
+            prop_assert!(out.contains(PLACEHOLDER));
+        }
+
+        /// Redaction is idempotent: re-redacting already-redacted text is a no-op.
+        #[test]
+        fn redaction_is_idempotent(input in any::<String>()) {
+            let once = redact_str(&input).into_owned();
+            let twice = redact_str(&once).into_owned();
+            prop_assert_eq!(once, twice);
+        }
+
+        /// Redaction never panics on any UTF-8 input (unicode, newlines, control).
+        #[test]
+        fn redaction_never_panics(input in any::<String>()) {
+            let _ = redact_str(&input);
+        }
+
+        /// Text with no secret shape and no secret keyword is returned unchanged
+        /// (borrowed): over-redaction would silently wreck search recall.
+        #[test]
+        fn benign_text_is_not_redacted(input in benign_filler()) {
+            let out = redact_str(&input);
+            prop_assert!(matches!(out, Cow::Borrowed(_)), "over-redacted: {out}");
+        }
+    }
 }

--- a/crates/cartog-languages/Cargo.toml
+++ b/crates/cartog-languages/Cargo.toml
@@ -29,5 +29,8 @@ tree-sitter-dart = { workspace = true }
 tree-sitter-swift = { workspace = true }
 tree-sitter-kotlin-sg = { workspace = true }
 
+[dev-dependencies]
+proptest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/cartog-languages/src/lib.rs
+++ b/crates/cartog-languages/src/lib.rs
@@ -183,12 +183,23 @@ mod tests {
         /// No extractor panics on arbitrary source — indexing whole repos must
         /// degrade (return Ok/Err), never abort the run. Covers unicode, control
         /// chars, and unbalanced delimiters via the regex generator.
+        ///
+        /// Extractors are built once per thread and reused across cases (the
+        /// trait takes `&mut self` for exactly this); building all 13 per case
+        /// would recompile every tree-sitter query thousands of times.
         #[test]
         fn extractors_never_panic_on_arbitrary_source(src in ".{0,400}") {
-            for lang in ALL_LANGS {
-                let mut ex = get_extractor(lang).unwrap();
-                let _ = ex.extract(&src, &format!("fuzz.{lang}"));
+            thread_local! {
+                static EXTRACTORS: std::cell::RefCell<Vec<(&'static str, Box<dyn Extractor>)>> =
+                    std::cell::RefCell::new(
+                        ALL_LANGS.iter().map(|&l| (l, get_extractor(l).unwrap())).collect()
+                    );
             }
+            EXTRACTORS.with_borrow_mut(|exs| {
+                for (lang, ex) in exs.iter_mut() {
+                    let _ = ex.extract(&src, &format!("fuzz.{lang}"));
+                }
+            });
         }
     }
 }

--- a/crates/cartog-languages/src/lib.rs
+++ b/crates/cartog-languages/src/lib.rs
@@ -162,4 +162,33 @@ mod tests {
         assert!(get_extractor("markdown").is_some());
         assert!(get_extractor("unknown").is_none());
     }
+
+    const ALL_LANGS: [&str; 13] = [
+        "python",
+        "typescript",
+        "tsx",
+        "javascript",
+        "rust",
+        "go",
+        "ruby",
+        "java",
+        "php",
+        "dart",
+        "swift",
+        "kotlin",
+        "markdown",
+    ];
+
+    proptest::proptest! {
+        /// No extractor panics on arbitrary source — indexing whole repos must
+        /// degrade (return Ok/Err), never abort the run. Covers unicode, control
+        /// chars, and unbalanced delimiters via the regex generator.
+        #[test]
+        fn extractors_never_panic_on_arbitrary_source(src in ".{0,400}") {
+            for lang in ALL_LANGS {
+                let mut ex = get_extractor(lang).unwrap();
+                let _ = ex.extract(&src, &format!("fuzz.{lang}"));
+            }
+        }
+    }
 }

--- a/crates/cartog-mcp/Cargo.toml
+++ b/crates/cartog-mcp/Cargo.toml
@@ -31,6 +31,7 @@ lsp = ["dep:cartog-lsp", "cartog-indexer/lsp"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+proptest = { workspace = true }
 # Pull cartog-rag's deterministic mock providers into tests so the MCP server
 # can be constructed without loading the real ONNX embedding model.
 cartog-rag = { workspace = true, features = ["test-util"] }

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -2946,15 +2946,32 @@ mod tests {
             proptest::prop_assert_eq!(got, format!("watch-{suffix}"));
         }
 
-        /// Any input that is neither `serve` nor `serve-<nonempty>` is rejected —
-        /// folding an off-pattern slot to the global watch slot would let distinct
-        /// embedders collide on `watch.pid`.
+        /// Total contract over arbitrary input, checked against the OUTPUT rather
+        /// than a re-implemented accept rule: the only accepted slots are `serve`
+        /// (→ `watch`) and `serve-<nonempty>` (→ `watch-<same>`); every other
+        /// input is rejected. Folding an off-pattern slot to the global watch slot
+        /// would let distinct embedders collide on `watch.pid`.
         #[test]
-        fn serve_to_watch_slot_rejects_off_pattern(s in ".{0,20}") {
-            let is_valid = s == "serve"
-                || s.strip_prefix("serve-").is_some_and(|r| !r.is_empty());
-            proptest::prop_assume!(!is_valid);
-            proptest::prop_assert!(serve_to_watch_slot(&s).is_err());
+        fn serve_to_watch_slot_contract(s in ".{0,20}") {
+            match serve_to_watch_slot(&s) {
+                Ok(out) if s == "serve" => proptest::prop_assert_eq!(out, "watch"),
+                Ok(out) => {
+                    // The only other accepted form: the suffix is carried verbatim.
+                    let suffix = s.strip_prefix("serve-");
+                    proptest::prop_assert!(
+                        suffix.is_some_and(|r| !r.is_empty()),
+                        "accepted off-pattern {s:?}"
+                    );
+                    proptest::prop_assert_eq!(out, format!("watch-{}", suffix.unwrap()));
+                }
+                Err(_) => {
+                    proptest::prop_assert_ne!(&s, "serve");
+                    proptest::prop_assert!(
+                        s.strip_prefix("serve-").map_or(true, str::is_empty),
+                        "rejected a valid serve-<nonempty> slot: {s:?}"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -2937,6 +2937,27 @@ mod tests {
         }
     }
 
+    proptest::proptest! {
+        /// `serve-<nonempty>` maps to `watch-<same suffix>`, preserving the DB
+        /// scope verbatim.
+        #[test]
+        fn serve_to_watch_slot_round_trips_suffix(suffix in "[0-9a-f]{1,16}") {
+            let got = serve_to_watch_slot(&format!("serve-{suffix}")).unwrap();
+            proptest::prop_assert_eq!(got, format!("watch-{suffix}"));
+        }
+
+        /// Any input that is neither `serve` nor `serve-<nonempty>` is rejected —
+        /// folding an off-pattern slot to the global watch slot would let distinct
+        /// embedders collide on `watch.pid`.
+        #[test]
+        fn serve_to_watch_slot_rejects_off_pattern(s in ".{0,20}") {
+            let is_valid = s == "serve"
+                || s.strip_prefix("serve-").is_some_and(|r| !r.is_empty());
+            proptest::prop_assume!(!is_valid);
+            proptest::prop_assert!(serve_to_watch_slot(&s).is_err());
+        }
+    }
+
     #[test]
     fn second_acquire_for_same_dir_reports_held() {
         // Two acquire_serve_lock calls against the same dir: the first wins,

--- a/crates/cartog/Cargo.toml
+++ b/crates/cartog/Cargo.toml
@@ -53,6 +53,7 @@ remote-s3 = ["dep:rust-s3"]
 [dev-dependencies]
 criterion = { workspace = true }
 serial_test = { workspace = true }
+proptest = { workspace = true }
 # Used by `tests/remote_integration.rs` to fabricate a non-cartog SQLite file
 # for the schema-version refusal negative test. Workspace already pins
 # `rusqlite` with `bundled` for the runtime DB, so no new dep is pulled in

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1614,10 +1614,12 @@ mod tests {
             let _ = truncate_to_budget(&s, budget);
         }
 
-        /// Within budget → returned verbatim, no notice.
+        /// Within budget → returned verbatim, no notice. Budget is derived from
+        /// the string so every case exercises the in-budget branch (a fixed
+        /// budget range would reject most strings via prop_assume).
         #[test]
-        fn truncate_within_budget_is_verbatim(s in ".{0,200}", budget in 0u32..200) {
-            proptest::prop_assume!(s.len() <= (budget as usize) * 4);
+        fn truncate_within_budget_is_verbatim(s in ".{0,200}", slack in 0u32..50) {
+            let budget = (s.len() as u32).div_ceil(4) + slack;
             proptest::prop_assert_eq!(truncate_to_budget(&s, budget), s);
         }
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -1607,6 +1607,38 @@ mod tests {
         // Should not panic on char boundary issues
     }
 
+    proptest::proptest! {
+        /// `s[..cut]` would panic if `cut` landed mid-codepoint.
+        #[test]
+        fn truncate_never_panics(s in ".*", budget in 0u32..64) {
+            let _ = truncate_to_budget(&s, budget);
+        }
+
+        /// Within budget → returned verbatim, no notice.
+        #[test]
+        fn truncate_within_budget_is_verbatim(s in ".{0,200}", budget in 0u32..200) {
+            proptest::prop_assume!(s.len() <= (budget as usize) * 4);
+            proptest::prop_assert_eq!(truncate_to_budget(&s, budget), s);
+        }
+
+        /// When truncation fires, the kept content stays within the byte budget.
+        #[test]
+        fn truncate_respects_byte_budget(s in ".{0,500}", budget in 0u32..200) {
+            let max_bytes = (budget as usize) * 4;
+            proptest::prop_assume!(s.len() > max_bytes);
+            let notice = "\n... (truncated to fit token budget)";
+            let out = truncate_to_budget(&s, budget);
+            proptest::prop_assert!(out.ends_with(notice), "truncated output must carry the notice");
+            let content = &out[..out.len() - notice.len()];
+            proptest::prop_assert!(
+                content.len() <= max_bytes,
+                "kept {} content bytes > {} budget",
+                content.len(),
+                max_bytes
+            );
+        }
+    }
+
     // ── cmd_* command bodies over a real indexed DB ───────────────────
     //
     // Drive the read commands end-to-end against a temp DB populated from a


### PR DESCRIPTION
## Summary

Introduces property-based testing (`proptest`) to cartog and, in doing so, **found and fixed a real symbol-ID collision bug**. Adds `proptest` as a dev-dependency to `cartog-core`, `cartog-indexer`, `cartog`, `cartog-languages`, and `cartog-mcp`.

PBT attacks a different failure class than the existing formal work (TLA+ proves protocol design, Loom proves memory ordering): it proves a real Rust function holds an invariant across a huge random input space and shrinks any failure to a minimal counterexample.

## ⚠️ Migration impact (read this)

This bumps **DB schema version 6 → 7** with a **destructive migration**: existing indexes are cleared on first open and rebuilt from scratch (mirrors the v2→3 stable-ID wipe). The pre-migration DB is backed up to `*.pre-v6-<ts>.bak` first. No user action needed; the next index/serve run rebuilds.

## The bug (found by the injectivity property)

`symbol_id` joined `parent.leaf` with an unescaped `.` and `kind:qname` with an unescaped `:`, so distinct logical symbols could map to one ID — a SQLite primary-key overwrite and a shared embedding-map key. Minimal shrunk case:

```
symbol_id(f, Method, "a", parent="0")  == "f:method:0.a"
symbol_id(f, Method, "0.a", None)      == "f:method:0.a"
```

Reachable via dotted import leaf names (`os.path`, `com.example.Foo`) and `.`/`:`-bearing markdown headings. (Honest scope: the *same-kind* collision isn't reachable through any single language's real syntax today — it's a function-contract bug + a real risk for cross-file ID use, embedding keys, and any future dotted-leaf kind.)

### Fix

`escape_segment()` percent-escapes `%`/`.`/`:` in the **leaf name only** — identity for any separator-free name, so IDs for functions/methods/classes stay byte-for-byte unchanged (existing DBs + ~20 hardcoded extractor ID assertions stay valid). Only composite leaves (dotted imports, separator-bearing headings) change. `parent_name` stays raw (structural dots, built from bare segments).

## Properties added

- **Redactor** — known secret never survives; idempotence; no panic on any UTF-8; no over-redaction.
- **Symbol-ID** — determinism + injectivity (the bug-finder) + regression tests.
- **Merkle** — diff model (partition/classification/removed) + hash determinism + sibling-order independence.
- **Truncation, extractor no-panic on garbage, watch-slot round-trip** — all hold, no further bugs.

## Code-review follow-ups (in this PR)

A multi-angle review of the PBT additions caught two latent CI flakes (test generators emitted shapes the `\b`-anchored redactor regex legitimately won't match) and the backup gap above. Both fixed; the de-flaked properties now survive 100k cases. `PROPTEST_CASES=1024` is set on the CI `test` + `coverage` jobs so rare reachable failures surface with a reproducible saved seed (~+5s/job, all from the extractor fuzz).

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --workspace` = 1427 passed, 32 suites
- `cargo test --no-default-features` clean
- formerly-flaky redactor properties pass at `PROPTEST_CASES=100000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Symbol ID generation now includes percent-escaping for separator characters in identifier names.

* **Chores**
  * Database schema upgraded from version 6 to 7. On first use, indexed data is automatically rebuilt with backup preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->