### PR TITLE
perf(db): planner stats + heuristic-exhausted seal; scaling-regression bench (#110 deferrals)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ make eval-agents           # LLM-as-judge agent evaluation (requires claude CLI)
 make bench                 # shell benchmark suite (13 scenarios x 10 languages)
 make bench-resolution      # edge-resolution rate (heuristic + host LSP, all languages; saves a provenance snapshot)
 make bench-resolution-docker # same, LSP servers via Docker images (all 10, strict — no host fallback); `make lsp-images` builds them
+make bench-resolution-scale # synthetic N-vs-2N repo, asserts index time stays near-linear (quadratic-regression guard, cf. #110)
 make bench-criterion       # ONNX-free criterion benches (queries, per-language indexing, hybrid search)
 make bench-onnx            # real-model embed/rerank benches (needs `cartog rag setup`; not in CI)
 make bench-rag             # RAG relevancy benchmarks (in-memory + shell scenario 13)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check check-rust check-fixtures check-fixtures-docker check-skill check-py check-ts check-go check-rs check-rb check-java check-php check-dart check-swift check-kt check-install-script sync-install-script tla loom bench bench-resolution bench-resolution-docker lsp-images bench-criterion bench-rag bench-onnx bench-agent eval-skill eval-agents
+.PHONY: check check-rust check-fixtures check-fixtures-docker check-skill check-py check-ts check-go check-rs check-rb check-java check-php check-dart check-swift check-kt check-install-script sync-install-script tla loom bench bench-resolution bench-resolution-docker bench-resolution-scale lsp-images bench-criterion bench-rag bench-onnx bench-agent eval-skill eval-agents
 
 # --- Full integrity check ---
 
@@ -190,6 +190,10 @@ bench-resolution: ## Run edge-resolution rate (heuristic + host LSP, all languag
 bench-resolution-docker: ## Run edge-resolution rate with Docker LSP servers (run `make lsp-images` first; errors on a missing image, no host fallback)
 	cargo build --release
 	CARTOG=$(CURDIR)/target/release/cartog ./benchmarks/resolution_rate.sh --lsp --docker-lsp
+
+bench-resolution-scale: ## Catch super-linear resolution regressions (synthetic N vs 2N repo, asserts time ratio; cf. #110)
+	cargo build --release
+	CARTOG=$(CURDIR)/target/release/cartog ./benchmarks/resolution_scale.sh
 
 lsp-images: ## Build all per-language Docker LSP images (cartog-lsp-<lang>:stable) from benchmarks/lsp-images/
 	@for df in benchmarks/lsp-images/*.Dockerfile; do \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,6 +10,7 @@ One row per entry point — if you're lost, start here:
 |---------|---------------------|----------|
 | **Shell suite** (this file) | Is a single cartog query smaller / more complete than grep? | `make bench` |
 | **Edge resolution** | What share of edges resolve, per language? (heuristic / host LSP / strict Docker LSP) | `make bench-resolution`, `make bench-resolution-docker` |
+| **Resolution scaling** | Does resolution stay near-linear as the repo grows? (catches quadratic regressions, cf. #110) | `make bench-resolution-scale` |
 | **Criterion micro-benchmarks** | How fast is cartog's own CPU work (µs–ms)? | `make bench-criterion` |
 | **ONNX model benches** | How fast are the real embed/rerank models? | `make bench-onnx` |
 | **RAG relevancy** | Does hybrid search rank the relevant symbols on top? | `make bench-rag` |
@@ -126,6 +127,34 @@ edges). Re-run after extractor or resolver changes.
 ./benchmarks/resolution_rate.sh --fixture rs    # one language
 ./benchmarks/resolution_rate.sh --baseline      # diff vs last snapshot (no overwrite)
 ```
+
+## Resolution scaling (quadratic-regression guard)
+
+The rate fixtures are ~50 files each, so a *time-complexity* regression hides in
+them — the tier-2 quadratic fixed in #110 only diverged at transformers scale.
+`resolution_scale.sh` is the time-axis complement: it generates a synthetic
+Python repo with heavy cross-file imports (so most edges resolve via tier-2, the
+#110 hot path) at sizes N and 2N, times `cartog index --no-lsp --force` for each,
+and asserts `time(2N)/time(N)` stays under a near-linear threshold. Linear
+resolution doubles (~2x); quadratic quadruples (~4x). Self-calibrating — no
+committed baseline, so it is machine-independent. Exit 1 on regression.
+
+```bash
+make bench-resolution-scale                      # default N=1000
+N=2000 ./benchmarks/resolution_scale.sh          # larger N → clearer signal, slower
+RATIO_MAX=2.5 ./benchmarks/resolution_scale.sh   # stricter threshold
+```
+
+Opt-in (not in `make check`): the large run is seconds-to-minutes depending on N.
+
+> **Known finding (0.26.0):** this bench currently *fails* at the default N=1000 —
+> resolution is still ~O(edges²) after #110 (which only fixed tier-2's query
+> plan). Measured curve (flat synthetic repo): 16k→0.48s, 32k→1.45s, 64k→5.17s,
+> 128k→19.8s (time ~4× per 2× edges). Reproduced on a realistic nested-package
+> shape too, so it is not a generator artifact. The remaining cost is in the
+> per-edge resolve loop / 2-pass structure, not a single mis-planned query. A red
+> run is expected until that open lead is fixed; the bench then guards against
+> *further* regression.
 
 ## Reproducing the numbers
 

--- a/benchmarks/resolution_scale.sh
+++ b/benchmarks/resolution_scale.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# cartog Edge-Resolution Scaling Regression Benchmark
+#
+# Catches super-linear (e.g. quadratic) regressions in edge resolution — the
+# class of bug fixed in #110, where tier-2 import-path resolution was O(unresolved
+# × import-edges) and invisible on the ~50-file rate fixtures, only diverging at
+# transformers scale (376k edges, ~38 min).
+#
+# Strategy (self-calibrating, no committed baseline):
+#   1. Generate a synthetic Python repo with heavy CROSS-FILE imports + calls,
+#      so most edges resolve via tier-2 (import-path) — the #110 hot path.
+#   2. Time `cartog index --no-lsp --force` at sizes N and 2N.
+#   3. Assert time(2N) / time(N) stays under a near-linear threshold. Linear
+#      resolution doubles the time (~2x); quadratic quadruples it (~4x). A
+#      threshold of 3x flags the regression while tolerating fixed per-run
+#      overhead (process start, walk, parse) that inflates the small-N ratio.
+#
+# Heuristic-only (--no-lsp): deterministic, server-independent, and the path the
+# #110 quadratic lived on. Generated repos go in a temp dir (never committed).
+#
+# KNOWN FINDING (as of 0.26.0): this bench FAILS at the default N=1000 — resolution
+# is still super-linear (~O(edges^2)) even after #110, which only fixed tier-2's
+# query *plan*. The remaining cost is in the per-edge resolve loop / 2-pass
+# structure (profile: sqlite3VdbeFinishMoveto btree seeks dominate), not in any
+# single mis-planned query. A red run today is expected and reproduces the open
+# lead; once that is fixed the bench should go green and then guards regressions.
+#
+# Usage:
+#   ./benchmarks/resolution_scale.sh                 # default N (see below)
+#   N=2000 ./benchmarks/resolution_scale.sh          # larger N (slower, clearer signal)
+#   RATIO_MAX=3.0 ./benchmarks/resolution_scale.sh   # tune the fail threshold
+#   CARTOG=target/release/cartog ./benchmarks/resolution_scale.sh
+#
+# Exit codes: 0 = within threshold, 1 = regression (ratio exceeded), 2 = usage/setup.
+
+set -euo pipefail
+export LC_NUMERIC=C
+
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$BENCH_DIR")"
+
+# N = files in the small run; the large run is 2N. Each file imports from and
+# calls into SYMS_PER_FILE symbols spread across a few sibling files, so edge
+# count grows ~linearly with file count and resolution stays in tier-2.
+N="${N:-1000}"
+SYMS_PER_FILE="${SYMS_PER_FILE:-8}"
+RATIO_MAX="${RATIO_MAX:-3.0}"
+
+# ── Resolve binary (prefer explicit CARTOG, then release, then debug) ──
+CARTOG="${CARTOG:-}"
+if [ -z "$CARTOG" ]; then
+  if [ -x "$REPO_DIR/target/release/cartog" ]; then
+    CARTOG="$REPO_DIR/target/release/cartog"
+  elif [ -x "$REPO_DIR/target/debug/cartog" ]; then
+    CARTOG="$REPO_DIR/target/debug/cartog"
+  else
+    echo "No cartog binary found. Run: cargo build --release" >&2
+    exit 2
+  fi
+fi
+case "$CARTOG" in
+  /*) ;;
+  */*) CARTOG="$(cd "$(dirname "$CARTOG")" && pwd)/$(basename "$CARTOG")" ;;
+esac
+echo "binary:  $CARTOG" >&2
+echo "version: $("$CARTOG" --version 2>/dev/null | head -1)" >&2
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Generate a synthetic repo of `count` Python files under `dir` ──
+# File i defines SYMS_PER_FILE functions and imports + calls functions from the
+# next 3 files (mod_{i+1..i+3}), forcing cross-file (tier-2) resolution. The
+# wrap-around modulo keeps every import target in-repo so edges resolve.
+gen_repo() {
+  local dir="$1" count="$2"
+  mkdir -p "$dir"
+  python3 - "$dir" "$count" "$SYMS_PER_FILE" <<'PY'
+import os, sys
+dir, count, spf = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+for i in range(count):
+    lines = []
+    # Import a few functions from sibling modules (cross-file → tier-2).
+    for d in (1, 2, 3):
+        j = (i + d) % count
+        names = ", ".join(f"fn_{j}_{k}" for k in range(spf))
+        lines.append(f"from mod_{j} import {names}")
+    lines.append("")
+    # Define this module's functions, each calling an imported one.
+    for k in range(spf):
+        callee = f"fn_{(i + 1) % count}_{k}"
+        lines.append(f"def fn_{i}_{k}(x):")
+        lines.append(f"    return {callee}(x) + {k}")
+        lines.append("")
+    with open(os.path.join(dir, f"mod_{i}.py"), "w") as f:
+        f.write("\n".join(lines))
+PY
+}
+
+# ── Time one `cartog index --no-lsp --force` over `dir`; echoes seconds ──
+# Uses python3 for monotonic, sub-second timing (portable; `date +%s.%N` is not
+# on macOS). Resolution stats are printed to stderr for context.
+time_index() {
+  local dir="$1"
+  local db
+  db="$WORK/$(basename "$dir").sqlite"
+  rm -f "$db"
+  python3 - "$CARTOG" "$dir" "$db" <<'PY'
+import subprocess, sys, time
+cartog, dir, db = sys.argv[1], sys.argv[2], sys.argv[3]
+t0 = time.monotonic()
+r = subprocess.run([cartog, "index", "--no-lsp", "--force", dir],
+                   env={"CARTOG_DB": db, "PATH": __import__("os").environ["PATH"]},
+                   stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+dt = time.monotonic() - t0
+if r.returncode != 0:
+    sys.stderr.write(r.stderr.decode(errors="replace"))
+    sys.stderr.write(f"\nindex failed for {dir}\n")
+    sys.exit(1)
+print(f"{dt:.4f}")
+PY
+}
+
+echo "generating synthetic repos (N=$N, 2N=$((N * 2)), syms/file=$SYMS_PER_FILE)..." >&2
+gen_repo "$WORK/small" "$N"
+gen_repo "$WORK/large" "$((N * 2))"
+
+echo "timing index of N=$N files..." >&2
+T_SMALL="$(time_index "$WORK/small")"
+echo "timing index of 2N=$((N * 2)) files..." >&2
+T_LARGE="$(time_index "$WORK/large")"
+
+# ── Verdict (Python for float math + clean formatting) ──
+T_SMALL="$T_SMALL" T_LARGE="$T_LARGE" N="$N" RATIO_MAX="$RATIO_MAX" python3 - <<'PY'
+import os, sys
+ts, tl = float(os.environ["T_SMALL"]), float(os.environ["T_LARGE"])
+n, ratio_max = int(os.environ["N"]), float(os.environ["RATIO_MAX"])
+ratio = (tl / ts) if ts > 0 else float("inf")
+print()
+print(f"{'size':<10}{'files':>8}{'index time (s)':>18}")
+print("-" * 36)
+print(f"{'N':<10}{n:>8}{ts:>18.3f}")
+print(f"{'2N':<10}{n * 2:>8}{tl:>18.3f}")
+print("-" * 36)
+print(f"time(2N)/time(N) = {ratio:.2f}  (linear ~2.0, quadratic ~4.0, threshold {ratio_max})")
+print()
+if ratio > ratio_max:
+    print(f"REGRESSION: scaling ratio {ratio:.2f} exceeds {ratio_max} — "
+          f"resolution looks super-linear (cf. #110).", file=sys.stderr)
+    sys.exit(1)
+print(f"OK: scaling ratio {ratio:.2f} within {ratio_max} (near-linear).")
+PY

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -1169,6 +1169,36 @@ mod tests {
     }
 
     #[test]
+    fn test_optimize_populates_planner_stats() {
+        // PRAGMA optimize must build sqlite_stat1 once the tables are large
+        // enough to be worth analyzing — proving the planner has real stats to
+        // pick join order from (the #110 misplan was a no-stats guess).
+        let db = Database::open_memory().unwrap();
+        let syms: Vec<_> = (0..2000)
+            .map(|i| test_symbol(&format!("f{i}"), SymbolKind::Function, "a.py", i + 1))
+            .collect();
+        db.insert_symbols(&syms).unwrap();
+
+        db.optimize().unwrap();
+
+        let analyzed: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = 'sqlite_stat1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(analyzed, 1, "PRAGMA optimize must create sqlite_stat1");
+    }
+
+    #[test]
+    fn test_optimize_is_safe_on_empty_db() {
+        let db = Database::open_memory().unwrap();
+        db.optimize().unwrap(); // no-op, must not error
+    }
+
+    #[test]
     fn is_empty_reflects_symbol_presence() {
         let db = Database::open_memory().unwrap();
         assert!(db.is_empty().unwrap(), "fresh DB should be empty");
@@ -4538,6 +4568,104 @@ mod tests {
         assert_eq!(reopened, 1);
         assert_eq!(resolution_state_of(&db, ext_foo), 0);
         assert_eq!(resolution_state_of(&db, ext_bar), 3);
+    }
+
+    // ── state=4 (heuristic-exhausted) tests ──
+
+    #[test]
+    fn test_mark_heuristic_exhausted_seals_unresolved_state_zero() {
+        // Edges the heuristic couldn't resolve (state=0, target NULL) flip to
+        // state=4 so the next re-index's resolution scan skips them.
+        let db = Database::open_memory().unwrap();
+        let unresolved = insert_test_edge(&db, "nowhere");
+        let resolved = insert_test_edge(&db, "somewhere");
+        db.update_edge_target(resolved, "some:id").unwrap();
+
+        let marked = db.mark_heuristic_exhausted_in_tx().unwrap();
+        assert_eq!(marked, 1);
+        assert_eq!(resolution_state_of(&db, unresolved), 4);
+        assert_eq!(resolution_state_of(&db, resolved), 1, "resolved untouched");
+    }
+
+    #[test]
+    fn test_resolve_edges_skips_heuristic_exhausted_state_four() {
+        // The state=0-only scan in resolve_edges_pass must not re-walk sealed
+        // state=4 edges — this is the watch-mode amplification guard (#109).
+        let db = Database::open_memory().unwrap();
+        let eid = insert_test_edge(&db, "nowhere");
+        db.mark_heuristic_exhausted_in_tx().unwrap();
+        assert_eq!(resolution_state_of(&db, eid), 4);
+
+        // A fresh resolve pass finds nothing to do and leaves the seal intact.
+        let resolved = db.resolve_edges().unwrap();
+        assert_eq!(resolved, 0);
+        assert_eq!(resolution_state_of(&db, eid), 4);
+    }
+
+    #[test]
+    fn test_unresolved_edges_excludes_state_four() {
+        // The LSP retry loop must skip state=4 too, same as {2, 3}. The blanket
+        // mark seals every open edge, so insert the still-open one afterward.
+        let db = Database::open_memory().unwrap();
+        let exhausted = insert_test_edge(&db, "exhausted");
+        db.mark_heuristic_exhausted_in_tx().unwrap();
+        let _open = insert_test_edge(&db, "still_open");
+
+        let edges = db.unresolved_edges().unwrap();
+        let names: Vec<&str> = edges.iter().map(|e| e.target_name.as_str()).collect();
+        assert!(names.contains(&"still_open"));
+        assert!(!names.contains(&"exhausted"));
+        let _ = exhausted;
+    }
+
+    #[test]
+    fn test_reopen_heuristic_exhausted_resets_only_state_four() {
+        // Before an LSP-enabled reindex, state=4 → 0, but genuine LSP verdicts
+        // (state {2, 3}) stay sealed.
+        let db = Database::open_memory().unwrap();
+        let exhausted = insert_test_edge(&db, "exhausted");
+        db.mark_heuristic_exhausted_in_tx().unwrap();
+        let burned = insert_test_edge(&db, "burned");
+        db.mark_edge_unresolvable(burned).unwrap();
+        let external = insert_test_edge(&db, "external");
+        db.mark_edge_external(external).unwrap();
+
+        let reopened = db.reopen_heuristic_exhausted().unwrap();
+        assert_eq!(reopened, 1);
+        assert_eq!(resolution_state_of(&db, exhausted), 0);
+        assert_eq!(resolution_state_of(&db, burned), 2, "LSP verdict sealed");
+        assert_eq!(resolution_state_of(&db, external), 3, "LSP verdict sealed");
+    }
+
+    #[test]
+    fn test_reset_all_unresolvable_also_resets_state_four() {
+        // --force must clear state=4 alongside {2, 3}.
+        let db = Database::open_memory().unwrap();
+        let exhausted = insert_test_edge(&db, "exhausted");
+        db.mark_heuristic_exhausted_in_tx().unwrap();
+        let burned = insert_test_edge(&db, "burned");
+        db.mark_edge_unresolvable(burned).unwrap();
+
+        let reset = db.reset_all_unresolvable().unwrap();
+        assert_eq!(reset, 2);
+        assert_eq!(resolution_state_of(&db, exhausted), 0);
+        assert_eq!(resolution_state_of(&db, burned), 0);
+    }
+
+    #[test]
+    fn test_reset_unresolvable_for_names_reopens_state_four() {
+        // A heuristic-exhausted edge reopens when a matching symbol is added.
+        let db = Database::open_memory().unwrap();
+        let foo = insert_test_edge(&db, "foo");
+        let bar = insert_test_edge(&db, "bar");
+        db.mark_heuristic_exhausted_in_tx().unwrap();
+
+        let reopened = db
+            .reset_unresolvable_for_names(&["foo".to_string()])
+            .unwrap();
+        assert_eq!(reopened, 1);
+        assert_eq!(resolution_state_of(&db, foo), 0);
+        assert_eq!(resolution_state_of(&db, bar), 4);
     }
 
     #[test]

--- a/crates/cartog-db/src/store/lifecycle.rs
+++ b/crates/cartog-db/src/store/lifecycle.rs
@@ -266,4 +266,24 @@ impl Database {
     pub fn begin_indexing_tx(&self) -> Result<rusqlite::Transaction<'_>> {
         Ok(self.conn.unchecked_transaction()?)
     }
+
+    /// Refresh the query planner's statistics via `PRAGMA optimize`.
+    ///
+    /// SQLite picks join order and index use from `sqlite_stat1`; without it,
+    /// the planner guesses from index shape alone and can mis-plan (the tier-2
+    /// resolution misplan in #110 was one such case). `PRAGMA optimize` runs
+    /// `ANALYZE` only on tables whose row counts have drifted since the last
+    /// analyze, so it is a cheap no-op when nothing changed — unlike a bare
+    /// `ANALYZE`, which would re-scan every index on each call and reintroduce
+    /// a per-index O(repo) cost.
+    ///
+    /// Call AFTER committing the indexing transaction, not inside it: a stats
+    /// rebuild bundled into the big write tx would bloat it. No-op-safe to call
+    /// when nothing was indexed, but the indexer skips it on no-op runs anyway.
+    pub fn optimize(&self) -> Result<()> {
+        self.conn
+            .execute_batch("PRAGMA optimize;")
+            .context("PRAGMA optimize (refresh planner statistics)")?;
+        Ok(())
+    }
 }

--- a/crates/cartog-db/src/store/lsp.rs
+++ b/crates/cartog-db/src/store/lsp.rs
@@ -18,14 +18,16 @@ impl Database {
 
     /// Return edges still waiting for resolution (`resolution_state = 0`).
     ///
-    /// Edges marked `state = 2` (unresolvable) or `state = 3` (external) are
-    /// excluded so a dirty reindex doesn't re-query the language server for
-    /// edges it already classified. Both are sticky and re-enter the
-    /// unresolved set only via [`Self::reset_unresolvable_for_names`] when a
-    /// matching symbol is added, or [`Self::reset_all_unresolvable`] on
-    /// `--force`. ([`Self::invalidate_edges_targeting`] only touches state=1
-    /// rows because it filters on `target_id IS NOT NULL`, and state {2, 3}
-    /// rows always have `target_id NULL`.)
+    /// Edges marked `state = 2` (unresolvable), `state = 3` (external), or
+    /// `state = 4` (heuristic-exhausted) are excluded so a dirty reindex
+    /// doesn't re-query the language server for edges it already classified.
+    /// All three are sticky and re-enter the unresolved set only via
+    /// [`Self::reset_unresolvable_for_names`] when a matching symbol is added,
+    /// [`Self::reset_all_unresolvable`] on `--force`, or (state 4 only)
+    /// [`Self::reopen_heuristic_exhausted`] before an LSP-enabled reindex.
+    /// ([`Self::invalidate_edges_targeting`] only touches state=1 rows because
+    /// it filters on `target_id IS NOT NULL`, and state {2, 3, 4} rows always
+    /// have `target_id NULL`.)
     ///
     /// tx-safe: read-only single statement — see note above the section header.
     pub fn unresolved_edges(&self) -> Result<Vec<UnresolvedEdge>> {
@@ -93,7 +95,7 @@ impl Database {
 
     /// Test-only inspector: returns the raw `resolution_state` value for an edge.
     ///
-    /// 0=unresolved, 1=resolved, 2=unresolvable, 3=external.
+    /// 0=unresolved, 1=resolved, 2=unresolvable, 3=external, 4=heuristic-exhausted.
     pub fn edge_resolution_state(&self, edge_id: i64) -> Result<i64> {
         let state: i64 = self.conn.query_row(
             "SELECT resolution_state FROM edges WHERE id = ?1",
@@ -103,16 +105,36 @@ impl Database {
         Ok(state)
     }
 
-    /// Reset every edge at `resolution_state IN (2, 3)` back to `0`. Used by
+    /// Reset every edge at `resolution_state IN (2, 3, 4)` back to `0`. Used by
     /// `cartog index --force` to honor the "retry everything" contract:
     /// without this, the heuristic + LSP would still skip permanently-marked
-    /// edges (both unresolvable and external) even on a forced re-index.
+    /// edges (unresolvable, external, or heuristic-exhausted) even on a forced
+    /// re-index.
     ///
     /// tx-safe: single statement — see the LSP-section header note.
     pub fn reset_all_unresolvable(&self) -> Result<u32> {
         let n = self.conn.execute(
             "UPDATE edges SET resolution_state = 0, resolution_source = NULL
-             WHERE resolution_state IN (2, 3)",
+             WHERE resolution_state IN (2, 3, 4)",
+            [],
+        )?;
+        Ok(n as u32)
+    }
+
+    /// Reset `resolution_state` from `4` (heuristic-exhausted) → `0` so a
+    /// later LSP-enabled reindex retries them.
+    ///
+    /// State 4 is written by [`Self::mark_heuristic_exhausted_in_tx`] only in
+    /// LSP-disabled runs (`--no-lsp`, `watch`). When a subsequent `cartog
+    /// index` does run LSP, those edges have never seen the language server, so
+    /// the indexer reopens them here before the LSP pass. Distinct from
+    /// [`Self::reset_all_unresolvable`]: this leaves the genuine LSP verdicts
+    /// (state {2, 3}) sealed.
+    ///
+    /// tx-safe: single statement — see the LSP-section header note.
+    pub fn reopen_heuristic_exhausted(&self) -> Result<u32> {
+        let n = self.conn.execute(
+            "UPDATE edges SET resolution_state = 0 WHERE resolution_state = 4",
             [],
         )?;
         Ok(n as u32)
@@ -162,17 +184,17 @@ impl Database {
         Ok(())
     }
 
-    /// Reset `resolution_state` from {2, 3} → 0 for edges whose target_name is in `names`.
+    /// Reset `resolution_state` from {2, 3, 4} → 0 for edges whose target_name is in `names`.
     ///
-    /// Called from the indexer when new symbols are added: an edge that was
-    /// previously "unresolvable" (no symbol with this name existed) or
-    /// "external" (target lived outside the index — but the user just vendored
-    /// it in-tree) may now be resolvable against the freshly-added target.
-    /// Returns the number of edges reopened. No-op when `names` is empty.
+    /// Called from the indexer when new symbols are added: an edge previously
+    /// "unresolvable" (no symbol with this name), "external" (target outside
+    /// the index, now vendored in-tree), or "heuristic-exhausted" may now
+    /// resolve against the freshly-added target. Returns edges reopened; no-op
+    /// when `names` is empty.
     ///
     /// tx-safe: single statement. Names are batched to honor SQLite's default
-    /// 999-parameter limit; only rows at state 2 or 3 are touched so the write
-    /// set stays tiny even on a large rename.
+    /// 999-parameter limit; only rows at state {2, 3, 4} are touched so the
+    /// write set stays tiny even on a large rename.
     pub fn reset_unresolvable_for_names(&self, names: &[String]) -> Result<u32> {
         if names.is_empty() {
             return Ok(0);
@@ -184,7 +206,7 @@ impl Database {
             let sql = format!(
                 "UPDATE edges
                  SET resolution_state = 0, resolution_source = NULL
-                 WHERE resolution_state IN (2, 3)
+                 WHERE resolution_state IN (2, 3, 4)
                    AND target_name IN ({placeholders})"
             );
             let params: Vec<&dyn rusqlite::ToSql> =

--- a/crates/cartog-db/src/store/resolution.rs
+++ b/crates/cartog-db/src/store/resolution.rs
@@ -286,6 +286,34 @@ impl Database {
         self.resolve_edges_in_tx()
     }
 
+    /// Mark every still-unresolved edge as `resolution_state = 4`
+    /// (heuristic-exhausted, no LSP pass ran).
+    ///
+    /// Call ONLY at the end of an index run that did not (and will not) run the
+    /// LSP pass — i.e. `--no-lsp`, `cartog watch`, or a feature-`lsp`-off build.
+    /// In those runs the 6-tier heuristic is the only resolver, so a leftover
+    /// state=0 edge is permanently unresolvable until the symbol graph changes.
+    /// Without this marker every incremental re-index re-walks the whole
+    /// state=0 backlog (the watch-mode amplification from #109): the
+    /// `resolution_state = 0` scan in `resolve_edges_pass` grows with the
+    /// permanent-failure set, not just the dirty edges.
+    ///
+    /// State 4 is sticky like {2, 3} and re-enters the unresolved set the same
+    /// way: [`Self::reset_unresolvable_for_names`] when a matching symbol is
+    /// added, [`Self::reset_all_unresolvable`] on `--force`, or
+    /// [`Self::reopen_heuristic_exhausted`] before a later LSP-enabled reindex.
+    /// Returns the number of edges marked.
+    ///
+    /// tx-safe: single statement — see [`Self::begin_indexing_tx`].
+    pub fn mark_heuristic_exhausted_in_tx(&self) -> Result<u32> {
+        let n = self.conn.execute(
+            "UPDATE edges SET resolution_state = 4
+             WHERE target_id IS NULL AND resolution_state = 0",
+            [],
+        )?;
+        Ok(n as u32)
+    }
+
     /// Recompute in-degree centrality after an incremental re-index.
     ///
     /// Scoping the reset to dirty files cannot be correct: a symbol in an

--- a/crates/cartog-indexer/README.md
+++ b/crates/cartog-indexer/README.md
@@ -39,7 +39,7 @@ Edges are always fully re-inserted for dirty files (no edge-level diff).
 
 When the `lsp` feature is enabled, a second pass resolves edges that the heuristic resolver in `cartog-db` left unresolved, using real language servers via `cartog-lsp`. Skipped on no-op reindexes (no file added, modified, or removed) — the unresolved set is identical to the previous run. Use `--force` to retry resolution after toggling `--no-lsp` off.
 
-Edges that LSP classifies are persisted to `resolution_state` so future runs skip them: `2` (unresolvable — typo, dyn dispatch, macro expansion) and `3` (external — stdlib, deps, node_modules). When a new symbol is added whose name matches such an edge (e.g. the user vendors a dep in-tree), the indexer auto-resets the marker so the next pass retries — see `Database::reset_unresolvable_for_names`. `--force` resets all sticky markers (see `Database::reset_all_unresolvable`).
+Edges that LSP classifies are persisted to `resolution_state` so future runs skip them: `2` (unresolvable — typo, dyn dispatch, macro expansion) and `3` (external — stdlib, deps, node_modules). A no-lsp run (`--no-lsp`, `watch`) has no LSP pass to retry the heuristic's leftovers, so the indexer seals them at `4` (heuristic-exhausted) — without this every incremental re-index re-walks the whole permanent-failure backlog. When a new symbol is added whose name matches a sealed edge (e.g. the user vendors a dep in-tree), the indexer auto-resets the marker so the next pass retries — see `Database::reset_unresolvable_for_names`. A later LSP-enabled reindex reopens state `4` first (`Database::reopen_heuristic_exhausted`) so the language server gets a shot. `--force` resets all sticky markers (see `Database::reset_all_unresolvable`).
 
 ## Public API
 

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -737,17 +737,33 @@ pub fn index_directory(
     //
     // Skipped on no-op runs: unresolved set is identical to last run, so
     // re-querying the LSP repeats work. Use `--force` to retry.
+    let lsp_ran;
     #[cfg(feature = "lsp")]
-    if lsp && !dirty_files.is_empty() {
-        emit(ProgressUpdate::ResolvingLsp);
-        let stats = cartog_lsp::lsp_resolve_edges(db, &root, None, lsp_overrides)
-            .with_context(|| format!("resolving LSP edges for root {}", root.display()))?;
-        result.edges_lsp_resolved = stats.resolved;
-        result.edges_marked_unresolvable = stats.marked_unresolvable;
-        result.edges_marked_external = stats.marked_external;
+    {
+        lsp_ran = lsp && !dirty_files.is_empty();
+        if lsp_ran {
+            // Watch (lsp=false) may have sealed edges at state=4; give LSP a shot.
+            db.reopen_heuristic_exhausted()?;
+            emit(ProgressUpdate::ResolvingLsp);
+            let stats = cartog_lsp::lsp_resolve_edges(db, &root, None, lsp_overrides)
+                .with_context(|| format!("resolving LSP edges for root {}", root.display()))?;
+            result.edges_lsp_resolved = stats.resolved;
+            result.edges_marked_unresolvable = stats.marked_unresolvable;
+            result.edges_marked_external = stats.marked_external;
+        }
     }
     #[cfg(not(feature = "lsp"))]
-    let _ = (lsp, lsp_overrides); // suppress unused warnings when feature is off
+    {
+        lsp_ran = false;
+        let _ = (lsp, lsp_overrides); // suppress unused warnings when feature is off
+    }
+
+    // No LSP pass ran, so the heuristic was the only resolver: seal remaining
+    // state=0 edges at state=4 to keep the next re-index's resolution scan from
+    // re-walking the permanent-failure backlog (#109 watch amplification).
+    if !lsp_ran && !dirty_files.is_empty() {
+        db.mark_heuristic_exhausted_in_tx()?;
+    }
 
     // Store the current git commit as last indexed
     if let Some(commit) = git_head_commit(&root) {
@@ -759,7 +775,16 @@ pub fn index_directory(
     db.set_metadata("redact_secrets", &redact.enabled.to_string())?;
 
     result.dirty_files = dirty_files.len() as u32;
+    let did_work = !dirty_files.is_empty();
     tx.commit()?;
+
+    // Refresh planner stats after the write commits (not inside the tx). Skipped
+    // on no-op runs — nothing changed, so the stats can't have drifted. Guards
+    // the planner against misplans like the tier-2 quadratic in #110.
+    if did_work {
+        db.optimize()?;
+    }
+
     Ok(result)
 }
 
@@ -1552,6 +1577,45 @@ mod tests {
     }
 
     #[test]
+    fn no_lsp_index_seals_unresolved_edges_at_state_four() {
+        // Watch / --no-lsp runs (lsp=false) have no LSP pass to retry the
+        // heuristic's leftovers, so a state=0 edge would be re-walked on every
+        // re-index (#109 amplification). The indexer must seal it at state=4.
+        use cartog_db::Database;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap().join("project");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("a.py"), "def caller():\n    nowhere('x')\n").unwrap();
+
+        let db = Database::open_memory().unwrap();
+        index_directory(
+            &db,
+            &root,
+            false,
+            false, // lsp off — the only resolver is the heuristic
+            None,
+            None,
+            crate::RedactionConfig::disabled(),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+
+        // The unresolvable `nowhere` call is sealed, so it no longer surfaces
+        // to the unresolved set the next pass would scan.
+        let names: Vec<String> = db
+            .unresolved_edges()
+            .unwrap()
+            .into_iter()
+            .map(|e| e.target_name)
+            .collect();
+        assert!(
+            !names.contains(&"nowhere".to_string()),
+            "no-lsp index must seal the unresolvable edge at state=4, got {names:?}"
+        );
+    }
+
+    #[test]
     fn test_added_symbol_reopens_unresolvable_edges() {
         // Name-keyed reset: a new symbol whose name matches a state=2 edge
         // returns the edge to state=0 (or state=1 if the heuristic resolves it).
@@ -1582,6 +1646,9 @@ mod tests {
             r1
         );
 
+        // The no-lsp index seals leftovers at state=4; reopen so the rest of
+        // the test exercises the state=0 → marker lifecycle as before.
+        db.reopen_heuristic_exhausted().unwrap();
         let before = db.unresolved_edges().unwrap();
         let find_user = before
             .iter()
@@ -1816,6 +1883,9 @@ mod tests {
         )
         .unwrap();
 
+        // The no-lsp index seals leftovers at state=4; reopen so we can mark
+        // them {2, 3} and test that --force clears those sticky markers.
+        db.reopen_heuristic_exhausted().unwrap();
         let pre = db.unresolved_edges().unwrap();
         let find_x_id = pre
             .iter()
@@ -1842,14 +1912,19 @@ mod tests {
             &std::collections::HashMap::new(),
         )
         .unwrap();
+        // --force clears the sticky LSP markers (reset_all_unresolvable), then
+        // this no-lsp run re-seals the still-unresolvable edges at state=4 — a
+        // fresh heuristic-exhaustion verdict, not the inherited {2, 3} markers.
+        // Reopen state=4 to confirm both edges came back to the resolvable set.
+        db.reopen_heuristic_exhausted().unwrap();
         let post = db.unresolved_edges().unwrap();
         assert!(
             post.iter().any(|e| e.target_name == "find_x"),
-            "after --force, find_x must be back in unresolved_edges (state=0)"
+            "after --force, find_x must not stay at an inherited {{2, 3}} marker"
         );
         assert!(
             post.iter().any(|e| e.target_name == "find_ext"),
-            "after --force, find_ext must be back in unresolved_edges (state=0)"
+            "after --force, find_ext must not stay at an inherited {{2, 3}} marker"
         );
     }
 
@@ -1878,6 +1953,9 @@ mod tests {
         )
         .unwrap();
 
+        // The no-lsp index seals leftovers at state=4; reopen so we can mark
+        // the edge external and test the vendored-in-tree reopen path.
+        db.reopen_heuristic_exhausted().unwrap();
         let unresolved = db.unresolved_edges().unwrap();
         let edge_id = unresolved
             .iter()
@@ -1946,6 +2024,9 @@ mod tests {
         )
         .unwrap();
 
+        // The no-lsp index seals leftovers at state=4; reopen so we can mark
+        // them {2, 3} and test that a no-op reindex preserves those markers.
+        db.reopen_heuristic_exhausted().unwrap();
         let unresolved = db.unresolved_edges().unwrap();
         let burned = unresolved
             .iter()


### PR DESCRIPTION
Closes the three deferred follow-ups from #110.

## 1. `PRAGMA optimize` after indexing (deferral: "ANALYZE for planner stats")

SQLite picks join order from `sqlite_stat1`; without it the planner guesses from index shape alone and can mis-plan (the tier-2 misplan in #110 was one case). `Database::optimize()` runs `PRAGMA optimize` — `ANALYZE` only on tables whose row counts drifted, so it is a cheap no-op when nothing changed (unlike a bare `ANALYZE`, which would re-scan every index each run and reintroduce a per-index O(repo) cost).

- Called **after** `tx.commit()` (not inside the write tx) and skipped on no-op runs.
- Profiled at **1 ms** on a 128k-edge DB.

## 2. `resolution_state = 4` — heuristic-exhausted seal (deferral: "mark heuristic-failed edges")

No-lsp runs (`--no-lsp`, `watch`) have no LSP pass to retry the heuristic's leftovers, so a state-0 edge was re-walked DB-wide on every incremental re-index (the #109 watch amplification). Sealing it at state-4 keeps it out of the resolution scan and the LSP retry set.

- Sticky like {2,3}: reopened by `reset_unresolvable_for_names` (matching new symbol), `reset_all_unresolvable` (`--force`), or `reopen_heuristic_exhausted` before a later LSP-enabled reindex.
- **No schema migration** — new value in an existing INTEGER column.

## 3. Scaling-regression bench (deferral: "large/synthetic scale case")

`benchmarks/resolution_scale.sh` + `make bench-resolution-scale`. Generates a synthetic repo with heavy cross-file imports (most edges resolve via tier-2, the #110 hot path) at N and 2N, times `index --no-lsp --force`, asserts `time(2N)/time(N)` near-linear (linear ~2×, quadratic ~4×). Self-calibrating, machine-independent, opt-in (**not** in CI / `make check`).

### ⚠️ Known finding surfaced by the new bench

The bench **fails at the default N=1000** — resolution is still **~O(edges²)** after #110, which fixed only tier-2's query *plan*. Measured (flat synthetic repo):

| files | edges | time |
|-------|-------|------|
| 500 | 16k | 0.48s |
| 1000 | 32k | 1.45s |
| 2000 | 64k | 5.17s |
| 4000 | 128k | 19.8s |

Time ~4× per 2× edges. Reproduced on a realistic nested-package shape too, so not a generator artifact. The remaining cost is in the per-edge resolve loop / 2-pass structure (profile: `sqlite3VdbeFinishMoveto` btree seeks dominate), **not** a single mis-planned query, and **not** caused by this PR (state-4 marker is a 0-row UPDATE on resolved repos; `optimize()` is 1 ms).

A red run is **expected** until that open lead is fixed; the bench then guards against further regression. Documented in the script header + `benchmarks/README.md`.

## Test plan

- `cargo test --workspace`: **1451 passed**, 3 ignored (was 1449 + 2 new `optimize` tests; 6 new resolution-state tests added earlier in the state-4 work)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (default + `--no-default-features`): clean
- `cargo doc --no-deps`, `cargo test --doc`: clean
- `shellcheck benchmarks/resolution_scale.sh`: clean
- Bench smoke-tested; synthetic repo verified 100% tier-2-resolved, edges scale linearly with files

🤖 Generated with [Claude Code](https://claude.com/claude-code)