### PR TITLE
fix(cli): align help text with behavior, split short/long help

### DIFF
--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -22,6 +22,8 @@ pub const LONG_VERSION: &str = concat!(
 #[command(about = "Map your codebase. Navigate by graph, not grep.")]
 #[command(version)]
 #[command(long_version = LONG_VERSION)]
+#[command(propagate_version = true)]
+#[command(after_help = "Docs: https://jrollin.github.io/cartog/")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
@@ -34,8 +36,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub tokens: Option<u32>,
 
-    /// Path to the cartog database (overrides .cartog.toml and auto-detection).
-    /// Can also be set via the CARTOG_DB environment variable.
+    /// Path to the cartog database (overrides .cartog.toml and auto-detection)
     #[arg(long, global = true, value_name = "PATH", env = "CARTOG_DB")]
     pub db: Option<PathBuf>,
 }
@@ -208,9 +209,10 @@ pub enum Command {
         /// Class name
         name: String,
 
-        /// Render the hierarchy as a Mermaid `graph TD` diagram instead of
-        /// plain text. Paste the output into any Mermaid renderer (GitHub,
-        /// mermaid.live, ...). Ignored when `--json` is also set.
+        /// Render the hierarchy as a Mermaid `graph TD` diagram instead of plain text
+        ///
+        /// Paste the output into any Mermaid renderer (GitHub, mermaid.live, ...).
+        /// Ignored when `--json` is also set.
         #[arg(long)]
         mermaid: bool,
     },
@@ -220,15 +222,17 @@ pub enum Command {
         /// File path
         file: String,
 
-        /// Render the imports as a Mermaid `graph LR` diagram instead of
-        /// plain text. Ignored when `--json` is also set.
+        /// Render the imports as a Mermaid `graph LR` diagram instead of plain text
+        ///
+        /// Ignored when `--json` is also set.
         #[arg(long)]
         mermaid: bool,
     },
 
     /// Index statistics summary
     Stats {
-        /// Show per-tool query counts and estimated tokens saved vs grep+read.
+        /// Show per-tool query counts and estimated tokens saved vs grep+read
+        ///
         /// Reads the local query log; no network calls.
         #[arg(long)]
         savings: bool,
@@ -236,8 +240,8 @@ pub enum Command {
 
     /// Per-tool query counts + estimated tokens saved.
     ///
-    /// Alias for `cartog stats --savings`. Shipped as a top-level verb because
-    /// it's the retention hook — surfaces ongoing ROI in one keystroke.
+    /// Alias for `cartog stats --savings`, promoted to a top-level verb so
+    /// day-to-day savings are one keystroke away.
     Savings,
 
     /// Upload the local index to an S3-compatible remote (opt-in feature).
@@ -289,27 +293,27 @@ pub enum Command {
         #[arg(long)]
         file: Option<String>,
 
-        /// Maximum results to return (default: 30, max: 100)
+        /// Maximum results to return (capped at 100)
         #[arg(long, default_value = "30")]
         limit: u32,
     },
 
     /// Token-budget-aware codebase summary (file tree + top symbols by centrality)
     Map {
-        /// Approximate token budget for the output (default: 4000)
+        /// Approximate token budget for the output
         #[arg(long, default_value = "4000")]
         tokens: u32,
 
-        /// Render the file tree as a Mermaid `graph TD` diagram instead of
-        /// indented text. Token budget still applies. Ignored when `--json`
-        /// is also set.
+        /// Render the file tree as a Mermaid `graph TD` diagram instead of indented text
+        ///
+        /// Token budget still applies. Ignored when `--json` is also set.
         #[arg(long)]
         mermaid: bool,
     },
 
     /// Show symbols affected by recent git changes
     Changes {
-        /// Number of recent commits to consider (default: 5)
+        /// Number of recent commits to consider
         #[arg(long, default_value = "5")]
         commits: u32,
 
@@ -328,7 +332,11 @@ pub enum Command {
         #[arg(long, default_value = "5")]
         debounce: u64,
 
-        /// Enable automatic RAG embedding after index
+        /// Turn on RAG embedding when auto-detection would leave it off
+        ///
+        /// Default is automatic: on when the repo already has embeddings.
+        /// `[embedding] auto_embed` (config) and CARTOG_WATCH_RAG (env) take
+        /// precedence over this flag.
         #[arg(long)]
         rag: bool,
 
@@ -350,9 +358,8 @@ pub enum Command {
 
     /// Wire `cartog serve` into one or all MCP-compatible editors.
     ///
-    /// Supports Claude Code, Claude Desktop, Cursor, VS Code, Codex CLI, Gemini CLI,
-    /// OpenCode, Windsurf, Zed. User-scope clients whose config directory does not
-    /// exist are skipped (not installed).
+    /// See `--client` for the supported editors. User-scope clients whose
+    /// config directory does not exist are skipped (not installed).
     ///
     /// See also `cartog install <client>...` for a positional shorthand that
     /// matches the brew/npm/pip convention.
@@ -361,12 +368,16 @@ pub enum Command {
         #[arg(long, value_enum)]
         client: Option<ClientKind>,
 
-        /// Filter by scope. `project` writes only .mcp.json / .cursor/mcp.json; `user`
-        /// writes only user-scope configs; `all` writes both.
+        /// Filter by scope
+        ///
+        /// `project` writes only .mcp.json / .cursor/mcp.json; `user` writes
+        /// only user-scope configs; `all` writes both.
         #[arg(long, value_enum, default_value_t = IdeScope::All)]
         scope: IdeScope,
 
-        /// Accept all prompts (non-interactive). Implied by --dry-run, --json, --client, or a non-TTY stdin.
+        /// Accept all prompts (non-interactive)
+        ///
+        /// Implied by --dry-run, --json, --client, or a non-TTY stdin.
         #[arg(long, short = 'y')]
         yes: bool,
 
@@ -389,12 +400,15 @@ pub enum Command {
     /// Positional mode is always non-interactive (`--yes` implied). For the
     /// interactive picker, use `cartog ide` directly.
     Install {
-        /// One or more editors to wire up. Omit to install into every
-        /// detected editor non-interactively. Repeatable.
+        /// One or more editors to wire up
+        ///
+        /// Omit to install into every detected editor non-interactively.
         clients: Vec<ClientKind>,
 
-        /// Filter by scope. `project` writes only .mcp.json / .cursor/mcp.json;
-        /// `user` writes only user-scope configs; `all` writes both.
+        /// Filter by scope
+        ///
+        /// `project` writes only .mcp.json / .cursor/mcp.json; `user` writes
+        /// only user-scope configs; `all` writes both.
         #[arg(long, value_enum, default_value_t = IdeScope::All)]
         scope: IdeScope,
 
@@ -413,7 +427,12 @@ pub enum Command {
         #[arg(long)]
         watch: bool,
 
-        /// Enable automatic RAG embedding when watching
+        /// Turn on RAG embedding when auto-detection would leave it off
+        ///
+        /// Default is automatic: on when the repo already has embeddings.
+        /// `[embedding] auto_embed` (config) and CARTOG_WATCH_RAG (env) take
+        /// precedence over this flag. Only meaningful with `--watch` (warns
+        /// otherwise).
         #[arg(long)]
         rag: bool,
     },
@@ -436,9 +455,7 @@ pub enum Command {
 
     /// Emit a troff-formatted manpage for `cartog` on stdout.
     ///
-    /// Example:
-    ///   cartog manpage > cartog.1
-    ///   man ./cartog.1
+    /// Example: `cartog manpage > cartog.1 && man ./cartog.1`
     Manpage,
 }
 
@@ -477,30 +494,37 @@ pub enum RagCommand {
 pub enum SelfCommand {
     /// Upgrade cartog in place (or check, defer, or apply a deferred update)
     Update {
-        /// Report whether an update is available without modifying anything.
+        /// Report whether an update is available without modifying anything
+        ///
         /// Exit codes: 0 up to date, 1 update available, 2 network/parse error.
         #[arg(long, conflicts_with_all = ["defer", "apply_pending"])]
         check: bool,
 
-        /// Arm a deferred update: record the target version in the state file
-        /// and exit WITHOUT swapping the binary. Succeeds even while a peer
-        /// `cartog serve`/`watch` is running — the swap happens later via
-        /// `--apply-pending` once the peer has exited. This is the right call
-        /// from inside a Claude Code session, where the MCP server is the peer.
-        /// Targets the latest stable release unless `--to` pins a version.
+        /// Arm a deferred update without swapping the binary
+        ///
+        /// Records the target version in the state file and exits. Succeeds
+        /// even while a peer `cartog serve`/`watch` is running — the swap
+        /// happens later via `--apply-pending` once the peer has exited. This
+        /// is the right call from inside a Claude Code session, where the MCP
+        /// server is the peer. Targets the latest stable release unless `--to`
+        /// pins a version.
         #[arg(long, conflicts_with_all = ["check", "apply_pending"])]
         defer: bool,
 
-        /// With `--defer`, arm exactly this `MAJOR.MINOR.PATCH` version instead
-        /// of resolving the latest stable release. Used by `/cartog-install` to
-        /// arm the plugin's pinned version. Requires `--defer`.
+        /// With `--defer`, arm exactly this `MAJOR.MINOR.PATCH` version
+        ///
+        /// Overrides resolving the latest stable release. Used by
+        /// `/cartog-install` to arm the plugin's pinned version. Requires
+        /// `--defer`.
         #[arg(long, value_name = "VERSION", requires = "defer")]
         to: Option<String>,
 
-        /// Apply a previously-armed deferred update (see `--defer`). Reads the
-        /// pending target from the state file, waits briefly for any peer lock
-        /// to clear, performs the swap, and clears the pending intent. Intended
-        /// to run from the SessionEnd hook once the serve process has exited.
+        /// Apply a previously-armed deferred update (see `--defer`)
+        ///
+        /// Reads the pending target from the state file, waits briefly for any
+        /// peer lock to clear, performs the swap, and clears the pending
+        /// intent. Intended to run from the SessionEnd hook once the serve
+        /// process has exited.
         #[arg(long, conflicts_with_all = ["check", "defer"])]
         apply_pending: bool,
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -466,7 +466,7 @@ comments and ordering in the rest of the file.
 | `--scope project\|user\|all` | Limit to project-scoped files, user-scoped files, or both (default `all`). |
 | `-y`, `--yes` | Skip interactive prompts. Also implied by `--dry-run`, `--client`, `--json`, or a non-TTY stdin. |
 | `--dry-run` | Print the planned changes (before/after diff per file) without writing. Implies non-interactive. |
-| `--no-watch` | Drop `--watch` from Claude Code's serve args. Other clients register plain `["serve"]` regardless. |
+| `--no-watch` | Drop `--watch` from every client's serve args (default wires `serve --watch` for all). |
 | `--json` (global) | Emit a structured `IdeReport` on stdout instead of human text. |
 
 #### Troubleshooting
@@ -806,8 +806,8 @@ On an unindexed repo all counts are `0` and the output ends with
 
 Per-tool query counts + an estimated tokens-saved figure versus a grep+read
 baseline (~1,420 tokens/query, drawn from the benchmark suite). Visible alias
-of `cartog stats --savings`; shipped as a top-level verb because it's the
-retention hook — surfaces ongoing ROI in one keystroke.
+of `cartog stats --savings`, promoted to a top-level verb so day-to-day
+savings are one keystroke away.
 
 ```bash
 cartog savings


### PR DESCRIPTION
Audit of all 26 commands + `rag`/`self` subcommands: rendered `-h`/`--help` compared against actual behavior and clap/clig.dev conventions.

## Accuracy fixes

- **`watch --rag` / `serve --rag` hid the auto-default.** Help implied embedding is off without the flag; actually it auto-enables when the repo already has embeddings, and `[embedding] auto_embed` / `CARTOG_WATCH_RAG` take precedence over the flag (docs had this right; the help was the outlier).
- **`ide` long help listed 9 clients; cartog supports 12** (Antigravity, Hermes, Kiro were missing). Dropped the prose list — clap's `[possible values]` is always current.
- **`docs/usage.md` `--no-watch` row was stale**: claimed Claude-Code-only; it strips `--watch` for every client since the single-writer change.

## Rendering & convention fixes

- **Short/long help split** (blank-line separator) so `-h` is one scannable line per flag — `--defer` was a 60-word wall; same for `--apply-pending`, `--mermaid` ×3, `--savings`, ide/install flags.
- **`manpage --help` example was mangled** by doc-comment line joining into `cartog manpage > cartog.1 man ./cartog.1`; now a single valid command.
- Dropped "(default: N)" text duplicating clap's auto `[default: N]` (map, changes, search); kept search's "capped at 100" — verified enforced in queries.rs.
- Dropped the `--db` sentence duplicating the auto `[env: CARTOG_DB=]` annotation.
- `propagate_version`: `cartog <cmd> --version` now works instead of erroring.
- `after_help` footer linking https://jrollin.github.io/cartog/ per clig.dev ("help should point to more help").
- `savings` long help: maintainer jargon ("retention hook — ongoing ROI") reworded for users; synced the mirrored sentence in usage.md.

No behavior changes beyond `propagate_version`. Manpage and completions regenerate from clap automatically. Site untouched (it never quoted flag-level help). skills/ untouched (no help quotes; avoids the eval-skill gate).

Gate: fmt + clippy clean, cartog crate tests 41 pass, rendered help eyeballed for every changed command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined CLI help text and usage documentation across multiple commands for improved clarity.
  * Enhanced documentation for `cartog ide` `--no-watch` flag behavior.
  * Clarified descriptions for various subcommands and their options.

* **Chores**
  * Enabled version propagation from main CLI to subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->