### PR TITLE
perf(db): eliminate two O(edges²) terms in indexing

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -147,14 +147,13 @@ RATIO_MAX=2.5 ./benchmarks/resolution_scale.sh   # stricter threshold
 
 Opt-in (not in `make check`): the large run is seconds-to-minutes depending on N.
 
-> **Known finding (0.26.0):** this bench currently *fails* at the default N=1000 —
-> resolution is still ~O(edges²) after #110 (which only fixed tier-2's query
-> plan). Measured curve (flat synthetic repo): 16k→0.48s, 32k→1.45s, 64k→5.17s,
-> 128k→19.8s (time ~4× per 2× edges). Reproduced on a realistic nested-package
-> shape too, so it is not a generator artifact. The remaining cost is in the
-> per-edge resolve loop / 2-pass structure, not a single mis-planned query. A red
-> run is expected until that open lead is fixed; the bench then guards against
-> *further* regression.
+> **History:** on first introduction this bench *failed* (ratio ~3.6 at N=1000),
+> surfacing two O(n²) terms #110 had not closed: `compute_in_degrees` used a
+> correlated subquery (re-scanned the counts set per row), and the per-file
+> `DELETE FROM edges WHERE file_path=?` full-scanned the edge table (no
+> `idx_edges_file`). Both were fixed (`UPDATE...FROM` + the index); the bench now
+> passes at ~1.3 and guards against further regression. Before: 32k→1.45s,
+> 64k→5.17s, 128k→19.8s. After: index of 2000 files dropped 5.17s→0.87s.
 
 ## Reproducing the numbers
 

--- a/benchmarks/resolution_scale.sh
+++ b/benchmarks/resolution_scale.sh
@@ -18,12 +18,10 @@
 # Heuristic-only (--no-lsp): deterministic, server-independent, and the path the
 # #110 quadratic lived on. Generated repos go in a temp dir (never committed).
 #
-# KNOWN FINDING (as of 0.26.0): this bench FAILS at the default N=1000 — resolution
-# is still super-linear (~O(edges^2)) even after #110, which only fixed tier-2's
-# query *plan*. The remaining cost is in the per-edge resolve loop / 2-pass
-# structure (profile: sqlite3VdbeFinishMoveto btree seeks dominate), not in any
-# single mis-planned query. A red run today is expected and reproduces the open
-# lead; once that is fixed the bench should go green and then guards regressions.
+# HISTORY: on introduction this bench FAILED (~3.6 at N=1000), surfacing two
+# O(edges^2) terms #110 had not closed — compute_in_degrees' correlated subquery
+# and the per-file edge DELETE full-scan (no idx_edges_file). Both fixed; the
+# bench now passes (~1.3) and guards against further regression.
 #
 # Usage:
 #   ./benchmarks/resolution_scale.sh                 # default N (see below)

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -173,6 +173,10 @@ CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_name);
 CREATE INDEX IF NOT EXISTS idx_edges_target_id ON edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind);
+-- Per-file edge delete (clear_file_data_in_tx); without it the DELETE full-scans
+-- edges per file, making --force/first-index O(files×edges). idx_edges_unresolved
+-- is partial (state=0) so it can't serve deletes of resolved edges.
+CREATE INDEX IF NOT EXISTS idx_edges_file ON edges(file_path);
 -- Tier-2 import-path lookups; kind-only index scans all imports edges per call (#109).
 CREATE INDEX IF NOT EXISTS idx_edges_kind_target ON edges(kind, target_name);
 -- idx_edges_unresolved (partial index on resolution_state=0) is created
@@ -3136,6 +3140,58 @@ mod tests {
         assert!(
             plan.contains("idx_edges_kind_target"),
             "tier-2 must drive off edges(kind, target_name); got plan:\n{plan}"
+        );
+    }
+
+    #[test]
+    fn test_per_file_edge_delete_uses_file_index() {
+        // Plan regression: clear_file_data_in_tx's DELETE FROM edges WHERE
+        // file_path=? must use an index, not full-scan. A scan makes
+        // --force/first-index O(files×edges) (the per-file-clear quadratic).
+        let db = Database::open_memory().unwrap();
+        let mut stmt = db
+            .conn
+            .prepare("EXPLAIN QUERY PLAN DELETE FROM edges WHERE file_path = ?1")
+            .unwrap();
+        let plan = stmt
+            .query_map(params!["a.py"], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n");
+        assert!(
+            plan.contains("idx_edges_file"),
+            "per-file edge delete must drive off edges(file_path); got plan:\n{plan}"
+        );
+    }
+
+    #[test]
+    fn test_compute_in_degrees_plan_has_no_correlated_subquery() {
+        // Plan regression: the in-degree UPDATE must materialize counts once and
+        // join by PK, not re-scan it per row (correlated subquery → O(symbols×edges)).
+        let db = Database::open_memory().unwrap();
+        let mut stmt = db
+            .conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 UPDATE symbols SET in_degree = counts.cnt
+                 FROM (
+                     SELECT target_id, COUNT(*) AS cnt
+                     FROM edges WHERE target_id IS NOT NULL
+                     GROUP BY target_id
+                 ) AS counts
+                 WHERE symbols.id = counts.target_id",
+            )
+            .unwrap();
+        let plan = stmt
+            .query_map([], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n");
+        assert!(
+            !plan.to_uppercase().contains("CORRELATED"),
+            "in-degree UPDATE must not use a correlated subquery; got plan:\n{plan}"
         );
     }
 

--- a/crates/cartog-db/src/store/resolution.rs
+++ b/crates/cartog-db/src/store/resolution.rs
@@ -201,18 +201,16 @@ impl Database {
     pub fn compute_in_degrees(&self) -> Result<u32> {
         self.conn.execute("UPDATE symbols SET in_degree = 0", [])?;
 
-        // CTE computes counts once; the UPDATE applies them.
-        // Avoids a correlated subquery per symbol (O(n*m) → O(n+m)).
+        // UPDATE...FROM joins each count to its symbol by PK once. A correlated
+        // subquery here re-scans the counts set per row — O(symbols×edges).
         let updated = self.conn.execute(
-            "WITH counts AS (
-                SELECT target_id, COUNT(*) AS cnt
-                FROM edges WHERE target_id IS NOT NULL
-                GROUP BY target_id
-            )
-            UPDATE symbols SET in_degree = (
-                SELECT cnt FROM counts WHERE counts.target_id = symbols.id
-            )
-            WHERE id IN (SELECT target_id FROM counts)",
+            "UPDATE symbols SET in_degree = counts.cnt
+             FROM (
+                 SELECT target_id, COUNT(*) AS cnt
+                 FROM edges WHERE target_id IS NOT NULL
+                 GROUP BY target_id
+             ) AS counts
+             WHERE symbols.id = counts.target_id",
             [],
         )?;
 
@@ -344,17 +342,17 @@ impl Database {
         )?;
 
         // Fix symbols whose stored value disagrees with the actual count.
+        // UPDATE...FROM avoids the correlated re-scan (see compute_in_degrees);
+        // the `!=` predicate keeps the write set to only changed rows.
         let updated = self.conn.execute(
-            "WITH counts AS (
-                SELECT target_id, COUNT(*) AS cnt
-                FROM edges WHERE target_id IS NOT NULL
-                GROUP BY target_id
-            )
-            UPDATE symbols SET in_degree = (
-                SELECT cnt FROM counts WHERE counts.target_id = symbols.id
-            )
-            WHERE id IN (SELECT target_id FROM counts)
-              AND in_degree != (SELECT cnt FROM counts WHERE counts.target_id = symbols.id)",
+            "UPDATE symbols SET in_degree = counts.cnt
+             FROM (
+                 SELECT target_id, COUNT(*) AS cnt
+                 FROM edges WHERE target_id IS NOT NULL
+                 GROUP BY target_id
+             ) AS counts
+             WHERE symbols.id = counts.target_id
+               AND symbols.in_degree != counts.cnt",
             [],
         )?;
 


### PR DESCRIPTION
The `bench-resolution-scale` guard added in #114 immediately earned its keep: it surfaced a quadratic the #110 index had not closed. Indexing 2000 synthetic files took **5.17s**, with time ~4× per 2× edges. Profiling found **two independent O(edges²) terms** — and notably, resolution itself was linear all along (my initial suspicion was wrong; the data corrected it).

## 1. In-degree centrality — correlated subquery

`compute_in_degrees` / `compute_in_degrees_scoped` used a CTE with a correlated scalar subquery. `EXPLAIN` showed `CORRELATED SCALAR SUBQUERY` **re-scanning the materialized `counts` set once per updated row** → O(symbols × edges). The "O(n+m)" comment was aspirational, not what SQLite planned.

Rewritten as `UPDATE...FROM`, which materializes `counts` once and joins each row to its symbol by primary key. The scoped variant keeps its `!=` predicate so it still writes only changed rows.

- **13.5s → 0.08s at 4000 files (160×).**
- `compute_in_degrees_scoped` runs on **every incremental / watch re-index**, so this also cuts watch-mode cost.
- **Byte-identical results**: verified the new query produces the same `in_degree` for every symbol as the old one. `in_degree` feeds search ranking (`rag/search.rs` tiebreaker) and context centrality (`context.rs`) — both unchanged.

## 2. Per-file edge delete — full table scan

`clear_file_data_in_tx`'s `DELETE FROM edges WHERE file_path=?` had no usable index (`idx_edges_unresolved` is partial on `resolution_state=0`, so it can't serve deletes of resolved edges). Each of N per-file deletes scanned the growing edge table → O(files × edges).

Added `idx_edges_file`. Store phase **6.1s → 0.6s at 4000 files (10×)**. Verified other edge queries (`source_id`, `target_name`) still pick their own indexes — no plan regression.

## Result

| | before | after |
|---|--------|-------|
| index of 2000 files | 5.17s | **0.87s (6×)** |
| `bench-resolution-scale` ratio | 3.6 (FAIL) | **1.3 (PASS)** |

## Migration — safe, zero-friction (verified)

- `idx_edges_file` builds on the next open via `CREATE INDEX IF NOT EXISTS` in the SCHEMA block (same pattern as #110's index). **No `SCHEMA_VERSION` bump** (stays 7), no data migration, no forced re-index. Verified empirically by dropping the index to simulate a pre-change DB, then reopening with the new binary — it auto-recreated.
- In-degree rewrites are query-only (no DDL).
- `UPDATE...FROM` needs SQLite ≥ 3.33; cartog bundles **3.51**.

## Test plan

- `cargo test --workspace`: **1453 passed**
- 2 new plan-shape regression tests: per-file edge delete uses `idx_edges_file`; in-degree UPDATE has no correlated subquery
- Empirical equivalence (in-degree values) + empirical migration (index auto-rebuild) checks
- `cargo fmt`, `cargo clippy` (default + `--no-default-features`), `cargo doc`, `shellcheck`: clean
- `make bench-resolution-scale` now passes; docs updated (script header + benchmarks/README) to record the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved performance regressions in database operations by eliminating inefficient query patterns and full-table scans.

* **Tests**
  * Added regression tests to ensure query performance remains optimized and prevent future degradation.

* **Documentation**
  * Updated benchmark documentation with historical notes on previously identified and resolved performance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->