### PR TITLE
perf(db): composite edges(kind, target_name) index for tier-2 resolution

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -173,6 +173,8 @@ CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_name);
 CREATE INDEX IF NOT EXISTS idx_edges_target_id ON edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind);
+-- Tier-2 import-path lookups; kind-only index scans all imports edges per call (#109).
+CREATE INDEX IF NOT EXISTS idx_edges_kind_target ON edges(kind, target_name);
 -- idx_edges_unresolved (partial index on resolution_state=0) is created
 -- post-migration in Database::open so pre-v4 DBs without the column don't
 -- blow up at SCHEMA-load time.
@@ -3076,6 +3078,35 @@ mod tests {
         // foo should still have in_degree = 2 (recomputed correctly)
         let results = db.search("foo", None, None, 10).unwrap();
         assert_eq!(results[0].in_degree, 2);
+    }
+
+    #[test]
+    fn test_tier2_import_resolution_plan_uses_kind_target_index() {
+        // Plan regression for #109; SQL mirrors tier-2 in store/resolution.rs.
+        let db = Database::open_memory().unwrap();
+        let mut stmt = db
+            .conn
+            .prepare(
+                "EXPLAIN QUERY PLAN SELECT s.id FROM symbols s
+                 INNER JOIN edges ie ON ie.kind = 'imports' AND ie.target_name = ?1
+                     AND ie.target_id IS NOT NULL
+                 INNER JOIN symbols is2 ON is2.id = ie.source_id AND is2.file_path = ?2
+                 INNER JOIN symbols resolved ON resolved.id = ie.target_id
+                 WHERE s.name = ?1 AND s.kind != 'import'
+                     AND s.file_path = resolved.file_path
+                 LIMIT 1",
+            )
+            .unwrap();
+        let plan = stmt
+            .query_map(params!["x", "y"], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n");
+        assert!(
+            plan.contains("idx_edges_kind_target"),
+            "tier-2 must drive off edges(kind, target_name); got plan:\n{plan}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #109

## Problem

Tier-2 (import-path) resolution runs one query per unresolved edge. SQLite drives the join off `idx_edges_kind`, scanning **every `imports` edge per call** (parameterized `target_name` + no stats → the literal `kind='imports'` wins). Cost is O(unresolved × import-edges); both grow with repo size, so resolution is effectively quadratic — invisible on 50-file fixtures, ~38 min single-core on transformers-scale. `sample` showed 99% of stacks in `resolve_edges_in_tx` → `query_row`.

## Fix

One composite index, `edges(kind, target_name)`, added to the schema block (`CREATE INDEX IF NOT EXISTS` runs at every open, so existing DBs pick it up with a one-time build — no migration).

## Measured

| | before | after |
|---|---|---|
| tier-2 call (transformers DB) | ~11 ms | ~0.2 ms (≈50×) |
| `cartog index --no-lsp` transformers@cd73b9a8 (376k edges) | ~38 min | **69 s (≈33×)** |
| resolution result | 112,223 edges | 112,223 edges — identical |

Affects every resolution entry point: `index`, `rag index` (fresh DB / dirty re-index), `watch` re-indexes, `--force`.

## Verified not needed elsewhere

EXPLAIN'd the remaining per-edge statements (tiers 1/3/4/5 + the pass collector) on the same 376k-edge DB — all drive off appropriate indexes; tier-2 was the only misplan.

## Deferred follow-ups (named, not in this PR)

- `ANALYZE` after indexing for planner stats generally
- A large/synthetic scale case for `make bench-resolution` so quadratic regressions get caught
- Marking heuristic-failed edges so `resolve_edges_scoped` stops re-walking the full unresolved backlog on every incremental re-index (the watch-mode amplification in #109)

## Test plan

- `test_tier2_import_resolution_plan_uses_kind_target_index` — plan-shape regression, watched fail first (reproduced the `idx_edges_kind` scan verbatim)
- `cargo test --workspace`: 32 suites pass; fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved query performance for import-path resolution.

* **Tests**
  * Enhanced test coverage for import-path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->