### PR TITLE
feat(benchmarks): ContextBench retrieval eval (cartog-as-retriever)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,13 +2,20 @@
 
 Compares cartog graph queries vs grep/cat approaches for common code navigation tasks.
 
-## Three benchmark surfaces
+## Benchmark surfaces
+
+One row per entry point — if you're lost, start here:
 
 | Surface | Question it answers | Run with |
 |---------|---------------------|----------|
 | **Shell suite** (this file) | Is a single cartog query smaller / more complete than grep? | `make bench` |
+| **Edge resolution** | What share of edges resolve, per language? (heuristic / host LSP / strict Docker LSP) | `make bench-resolution`, `make bench-resolution-docker` |
 | **Criterion micro-benchmarks** | How fast is cartog's own CPU work (µs–ms)? | `make bench-criterion` |
+| **ONNX model benches** | How fast are the real embed/rerank models? | `make bench-onnx` |
+| **RAG relevancy** | Does hybrid search rank the relevant symbols on top? | `make bench-rag` |
 | **Agent-task** (`agent/`) | Does giving an agent cartog cut the *end-to-end* token cost of a task? | `make bench-agent` |
+| **ContextBench** (`contextbench/`) | Does cartog retrieve the *right* context for real issues (vs human gold)? | [contextbench/README.md](contextbench/README.md) |
+| **Skill / agent evals** | Do the cartog skill and agents behave as designed? (LLM-as-judge) | `make eval-skill`, `make eval-agents` |
 
 The shell suite below is **per-query** (no LLM). The
 [agent-task suite](agent/README.md) drives a real agent through whole tasks with

--- a/benchmarks/contextbench/README.md
+++ b/benchmarks/contextbench/README.md
@@ -1,0 +1,115 @@
+# ContextBench eval (cartog-as-retriever)
+
+[ContextBench](https://github.com/EuniAI/ContextBench) (arXiv 2602.05892) is a
+process-oriented benchmark for **context retrieval** in coding agents: 1,136
+issue-resolution tasks across 66 repos and 8 languages, each with a
+human-annotated gold context. It scores how well an agent *finds the right code*
+(file / symbol / span / line coverage + precision), not whether a patch passes
+tests.
+
+This directory wires **cartog as the retriever** ("Mode A"): for each task we
+check out the repo at its base commit, index it with cartog, run `cartog context`
++ `cartog rag search` on the issue text, and emit a ContextBench prediction. This
+measures cartog's retrieval quality directly, with no LLM edit loop.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `cartog_adapter.py` | Run cartog over gold instances → ContextBench unified predictions JSONL |
+| `prepare_gold.py` | Convert a gold parquet → JSONL the evaluator accepts (works around the loader bug below) |
+
+## Setup
+
+ContextBench pins `tree-sitter==0.20.4` and `tree-sitter-languages`, which do not
+build/install on Python ≥ 3.12. Use the modern stack instead — the ContextBench
+code already falls back to `tree_sitter_language_pack`:
+
+```bash
+git clone https://github.com/EuniAI/ContextBench /tmp/ContextBench
+cd /tmp/ContextBench
+python3 -m venv .venv
+.venv/bin/pip install pyarrow pandas tree-sitter tree-sitter-language-pack
+# datasets live in data/*.parquet (verified subset, full set)
+```
+
+## Run
+
+```bash
+export CONTEXTBENCH_DIR=/tmp/ContextBench   # so the adapter can import contextbench.core.checkout
+
+# 1. Prepare gold JSONL (filter to cartog-supported languages)
+.venv/bin/python prepare_gold.py \
+    --in data/contextbench_verified_test.parquet \
+    --out gold.jsonl \
+    --langs go,rust,typescript,java,python
+
+# 2. Run cartog as the retriever (clones + indexes each repo; slow on large repos)
+#    --rag-index    builds embeddings so vector search is live (needs `cartog rag setup`)
+#    --keyword-query extracts code identifiers from issue prose (see "prose query" gotcha)
+.venv/bin/python cartog_adapter.py \
+    --gold gold.jsonl --out preds.jsonl --cache ./repos \
+    --rag-index --keyword-query \
+    --tokens 6000 --index-timeout 1200 --query-timeout 240
+
+# 3. Score against gold
+.venv/bin/python -m contextbench.evaluate \
+    --gold gold.jsonl --pred preds.jsonl --cache ./repos --out results.jsonl
+```
+
+The summary (file/symbol/span/line Coverage + Precision, plus trajectory AUC and
+EditLoc) is printed to stderr; per-instance breakdowns go to `results.jsonl`.
+
+## Gotchas (learned the hard way)
+
+- **Feed gold as JSONL, not parquet.** ContextBench's parquet loader
+  (`contextbench/parsers/gold.py::_load_parquet`) hard-codes a `repo_url` column
+  that the verified-test/verified parquet does not have, and crashes with
+  `ArrowInvalid: No match for FieldRef.Name(repo_url)`. `prepare_gold.py` emits
+  JSONL with `repo_url` derived from `original_inst_id`
+  (`owner__repo-N` → `https://github.com/owner/repo.git`), which the JSONL loader
+  path accepts.
+- **Python ≥ 3.12 dep wall.** `tree-sitter==0.20.4` / `tree-sitter-languages` from
+  `requirements.txt` won't install; use `tree-sitter-language-pack` (see Setup).
+- **Span precision is sensitive to what cartog emits.** cartog's `context`/`rag`
+  entries return whole symbol bodies, including large containers (modules, big
+  classes). Counting every byte of a module body as "predicted" tanks span/line
+  precision. The adapter drops `module`/`import`-kind spans and caps any single
+  span at `MAX_SPAN_LINES` (default 200); symbol *names* are kept regardless, so
+  symbol-level recall is unaffected.
+- **Empty gold symbols.** Some gold contexts (often Python) annotate file-header /
+  import regions that don't overlap a tree-sitter `function`/`class` node, so
+  ContextBench extracts zero gold symbols. Symbol-level Coverage/Precision then
+  reads 1.000/1.000 vacuously — treat file + span + EditLoc as the trustworthy
+  axes for those instances.
+- **Wall-clock is dominated by clone+index** of large repos (django, transformers,
+  cli). Scope runs by language and/or `--limit`; repos are cached under `--cache`
+  and shared with the evaluator. The adapter caches the cartog DB by repo+commit,
+  so re-runs and repeated commits skip re-indexing.
+- **Feed cartog a keyword query, not raw issue prose** (`--keyword-query`). With
+  vector search off, a long prose query's stopword-heavy tokens
+  (`changes`, `however`, `Related`) match **markdown** symbols (CHANGELOG, docs)
+  far more than code. FTS ranks those docs top, then cartog's default `CodeOnly`
+  filter drops every `Document` → **0 results** ("no cartog context produced").
+  Empirically, on the same indexed DB, raw prose → 0 results, 12 code identifiers
+  → 6+ results. `--keyword-query` extracts backticked spans, CamelCase, and
+  snake_case identifiers from the issue text. `--rag-index` (vector search on)
+  also rescues prose queries.
+- **`cartog rag setup` is a prerequisite for `--rag-index`.** Without embeddings,
+  `vec_count=0` and only FTS keyword matching is live — which is what made the
+  first run's TypeScript coverage collapse.
+
+## Interpreting results
+
+cartog is built for **high recall** retrieval (hybrid search + 1-hop graph
+neighbors + centrality), so expect strong file/span **coverage** and lower
+**precision** — exactly the recall-over-precision tradeoff the ContextBench paper
+identifies across agents. The honest way to report cartog is a coverage-precision
+table per language, optionally sweeping `--tokens` to trace the tradeoff curve.
+
+## Results
+
+_Mode A, verified-test subset (go/rust/typescript/java/python). Populated from a
+real run — see `results.jsonl`._
+
+<!-- RESULTS_TABLE -->

--- a/benchmarks/contextbench/README.md
+++ b/benchmarks/contextbench/README.md
@@ -109,7 +109,73 @@ table per language, optionally sweeping `--tokens` to trace the tradeoff curve.
 
 ## Results
 
-_Mode A, verified-test subset (go/rust/typescript/java/python). Populated from a
-real run — see `results.jsonl`._
+_Mode A, verified-test subset, 38 instances (2026-06-10), `--rag-index
+--keyword-query --tokens 6000`. Macro-averaged (mean of per-instance scores)
+per language; the evaluator's pooled overall is shown below the table._
 
-<!-- RESULTS_TABLE -->
+| Language   | n  | File cov | File ceiling | File prec | Span cov | Span prec | Line cov |
+|------------|----|----------|--------------|-----------|----------|-----------|----------|
+| rust       | 3  | 1.000    | 1.000        | 0.117     | 0.534    | 0.254     | 0.511    |
+| go         | 3  | 0.833    | 0.917        | 0.126     | 0.314    | 0.135     | 0.256    |
+| java       | 4  | 0.596    | 0.929        | 0.392     | 0.075    | 0.404     | 0.063    |
+| typescript | 6  | 0.533    | 0.833        | 0.101     | 0.168    | 0.071     | 0.210    |
+| python     | 22 | 0.504    | 1.000        | 0.103     | 0.277    | 0.075     | 0.256    |
+| **ALL**    | 38 | 0.583    | 0.960        | 0.136     | 0.262    | 0.128     | 0.249    |
+
+Evaluator pooled overall: file 0.500/0.118, span 0.144/0.091, line 0.134/0.091
+(coverage/precision), EditLoc recall 0.013.
+
+### Ablation: FTS-only (vector search off)
+
+_Same harness and instances, `--keyword-query` only (no `--rag-index`), all 38
+indexed `--no-lsp`. Measures what vector search adds on top of keyword FTS._
+
+| Language   | n  | File cov | File prec | Span cov | Span prec | Line cov |
+|------------|----|----------|-----------|----------|-----------|----------|
+| rust       | 3  | 1.000    | 0.172     | 0.536    | 0.319     | 0.513    |
+| go         | 3  | 0.833    | 0.117     | 0.366    | 0.131     | 0.302    |
+| python     | 22 | 0.519    | 0.109     | 0.261    | 0.079     | 0.242    |
+| typescript | 6  | 0.406    | 0.093     | 0.084    | 0.071     | 0.118    |
+| java       | 4  | 0.400    | 0.363     | 0.068    | 0.508     | 0.056    |
+| **ALL**    | 38 | 0.551    | 0.138     | 0.243    | 0.146     | 0.229    |
+
+Evaluator pooled overall: file 0.477/0.115, span 0.139/0.094, line 0.130/0.096,
+EditLoc recall 0.013.
+
+Hybrid minus FTS-only, file coverage: java **+0.196**, typescript **+0.127**
+(plus 2× span coverage there), rust/go **0.000** (identifier-rich issues —
+keywords already saturate), python **−0.015** (a wash, within noise). Vector
+search pays where issue prose and code vocabulary diverge (java, typescript)
+and costs nothing elsewhere. Caveat: the ablation ran `--no-lsp` on all 38
+while the hybrid run had LSP on 34, so the deltas bundle both effects — but
+LSP only changes 1-hop neighbor expansion (heuristics resolve ~90% of edges),
+so the vector effect dominates.
+
+Caveats for reading these numbers:
+
+- **Symbol-level metrics are omitted — they are vacuous on this dataset.** The
+  evaluator (under the `tree-sitter-language-pack` fallback) extracted zero
+  gold symbols on every one of the 38 instances, so symbol coverage/precision
+  read 1.000/1.000 by the 0/0 convention and carry no information.
+- **Single-shot retrieval, not an agent.** One query per instance, no
+  iteration, 6000-token budget; gold contexts are annotated from solutions and
+  often exceed the budget. Expect coverage ceilings well below multi-turn
+  agents.
+- **Recall-first by design**: low file precision is the cost of bundling
+  1-hop graph neighbors; an agent can skim past extras, but it cannot use
+  files that were never retrieved.
+- **File ceiling** is the max achievable file coverage: 5 of 86 gold files
+  are unreachable in principle (build/config files cartog doesn't index —
+  Makefile, 2× package.json, pom.xml — plus one issue-attached reproducer
+  outside the repo tree). rust/go sit at their ceiling; the
+  python/typescript gaps are genuine retrieval headroom.
+- **Java span coverage (0.075) understates retrieval there**: java gold
+  spans are whole-class regions (often 300+ lines from line 1, imports and
+  class header included) while cartog returns method-level spans — java's
+  span *precision* (0.404) is the highest of any language. Right
+  neighborhoods, small slices.
+- 34 instances were indexed with LSP edge resolution; 4 oversized repos
+  (transformers ×2, django-11603, material-ui-32626) used `--no-lsp` after
+  blowing the index timeout. This affects only 1-hop neighbor expansion,
+  not search seeds.
+- n is tiny for rust/go/java — single instances move those means a lot.

--- a/benchmarks/contextbench/cartog_adapter.py
+++ b/benchmarks/contextbench/cartog_adapter.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Adapter: run cartog as the context retriever on ContextBench tasks (Mode A).
+
+For each gold instance: check out the repo at base_commit, index it with cartog,
+run `cartog context` (and optionally `cartog rag search`) against the issue's
+problem_statement, then emit a ContextBench unified prediction record.
+
+This measures cartog's *retrieval* quality (no LLM edit loop) against
+ContextBench's human-annotated gold contexts.
+
+Output is a JSONL consumable directly by:
+    python -m contextbench.evaluate --gold <gold.jsonl> --pred preds.jsonl --out results.jsonl
+
+Each record:
+    {
+      "instance_id": <original_inst_id>,
+      "repo_url": <git url>, "commit": <base_commit>,
+      "traj_data": {
+        "pred_steps": [{"files": [...], "spans": {f: [{start,end}]}, "symbols": {f: [name]}}],
+        "pred_files": [...], "pred_spans": {f: [{start,end}]}, "pred_symbols": {f: [name]}
+      },
+      "model_patch": ""        # Mode A does no editing
+    }
+
+NOTE on span precision: cartog's context/rag entries return whole symbol bodies,
+including large enclosing containers (modules, big classes). Counting every byte
+of a module body as "predicted" destroys span precision. We therefore drop
+module-kind spans and cap any single span at MAX_SPAN_LINES; symbol names are kept
+regardless so symbol-level recall is unaffected.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import pyarrow.dataset as ds
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# ContextBench checkout helper, used so adapter + evaluator share the repo cache.
+# Set CONTEXTBENCH_DIR to the cloned ContextBench repo if it's not on sys.path.
+_cb_dir = os.environ.get("CONTEXTBENCH_DIR")
+if _cb_dir:
+    sys.path.insert(0, _cb_dir)
+from contextbench.core import checkout  # noqa: E402
+
+CARTOG_LANGS = {"python", "typescript", "javascript", "rust", "go", "ruby",
+                "java", "php", "dart", "swift", "kotlin"}
+
+# Spans larger than this many lines are container bodies (modules / huge classes),
+# not localized context; drop them from span/line scoring. Names are still kept.
+MAX_SPAN_LINES = 200
+# Symbol kinds whose body spans the whole file or a large region — exclude their spans.
+CONTAINER_KINDS = {"module", "import"}
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def resolve_repo_url(repo_url: Optional[str], original_inst_id: str) -> str:
+    if repo_url:
+        return repo_url
+    s = (original_inst_id or "").strip()
+    m = re.match(r"^([A-Za-z0-9_.-]+)__([A-Za-z0-9_.-]+)-\d+$", s)
+    if m:
+        return f"https://github.com/{m.group(1)}/{m.group(2)}.git"
+    return ""
+
+
+def run_cartog(args: List[str], cwd: str, db_path: str, timeout: int) -> Optional[Any]:
+    cmd = ["cartog", *args, "--json", "--db", db_path]
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log(f"    cartog {args[0]} timed out")
+        return None
+    if proc.returncode != 0:
+        log(f"    cartog {args[0]} failed (rc={proc.returncode}): {proc.stderr.strip()[:200]}")
+        return None
+    out = proc.stdout.strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        log(f"    cartog {args[0]} non-JSON output: {out[:120]}")
+        return None
+
+
+def index_repo(repo_dir: str, db_path: str, timeout: int) -> bool:
+    cmd = ["cartog", "index", repo_dir, "--db", db_path]
+    try:
+        proc = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log("    cartog index timed out")
+        return False
+    if proc.returncode != 0:
+        log(f"    cartog index failed (rc={proc.returncode}): {proc.stderr.strip()[:200]}")
+        return False
+    return True
+
+
+def rag_index_repo(repo_dir: str, db_path: str, timeout: int) -> bool:
+    """Build the embedding index so vector search (semantic) is live.
+
+    PATH must be the repo: `rag index` re-walks it before embedding, and a
+    mismatched cwd (e.g. the run dir) makes the sweep delete every indexed file.
+    """
+    cmd = ["cartog", "rag", "index", repo_dir, "--db", db_path]
+    try:
+        proc = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log("    cartog rag index timed out")
+        return False
+    if proc.returncode != 0:
+        log(f"    cartog rag index failed (rc={proc.returncode}): {proc.stderr.strip()[:200]}")
+        return False
+    return True
+
+
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+_STOPWORDS = {
+    "the", "and", "for", "with", "that", "this", "from", "have", "has", "not",
+    "but", "all", "any", "are", "was", "were", "when", "then", "than", "also",
+    "should", "would", "could", "doesn", "don", "isn", "you", "your", "they",
+    "them", "their", "its", "it's", "however", "related", "issue", "bug", "fix",
+    "works", "work", "working", "expected", "expect", "example", "https", "http",
+    "com", "github", "codesandbox", "great", "awesome", "looks", "look", "seem",
+    "seems", "apply", "applied", "passing", "pass", "change", "changes", "perspective",
+}
+
+
+def keyword_query(problem: str, max_terms: int = 12) -> str:
+    """Extract a keyword/identifier query from issue prose.
+
+    cartog's FTS path drowns in prose: stopword-heavy queries rank markdown docs
+    above code, which the default CodeOnly filter then drops. Prefer code-like
+    tokens: backticked spans, CamelCase, snake_case, and distinctive identifiers.
+    """
+    # 1. Backticked / quoted code spans get top priority.
+    spans = re.findall(r"`([^`]+)`", problem)
+    terms: List[str] = []
+    seen: set = set()
+
+    def add(tok: str) -> None:
+        t = tok.strip()
+        low = t.lower()
+        if not t or low in seen or low in _STOPWORDS:
+            return
+        seen.add(low)
+        terms.append(t)
+
+    for s in spans:
+        for tok in _IDENT_RE.findall(s):
+            add(tok)
+
+    # 2. CamelCase / snake_case identifiers in the title (first line) and body.
+    title = problem.splitlines()[0] if problem else ""
+    for region in (title, problem):
+        for tok in _IDENT_RE.findall(region):
+            if any(c.isupper() for c in tok[1:]) or "_" in tok:  # camelCase / snake_case
+                add(tok)
+            if len(terms) >= max_terms:
+                break
+
+    # 3. Backfill with remaining distinctive words if we are short.
+    if len(terms) < 4:
+        for tok in _IDENT_RE.findall(title or problem):
+            add(tok)
+            if len(terms) >= max_terms:
+                break
+
+    return " ".join(terms[:max_terms])
+
+
+def symbols_to_step(entries: List[dict]) -> Dict[str, Any]:
+    """Convert cartog context/search entries into a unified step.
+
+    Names are always recorded (symbol recall). Spans are recorded only for
+    localized, non-container symbols (span/line precision).
+    """
+    files: set = set()
+    spans: Dict[str, List[dict]] = defaultdict(list)
+    symbols: Dict[str, List[str]] = defaultdict(list)
+    for e in entries:
+        sym = e.get("symbol", e)  # rag search may put symbol fields at top level
+        fp = sym.get("file_path") or sym.get("file")
+        if not fp:
+            continue
+        files.add(fp)
+        name = sym.get("name")
+        if name:
+            symbols[fp].append(name)
+        start = sym.get("start_line")
+        end = sym.get("end_line")
+        kind = (sym.get("kind") or "").lower()
+        if not (isinstance(start, int) and isinstance(end, int) and start > 0 and end >= start):
+            continue
+        if kind in CONTAINER_KINDS:
+            continue
+        if (end - start + 1) > MAX_SPAN_LINES:
+            continue
+        spans[fp].append({"start": start, "end": end})
+    return {
+        "files": sorted(files),
+        "spans": {f: v for f, v in spans.items() if v},
+        "symbols": {f: sorted(set(v)) for f, v in symbols.items()},
+    }
+
+
+def merge_steps(steps: List[Dict[str, Any]]) -> Dict[str, Any]:
+    files: set = set()
+    spans: Dict[str, List[dict]] = defaultdict(list)
+    symbols: Dict[str, List[str]] = defaultdict(list)
+    for st in steps:
+        files.update(st.get("files", []))
+        for f, v in st.get("spans", {}).items():
+            spans[f].extend(v)
+        for f, v in st.get("symbols", {}).items():
+            symbols[f].extend(v)
+    # Dedup spans per file.
+    dedup_spans: Dict[str, List[dict]] = {}
+    for f, v in spans.items():
+        seen = set()
+        uniq = []
+        for s in v:
+            key = (s["start"], s["end"])
+            if key in seen:
+                continue
+            seen.add(key)
+            uniq.append(s)
+        dedup_spans[f] = uniq
+    return {
+        "files": sorted(files),
+        "spans": dedup_spans,
+        "symbols": {f: sorted(set(v)) for f, v in symbols.items()},
+    }
+
+
+def build_prediction(row: dict, cache_dir: str, tokens: int, use_rag: bool,
+                     idx_timeout: int, q_timeout: int, build_embeddings: bool,
+                     use_keyword: bool) -> Optional[dict]:
+    instance_id = row.get("instance_id") or row.get("original_inst_id")
+    original = row.get("original_inst_id") or instance_id
+    commit = row.get("base_commit") or row.get("commit")
+    language = (row.get("language") or "").lower()
+    problem = (row.get("problem_statement") or "").strip()
+
+    if language not in CARTOG_LANGS:
+        log(f"  SKIP {instance_id}: language '{language}' unsupported by cartog")
+        return None
+    if not problem:
+        log(f"  SKIP {instance_id}: empty problem_statement")
+        return None
+
+    repo_url = resolve_repo_url(row.get("repo_url"), original)
+    if not repo_url or not commit:
+        log(f"  SKIP {instance_id}: missing repo_url/commit")
+        return None
+
+    log(f"  {instance_id} [{language}] {repo_url}@{commit[:10]}")
+    repo_dir = checkout(repo_url, commit, cache_dir, verbose=False)
+    if not repo_dir or not os.path.isdir(repo_dir):
+        log("    checkout failed")
+        return None
+
+    # Cache the DB by repo+commit so re-runs and repeated commits skip re-indexing.
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", f"{original}_{commit[:10]}")
+    db_path = os.path.join(tempfile.gettempdir(), f"cartog_cb_{slug}.db")
+    if not os.path.exists(db_path):
+        if not index_repo(repo_dir, db_path, idx_timeout):
+            return None
+        if build_embeddings:
+            log("    building embeddings (rag index)")
+            rag_index_repo(repo_dir, db_path, idx_timeout)  # best-effort; FTS still works if it fails
+
+    query = keyword_query(problem) if use_keyword else problem[:2000]
+    log(f"    query: {query!r}")
+    steps: List[Dict[str, Any]] = []
+
+    ctx = run_cartog(["context", query, "--tokens", str(tokens)], repo_dir, db_path, q_timeout)
+    if ctx and ctx.get("entries"):
+        steps.append(symbols_to_step(ctx["entries"]))
+
+    if use_rag:
+        rag = run_cartog(["rag", "search", query], repo_dir, db_path, q_timeout)
+        if rag:
+            results = rag.get("results") or rag.get("entries") or (rag if isinstance(rag, list) else [])
+            if isinstance(results, list) and results:
+                steps.append(symbols_to_step(results))
+
+    if not steps:
+        log("    no cartog context produced")
+        return None
+
+    final = merge_steps(steps)
+    return {
+        "instance_id": original,
+        "repo_url": repo_url,
+        "commit": commit,
+        "traj_data": {
+            "pred_steps": steps,
+            "pred_files": final["files"],
+            "pred_spans": final["spans"],
+            "pred_symbols": final["symbols"],
+        },
+        "model_patch": "",
+    }
+
+
+def repo_url_from_id(orig: str) -> str:
+    return resolve_repo_url(None, orig)
+
+
+def load_gold_rows(gold_path: str, limit: int, langs: Optional[set]) -> List[dict]:
+    """Load gold rows from a parquet or JSONL file into adapter-ready dicts."""
+    rows: List[dict] = []
+    if gold_path.endswith(".parquet"):
+        table = ds.dataset(gold_path, format="parquet").to_table()
+        for r in table.to_pylist():
+            rows.append({
+                "instance_id": r.get("instance_id"),
+                "original_inst_id": r.get("original_inst_id"),
+                "repo": r.get("repo"),
+                "repo_url": r.get("repo_url"),
+                "base_commit": r.get("base_commit"),
+                "language": r.get("language"),
+                "problem_statement": r.get("problem_statement"),
+            })
+    else:
+        with open(gold_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    if langs:
+        rows = [r for r in rows if (r.get("language") or "").lower() in langs]
+    if limit and limit > 0:
+        rows = rows[:limit]
+    return rows
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="cartog-as-retriever adapter for ContextBench")
+    p.add_argument("--gold", required=True, help="Gold parquet or JSONL path")
+    p.add_argument("--out", required=True, help="Output predictions JSONL")
+    p.add_argument("--cache", default="./repos", help="Repo cache dir (shared with evaluator)")
+    p.add_argument("--limit", type=int, default=0, help="Max instances (0 = all)")
+    p.add_argument("--langs", default="", help="Comma-separated language filter")
+    p.add_argument("--tokens", type=int, default=6000, help="cartog context token budget")
+    p.add_argument("--no-rag", action="store_true", help="Skip cartog rag search step")
+    p.add_argument("--rag-index", action="store_true",
+                   help="Build embeddings (cartog rag index) so vector search is live; requires `cartog rag setup`")
+    p.add_argument("--keyword-query", action="store_true",
+                   help="Extract code identifiers from the issue text instead of feeding raw prose")
+    p.add_argument("--index-timeout", type=int, default=600)
+    p.add_argument("--query-timeout", type=int, default=120)
+    args = p.parse_args()
+
+    langs = {x.strip().lower() for x in args.langs.split(",") if x.strip()} or None
+    rows = load_gold_rows(args.gold, args.limit, langs)
+    log(f"Loaded {len(rows)} gold instances")
+
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    written = 0
+    with open(args.out, "w", encoding="utf-8") as f:
+        for i, row in enumerate(rows, 1):
+            log(f"[{i}/{len(rows)}]")
+            pred = build_prediction(row, args.cache, args.tokens, not args.no_rag,
+                                    args.index_timeout, args.query_timeout,
+                                    args.rag_index, args.keyword_query)
+            if pred:
+                f.write(json.dumps(pred, ensure_ascii=False) + "\n")
+                f.flush()
+                written += 1
+    log(f"Wrote {written} predictions to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/contextbench/cartog_adapter.py
+++ b/benchmarks/contextbench/cartog_adapter.py
@@ -93,8 +93,9 @@ def run_cartog(args: List[str], cwd: str, db_path: str, timeout: int) -> Optiona
         return None
 
 
-def index_repo(repo_dir: str, db_path: str, timeout: int) -> bool:
-    cmd = ["cartog", "index", repo_dir, "--db", db_path]
+def index_repo(repo_dir: str, db_path: str, timeout: int, no_lsp: bool = False) -> bool:
+    # LSP dominates cold-index time on giant repos; skipping it only weakens 1-hop edges.
+    cmd = ["cartog", "index", repo_dir, "--db", db_path] + (["--no-lsp"] if no_lsp else [])
     try:
         proc = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
@@ -245,7 +246,7 @@ def merge_steps(steps: List[Dict[str, Any]]) -> Dict[str, Any]:
 
 def build_prediction(row: dict, cache_dir: str, tokens: int, use_rag: bool,
                      idx_timeout: int, q_timeout: int, build_embeddings: bool,
-                     use_keyword: bool) -> Optional[dict]:
+                     use_keyword: bool, no_lsp: bool = False) -> Optional[dict]:
     instance_id = row.get("instance_id") or row.get("original_inst_id")
     original = row.get("original_inst_id") or instance_id
     commit = row.get("base_commit") or row.get("commit")
@@ -270,15 +271,20 @@ def build_prediction(row: dict, cache_dir: str, tokens: int, use_rag: bool,
         log("    checkout failed")
         return None
 
-    # Cache the DB by repo+commit so re-runs and repeated commits skip re-indexing.
+    # Cache the DB by repo+commit; `.ok` gates it (a killed index leaves a partial DB behind).
     slug = re.sub(r"[^A-Za-z0-9]+", "_", f"{original}_{commit[:10]}")
     db_path = os.path.join(tempfile.gettempdir(), f"cartog_cb_{slug}.db")
-    if not os.path.exists(db_path):
-        if not index_repo(repo_dir, db_path, idx_timeout):
+    done_marker = db_path + ".ok"
+    if not (os.path.exists(db_path) and os.path.exists(done_marker)):
+        for stale in (db_path, db_path + "-wal", db_path + "-shm", done_marker):
+            if os.path.exists(stale):
+                os.remove(stale)
+        if not index_repo(repo_dir, db_path, idx_timeout, no_lsp):
             return None
         if build_embeddings:
             log("    building embeddings (rag index)")
             rag_index_repo(repo_dir, db_path, idx_timeout)  # best-effort; FTS still works if it fails
+        open(done_marker, "w").close()
 
     query = keyword_query(problem) if use_keyword else problem[:2000]
     log(f"    query: {query!r}")
@@ -359,6 +365,8 @@ def main() -> int:
                    help="Build embeddings (cartog rag index) so vector search is live; requires `cartog rag setup`")
     p.add_argument("--keyword-query", action="store_true",
                    help="Extract code identifiers from the issue text instead of feeding raw prose")
+    p.add_argument("--no-lsp", action="store_true",
+                   help="Skip LSP edge resolution during indexing (giant-repo escape hatch)")
     p.add_argument("--index-timeout", type=int, default=600)
     p.add_argument("--query-timeout", type=int, default=120)
     args = p.parse_args()
@@ -374,7 +382,7 @@ def main() -> int:
             log(f"[{i}/{len(rows)}]")
             pred = build_prediction(row, args.cache, args.tokens, not args.no_rag,
                                     args.index_timeout, args.query_timeout,
-                                    args.rag_index, args.keyword_query)
+                                    args.rag_index, args.keyword_query, args.no_lsp)
             if pred:
                 f.write(json.dumps(pred, ensure_ascii=False) + "\n")
                 f.flush()

--- a/benchmarks/contextbench/prepare_gold.py
+++ b/benchmarks/contextbench/prepare_gold.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Convert a ContextBench gold parquet into JSONL the evaluator accepts.
+
+The verified-test/verified parquet lacks a `repo_url` column, but
+contextbench.parsers.gold._load_parquet hard-codes it and crashes. The JSONL
+loader path has no such requirement, so we emit JSONL with repo_url derived from
+original_inst_id (owner__repo-N -> https://github.com/owner/repo.git).
+
+Usage:
+    python prepare_gold.py --in data/contextbench_verified_test.parquet \
+        --out gold.jsonl [--langs go,rust,typescript,java,python]
+"""
+
+import argparse
+import json
+import re
+
+import pyarrow.dataset as ds
+
+
+def repo_url(orig: str) -> str:
+    m = re.match(r"^([A-Za-z0-9_.-]+)__([A-Za-z0-9_.-]+)-\d+$", orig or "")
+    return f"https://github.com/{m.group(1)}/{m.group(2)}.git" if m else ""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--in", dest="inp", required=True, help="Gold parquet")
+    p.add_argument("--out", required=True, help="Output JSONL")
+    p.add_argument("--langs", default="", help="Comma-separated language filter")
+    args = p.parse_args()
+
+    langs = {x.strip().lower() for x in args.langs.split(",") if x.strip()} or None
+    table = ds.dataset(args.inp, format="parquet").to_table()
+    written = 0
+    skipped_no_url = 0
+    with open(args.out, "w", encoding="utf-8") as f:
+        for r in table.to_pylist():
+            lang = (r.get("language") or "").lower()
+            if langs and lang not in langs:
+                continue
+            url = r.get("repo_url") or repo_url(r.get("original_inst_id") or "")
+            if not url:
+                skipped_no_url += 1
+                continue
+            gc = r.get("gold_context")
+            try:
+                gc = json.loads(gc) if isinstance(gc, str) else (gc or [])
+            except json.JSONDecodeError:
+                gc = []
+            d = {
+                "inst_id": r.get("instance_id"),
+                "original_inst_id": r.get("original_inst_id"),
+                "repo": r.get("repo"),
+                "repo_url": url,
+                "commit": r.get("base_commit"),
+                "gold_ctx": gc,  # Gold falls back to gold_ctx -> init
+                "patch": r.get("patch") or "",
+                "language": lang,
+                "problem_statement": r.get("problem_statement") or "",
+            }
+            f.write(json.dumps(d, ensure_ascii=False) + "\n")
+            written += 1
+    print(f"wrote {written} rows to {args.out} (skipped {skipped_no_url} without resolvable repo_url)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why this benchmark

cartog's core promise is *retrieval*: surface the right code for a task. Our existing
benchmarks (`make bench`, `bench-rag`) score against fixtures we wrote ourselves.
[ContextBench](https://github.com/EuniAI/ContextBench) (EuniAI, arXiv 2602.05892) is an
independent, third-party benchmark with **human-annotated gold contexts** for 1,136 real
issue-resolution tasks across 66 repos / 8 languages — it scores whether a retriever finds
the files/spans/lines a human marked as needed, not whether a patch passes tests.

Wiring cartog into it gives us:

- an honest external anchor for retrieval quality (file/span/line coverage + precision per language)
- a regression harness for search changes (hybrid ranking, reranker, `--tokens` budgets)
- it already paid for itself: the runs surfaced the `rag index` cwd wipe (#107 → #108) and
  the tier-2 resolution hotspot (#109 → #110), plus the prose-query recall lead

## What

- `benchmarks/contextbench/cartog_adapter.py` — Mode A: cartog as single-shot retriever
  (`cartog context` + `rag search` per task), emits ContextBench unified predictions.
  Hardened: `.ok` marker gates the per-repo DB cache; `--no-lsp` giant-repo escape hatch
- `benchmarks/contextbench/prepare_gold.py` — gold parquet → JSONL (works around upstream loader bug)
- `benchmarks/contextbench/README.md` — setup, gotchas (hard-won), results + caveats
- `benchmarks/README.md` — surfaces table now lists every benchmark entry point

## Results (38-instance verified subset)

Hybrid (`--rag-index --keyword-query --tokens 6000`), macro per language:

| Language | n | File cov | File ceiling | Span cov |
|---|---|---|---|---|
| rust | 3 | 1.000 | 1.000 | 0.534 |
| go | 3 | 0.833 | 0.917 | 0.314 |
| java | 4 | 0.596 | 0.929 | 0.075 |
| typescript | 6 | 0.533 | 0.833 | 0.168 |
| python | 22 | 0.504 | 1.000 | 0.277 |
| **ALL** | 38 | **0.583** | 0.960 | 0.262 |

FTS-only ablation: vector search adds **java +0.196 / typescript +0.127** file coverage
(2× typescript span coverage), rust/go +0, python a wash — it pays where issue prose and
code vocabulary diverge. Full tables, ceiling definition, and caveats (vacuous symbol axis,
java whole-class gold spans, mixed-LSP footnote) in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)