### PR TITLE
fix(db): correct stale in_degree for symbols that lose an incoming edge

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2992,6 +2992,41 @@ mod tests {
         assert_eq!(results[0].in_degree, 2);
     }
 
+    #[test]
+    fn test_compute_in_degrees_scoped_resets_target_that_lost_edge() {
+        let db = Database::open_memory().unwrap();
+
+        let foo = test_symbol("foo", SymbolKind::Function, "a.py", 1);
+        let bar = test_symbol("bar", SymbolKind::Function, "b.py", 1);
+        let baz = test_symbol("baz", SymbolKind::Function, "c.py", 1);
+        db.insert_symbol(&foo).unwrap();
+        db.insert_symbol(&bar).unwrap();
+        db.insert_symbol(&baz).unwrap();
+
+        // bar calls foo, baz calls foo
+        db.insert_edge(&Edge::new(&bar.id, "foo", EdgeKind::Calls, "b.py", 5))
+            .unwrap();
+        db.insert_edge(&Edge::new(&baz.id, "foo", EdgeKind::Calls, "c.py", 3))
+            .unwrap();
+
+        db.resolve_edges().unwrap();
+        db.compute_in_degrees().unwrap();
+        let results = db.search("foo", None, None, 10).unwrap();
+        assert_eq!(results[0].in_degree, 2);
+
+        // Re-index b.py with the call removed: the indexer clears the file's
+        // old edges before the scoped recompute, so foo (unchanged a.py) has
+        // already lost an incoming edge by the time the recompute runs.
+        db.clear_edges_for_file("b.py").unwrap();
+        let dirty = std::collections::HashSet::from(["b.py".to_string()]);
+        db.invalidate_edges_targeting(&dirty).unwrap();
+        db.resolve_edges_scoped(&dirty).unwrap();
+        db.compute_in_degrees_scoped(&dirty).unwrap();
+
+        let results = db.search("foo", None, None, 10).unwrap();
+        assert_eq!(results[0].in_degree, 1);
+    }
+
     // ── Embedding dimension migration tests ──
 
     #[test]

--- a/crates/cartog-db/src/store/resolution.rs
+++ b/crates/cartog-db/src/store/resolution.rs
@@ -282,12 +282,19 @@ impl Database {
         self.resolve_edges_in_tx()
     }
 
-    /// Recompute in-degree centrality only for symbols in/around dirty files.
+    /// Recompute in-degree centrality after an incremental re-index.
+    ///
+    /// Scoping the reset to dirty files cannot be correct: a symbol in an
+    /// unchanged file that *lost* its incoming edge is unfindable once the
+    /// dirty file's old edges are deleted. Instead, correct every symbol
+    /// whose stored value disagrees with the actual edge count — a full
+    /// ground-truth pass that writes only the rows that changed (unlike
+    /// [`Self::compute_in_degrees`], which rewrites all rows).
     ///
     /// tx-safe: every internal statement participates in any active outer
     /// transaction — see [`Self::begin_indexing_tx`]. Does NOT open one of
     /// its own, unlike the batched `*_in_tx` helpers; outside an outer
-    /// transaction the per-file resets are not atomic with the recompute.
+    /// transaction the zeroing is not atomic with the recompute.
     pub fn compute_in_degrees_scoped(
         &self,
         dirty_files: &std::collections::HashSet<String>,
@@ -296,28 +303,15 @@ impl Database {
             return Ok(0);
         }
 
-        // Reset in-degree for symbols in dirty files
-        for file in dirty_files {
-            self.conn.execute(
-                "UPDATE symbols SET in_degree = 0 WHERE file_path = ?1",
-                params![file],
-            )?;
-        }
+        // Zero symbols that no longer have any incoming edge.
+        let zeroed = self.conn.execute(
+            "UPDATE symbols SET in_degree = 0
+             WHERE in_degree != 0
+               AND id NOT IN (SELECT target_id FROM edges WHERE target_id IS NOT NULL)",
+            [],
+        )?;
 
-        // Also reset symbols that are targets of edges from dirty files
-        // (their in-degree may have changed)
-        for file in dirty_files {
-            self.conn.execute(
-                "UPDATE symbols SET in_degree = 0
-                 WHERE id IN (
-                     SELECT DISTINCT e.target_id FROM edges e
-                     WHERE e.file_path = ?1 AND e.target_id IS NOT NULL
-                 )",
-                params![file],
-            )?;
-        }
-
-        // Recompute for all symbols with in_degree = 0 that have incoming edges
+        // Fix symbols whose stored value disagrees with the actual count.
         let updated = self.conn.execute(
             "WITH counts AS (
                 SELECT target_id, COUNT(*) AS cnt
@@ -327,11 +321,11 @@ impl Database {
             UPDATE symbols SET in_degree = (
                 SELECT cnt FROM counts WHERE counts.target_id = symbols.id
             )
-            WHERE in_degree = 0
-              AND id IN (SELECT target_id FROM counts)",
+            WHERE id IN (SELECT target_id FROM counts)
+              AND in_degree != (SELECT cnt FROM counts WHERE counts.target_id = symbols.id)",
             [],
         )?;
 
-        Ok(updated as u32)
+        Ok((zeroed + updated) as u32)
     }
 }


### PR DESCRIPTION
## Problem

`compute_in_degrees_scoped` only reset `in_degree` for symbols in dirty files and current targets of dirty-file edges, then recomputed behind a `WHERE in_degree = 0` guard. A symbol in an unchanged file whose incoming edge was deleted along with the dirty file's old edges (`clear_edges_for_file` runs before the recompute) was never reset, so it kept an inflated centrality until the next `--force`. The same guard also left counts stale-low when a previously unresolved edge from an unchanged file newly resolved.

## Fix

Dirty-file scoping cannot catch lost edges: by recompute time the old edges are deleted and their targets are unknowable. Replace it with a ground-truth diff:

- zero symbols with `in_degree != 0` and no incoming edges
- update symbols whose stored value disagrees with the actual edge count

Full correctness pass, but writes only disagreeing rows (unlike `compute_in_degrees`, which rewrites every row). Signature and indexer call site unchanged.

## Test plan

- New regression test `test_compute_in_degrees_scoped_resets_target_that_lost_edge` (fails on main with `left: 2, right: 1`): `foo` referenced from b.py + c.py, re-index b.py with the call removed via the real indexer sequence, assert `in_degree == 1`
- `cargo test --workspace`: 1430 passed
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of in-degree computation during incremental re-indexing by using a more robust approach to ensure all state remains consistent.

* **Tests**
  * Added test coverage for edge removal scenarios during incremental recomputation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->