### PR TITLE
fix(indexer): refuse to empty a populated index when the walk finds no files

### DIFF
--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -681,6 +681,20 @@ pub fn index_directory(
     // is a file deletion — otherwise unchanged files keep dangling target_ids
     // and stale in-degrees until the next edit.
     let all_indexed = db.all_files()?;
+    // A walk that found nothing while the DB holds an index almost always
+    // means the wrong root (e.g. `cartog rag index --db <db>` run from another
+    // directory). Sweeping would silently delete the whole index — refuse.
+    if current_files.is_empty() && !all_indexed.is_empty() && !force {
+        anyhow::bail!(
+            "refusing to empty the index: no supported source files found under {} \
+             but the database holds {} indexed files. This usually means the wrong \
+             root for this database (e.g. `cartog rag index --db <db>` run from \
+             another directory). Re-run from the project root, or pass --force to \
+             really empty the index.",
+            root.display(),
+            all_indexed.len()
+        );
+    }
     for indexed_path in all_indexed {
         if !current_files.contains(&indexed_path) {
             dirty_files.insert(indexed_path.clone());
@@ -1071,6 +1085,61 @@ pub mod bench_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn index_dir(db: &cartog_db::Database, root: &Path, force: bool) -> Result<IndexResult> {
+        index_directory(
+            db,
+            root,
+            force,
+            false,
+            None,
+            None,
+            RedactionConfig::disabled(),
+            &std::collections::HashMap::new(),
+        )
+    }
+
+    // TempDir roots are dot-prefixed (`.tmpXXXX`) and the walker skips hidden
+    // roots entirely — give each test a visible subdir to index.
+    fn visible_dir(tmp: &tempfile::TempDir, name: &str) -> std::path::PathBuf {
+        let dir = tmp.path().join(name);
+        std::fs::create_dir(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn index_refuses_empty_root_when_db_has_files() {
+        let db = cartog_db::Database::open_memory().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = visible_dir(&tmp, "proj");
+        std::fs::write(src.join("a.py"), "def foo():\n    return 1\n").unwrap();
+        index_dir(&db, &src, false).unwrap();
+        assert!(!db.all_files().unwrap().is_empty());
+
+        // Pointing the same DB at a root with no supported files (the
+        // `rag index --db X` from-a-wrong-cwd footgun) must refuse instead
+        // of sweeping every indexed file away.
+        let empty = visible_dir(&tmp, "elsewhere");
+        let res = index_dir(&db, &empty, false);
+        assert!(res.is_err(), "expected refusal, got {res:?}");
+        assert!(
+            !db.all_files().unwrap().is_empty(),
+            "index must be left untouched on refusal"
+        );
+    }
+
+    #[test]
+    fn index_force_allows_emptying_the_index() {
+        let db = cartog_db::Database::open_memory().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = visible_dir(&tmp, "proj");
+        std::fs::write(src.join("a.py"), "def foo():\n    return 1\n").unwrap();
+        index_dir(&db, &src, false).unwrap();
+
+        let empty = visible_dir(&tmp, "elsewhere");
+        index_dir(&db, &empty, true).unwrap();
+        assert!(db.all_files().unwrap().is_empty());
+    }
 
     #[test]
     fn test_file_hash_deterministic() {


### PR DESCRIPTION
Closes #107

## Problem

`cartog rag index --db <db>` (and `cartog index`) re-walk the given root before doing their work. Run from a directory that isn't the DB's repo — the exact shape of the ContextBench harness bug — the walk finds zero supported files and the deletion sweep silently removes **every indexed file**:

```bash
cartog index /path/to/repo --db /tmp/x.db   # Files: 499
cd /tmp/empty && cartog rag index --db /tmp/x.db
cartog stats --db /tmp/x.db                 # Files: 0 — index gone
```

## Fix

In `index_directory`, right before the removal sweep: bail with a descriptive error when the walk found no supported files while the DB holds an index. `--force` remains the escape hatch for intentionally emptying an index. The error names the root, the indexed-file count, the likely cause, and both remedies.

A no-op incremental run cannot trip the guard: `current_files` is filled at walk discovery time, so unchanged-but-present files count.

## Not covered (possible follow-up)

The stronger variant from #107 — a root fingerprint in DB metadata — would also catch a *different-but-non-empty* root (running `rag index` from another project still swaps the index today). Deferred; needs a schema-metadata decision.

## Test plan

- `index_refuses_empty_root_when_db_has_files` (watched fail: the sweep wiped the DB) — refusal + index left intact
- `index_force_allows_emptying_the_index` — escape hatch documented by test
- Incidental finding encoded in a test helper: the walker yields nothing for a dot-prefixed walk *root* (TempDir's `.tmpXXXX` names), hence the visible-subdir setup
- `cargo test --workspace`: 32 suites pass; fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental erasure of indexed data when directory scanning finds no supported source files but existing indexes remain. Operation now aborts safely unless explicitly forced.

* **Tests**
  * Added integration tests verifying data preservation behavior and forced index clearing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->