### PR TITLE
fix(db): resolve PHP namespace-qualified inherits edges, surface them in hierarchy

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -81,10 +81,6 @@ Some scenarios deliberately keep ground truth at the *objectively correct* answe
 read from source, so cartog scores below 100% where its resolution is incomplete.
 These rows exist to track that — they should approach parity as the gaps close:
 
-- **PHP class inheritance (scenario 04)**: `hierarchy BaseService` returns nothing
-  even though `AuthService`/`AuthenticationService`/`PaymentProcessor` extend it.
-  PHP's *error* tree resolves (`TokenError -> App\AppError`), so this looks
-  namespace/`use`-related rather than a total miss.
 - **Rust traits / Go interfaces (excluded from scenario 04)**: Rust uses traits and
   Go uses struct embedding, not class inheritance. cartog does not model
   trait-impl or interface-satisfaction as a hierarchy, so "who implements this

--- a/benchmarks/ground_truth/webapp_php.json
+++ b/benchmarks/ground_truth/webapp_php.json
@@ -39,7 +39,6 @@
     "query": "hierarchy BaseService",
     "expected": [
       { "child": "AuthService", "parent": "BaseService" },
-      { "child": "AdminService", "parent": "AuthService" },
       { "child": "AuthenticationService", "parent": "BaseService" },
       { "child": "PaymentProcessor", "parent": "BaseService" }
     ]

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -1396,6 +1396,92 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_edges_php_fqcn_target_same_file() {
+        let db = Database::open_memory().unwrap();
+
+        // PHP emits namespace-qualified targets: `extends BaseService` inside
+        // `namespace App\Auth` becomes "App\Auth\BaseService".
+        let base = test_symbol("BaseService", SymbolKind::Class, "auth/service.php", 1);
+        let child = test_symbol("AuthService", SymbolKind::Class, "auth/service.php", 30);
+        db.insert_symbols(&[base.clone(), child.clone()]).unwrap();
+
+        db.insert_edge(&Edge::new(
+            &child.id,
+            "App\\Auth\\BaseService",
+            EdgeKind::Inherits,
+            "auth/service.php",
+            30,
+        ))
+        .unwrap();
+
+        let resolved = db.resolve_edges().unwrap();
+        assert_eq!(resolved, 1);
+
+        let refs = db.refs("App\\Auth\\BaseService", None).unwrap();
+        assert_eq!(refs[0].0.target_id.as_ref().unwrap(), &base.id);
+    }
+
+    #[test]
+    fn test_resolve_edges_php_fqcn_target_prefers_class_over_import_symbol() {
+        let db = Database::open_memory().unwrap();
+
+        let class_sym = test_symbol("AppError", SymbolKind::Class, "exceptions.php", 1);
+        let child = test_symbol("TokenError", SymbolKind::Class, "auth/tokens.php", 10);
+        // PHP `use App\AppError;` extracts an Import symbol named by FQCN.
+        let import_sym = test_symbol("App\\AppError", SymbolKind::Import, "auth/tokens.php", 1);
+        db.insert_symbols(&[class_sym.clone(), child.clone(), import_sym])
+            .unwrap();
+
+        db.insert_edge(&Edge::new(
+            &child.id,
+            "App\\AppError",
+            EdgeKind::Inherits,
+            "auth/tokens.php",
+            10,
+        ))
+        .unwrap();
+
+        db.resolve_edges().unwrap();
+
+        let refs = db.refs("App\\AppError", None).unwrap();
+        let inherits = refs
+            .iter()
+            .find(|(e, _)| e.kind == EdgeKind::Inherits)
+            .unwrap();
+        assert_eq!(inherits.0.target_id.as_ref().unwrap(), &class_sym.id);
+    }
+
+    #[test]
+    fn test_hierarchy_finds_children_of_fqcn_resolved_target() {
+        let db = Database::open_memory().unwrap();
+
+        let base = test_symbol("BaseService", SymbolKind::Class, "auth/service.php", 1);
+        let child = test_symbol(
+            "PaymentProcessor",
+            SymbolKind::Class,
+            "services/payment.php",
+            5,
+        );
+        db.insert_symbols(&[base.clone(), child.clone()]).unwrap();
+
+        db.insert_edge(&Edge::new(
+            &child.id,
+            "App\\Auth\\BaseService",
+            EdgeKind::Inherits,
+            "services/payment.php",
+            5,
+        ))
+        .unwrap();
+        db.resolve_edges().unwrap();
+
+        let pairs = db.hierarchy("BaseService").unwrap();
+        assert_eq!(
+            pairs,
+            vec![("PaymentProcessor".to_string(), "BaseService".to_string())]
+        );
+    }
+
+    #[test]
     fn test_resolve_edges_class_over_constructor() {
         let db = Database::open_memory().unwrap();
 

--- a/crates/cartog-db/src/store/queries.rs
+++ b/crates/cartog-db/src/store/queries.rs
@@ -219,14 +219,20 @@ impl Database {
     }
 
     /// Inheritance hierarchy rooted at a class.
+    ///
+    /// Like [`Self::refs`], matches the resolved target symbol's name too:
+    /// qualified `target_name`s (PHP `App\Auth\BaseService`) never equal the
+    /// class's short name, so children would otherwise be invisible. The
+    /// parent column reports the resolved short name when available.
     pub fn hierarchy(&self, class_name: &str) -> Result<Vec<(String, String)>> {
         // Returns (child, parent) pairs
         let mut stmt = self.conn.prepare(
-            "SELECT s.name, e.target_name
+            "SELECT s.name, COALESCE(sym2.name, e.target_name)
              FROM edges e
              JOIN symbols s ON e.source_id = s.id
+             LEFT JOIN symbols sym2 ON e.target_id = sym2.id
              WHERE e.kind = 'inherits'
-               AND (s.name = ?1 OR e.target_name = ?1)",
+               AND (s.name = ?1 OR e.target_name = ?1 OR sym2.name = ?1)",
         )?;
         let rows = stmt
             .query_map(params![class_name], |row| Ok((row.get(0)?, row.get(1)?)))?

--- a/crates/cartog-db/src/store/resolution.rs
+++ b/crates/cartog-db/src/store/resolution.rs
@@ -105,7 +105,11 @@ impl Database {
         )?;
 
         for (edge_id, target_name, edge_file, source_id) in unresolved {
-            let simple_name = target_name.rsplit('.').next().unwrap_or(target_name);
+            // `\` is PHP's namespace separator (App\Auth\BaseService).
+            let simple_name = target_name
+                .rsplit(['.', '\\'])
+                .next()
+                .unwrap_or(target_name);
 
             // 1) Same file
             let target_id: Option<String> = same_file_stmt


### PR DESCRIPTION
Fixes #77

## Root cause (two-sided, neither in the PHP extractor)

1. **Resolver** (`resolution.rs`): `simple_name` split target names on `.` only. PHP emits FQCN targets (`App\Auth\BaseService`), which never reduce to the class's short name, so tiers 1–6 all miss. In the `webapp_php` fixture, 8 of 12 inherits edges stayed unresolved; the 4 that resolved bound to same-file `use`-statement **import symbols** instead of the class (PHP import edges even resolved to themselves, killing tier-2 import-path resolution).
2. **Hierarchy query** (`queries.rs`): `hierarchy()` matched raw `target_name` strings only and never joined `target_id` (unlike `refs()` directly above it), so FQCN-named edges stayed invisible even once resolved.

This explains the issue's odd split: `TokenError -> App\AppError` "worked" only because hierarchy printed the raw target string for the child→parent direction, while the parent→children direction needs name matching.

## Fix

- Split `simple_name` on `\` too (PHP's namespace separator; only PHP emits backslash-qualified targets).
- `hierarchy()` LEFT JOINs the resolved target symbol, matches on its name, and reports the resolved short name as the parent (raw `target_name` fallback when unresolved).
- Align `webapp_php` ground truth (scenario 04) with the direct-children convention used by every other language's GT (webapp_py has the identical `AdminService` grandchild and excludes it), and drop the closed known-gap note from `benchmarks/README.md`.

## Results on the issue's repro

```
$ cartog hierarchy BaseService
AuthService -> BaseService
PaymentProcessor -> BaseService
AuthenticationService -> BaseService

$ cartog hierarchy TokenError
TokenError -> AppError
ExpiredTokenError -> TokenError   # previously missing too
```

All 12 fixture inherits edges resolve, 11 to real class symbols (the 12th is `extends RuntimeException`, a PHP built-in with no in-repo class). Fixture edge resolution: 301 → 322.

## Test plan

- 3 regression tests in `cartog-db`, each watched fail first: same-file FQCN resolution (was 0 resolved), class preferred over import symbol (was bound to the import), hierarchy children of an FQCN-resolved target (was empty).
- `cargo test --workspace`: all 32 suites pass; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)