### PR TITLE
feat(progress): live file/edge counters for indexing phases

### DIFF
--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -17,6 +17,10 @@ use serde::Serialize;
 mod provenance;
 pub use provenance::EdgeProvenance;
 
+/// Emit one progress event per this many work units (files, edges). Shared by
+/// the indexer and LSP resolver so every phase throttles at the same cadence.
+pub const PROGRESS_STRIDE: u32 = 64;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub struct Symbol {
     pub id: String,

--- a/crates/cartog-indexer/src/lib.rs
+++ b/crates/cartog-indexer/src/lib.rs
@@ -19,7 +19,7 @@ use sha2::{Digest, Sha256};
 use tracing::warn;
 use walkdir::WalkDir;
 
-use cartog_core::{FileInfo, Symbol};
+use cartog_core::{FileInfo, Symbol, PROGRESS_STRIDE};
 use cartog_db::Database;
 use cartog_languages::{detect_language, get_extractor, Extractor};
 
@@ -283,14 +283,16 @@ pub fn render_index_summary(r: &IndexResult) -> String {
 pub enum ProgressUpdate {
     /// Phase 1 starting: walking the directory tree, collecting candidates.
     Walking,
-    /// Phase 2 starting: `total` candidates queued for parallel parse/extract.
-    Parsing { total: u32 },
-    /// Phase 3 starting: `total` parsed files about to be written in the
-    /// indexing transaction.
-    Storing { total: u32 },
-    /// Phase 4 starting: LSP-based edge resolution. Slowest phase on large
-    /// repos and the one most likely to look "stuck", so it gets its own event.
-    ResolvingLsp,
+    /// Phase 2 in progress: `done` of `total` candidates parsed/extracted.
+    /// `done == 0` marks the phase start; subsequent events climb toward `total`.
+    Parsing { done: u32, total: u32 },
+    /// Phase 3 in progress: `done` of `total` parsed files written in the
+    /// indexing transaction. `done == 0` marks the phase start.
+    Storing { done: u32, total: u32 },
+    /// Phase 4 in progress: LSP-based edge resolution, `done` of `total`
+    /// unresolved edges queried. Slowest phase on large repos and the one most
+    /// likely to look "stuck". `done == 0` marks the phase start.
+    ResolvingLsp { done: u32, total: u32 },
 }
 
 impl ProgressUpdate {
@@ -301,9 +303,18 @@ impl ProgressUpdate {
     pub fn label(&self) -> String {
         match self {
             ProgressUpdate::Walking => "scanning files".to_string(),
-            ProgressUpdate::Parsing { total } => format!("parsing {total} files"),
-            ProgressUpdate::Storing { total } => format!("storing {total} files"),
-            ProgressUpdate::ResolvingLsp => "resolving edges with LSP".to_string(),
+            // At phase start (done == 0) keep the terse "parsing N files"; once
+            // files complete, show the climbing "parsing M/N files" counter.
+            ProgressUpdate::Parsing { done: 0, total } => format!("parsing {total} files"),
+            ProgressUpdate::Parsing { done, total } => format!("parsing {done}/{total} files"),
+            ProgressUpdate::Storing { done: 0, total } => format!("storing {total} files"),
+            ProgressUpdate::Storing { done, total } => format!("storing {done}/{total} files"),
+            ProgressUpdate::ResolvingLsp { done: 0, total } => {
+                format!("resolving {total} edges with LSP")
+            }
+            ProgressUpdate::ResolvingLsp { done, total } => {
+                format!("resolving {done}/{total} edges with LSP")
+            }
         }
     }
 }
@@ -484,20 +495,40 @@ pub fn index_directory(
 
     // ── Phase 2: parallel parse + extract (CPU-bound, rayon-worker pool) ──
     check_cancel()?;
+    let parse_total = candidates.len() as u32;
     emit(ProgressUpdate::Parsing {
-        total: candidates.len() as u32,
+        done: 0,
+        total: parse_total,
     });
+    // Rayon workers finish out of order. `parsed_count` assigns each a unique n;
+    // `reported_high` is a running max so a late straggler never emits a `done`
+    // below one already shown (the spinner would otherwise flicker backward).
+    use std::sync::atomic::{AtomicU32, Ordering};
+    let parsed_count = AtomicU32::new(0);
+    let reported_high = AtomicU32::new(0);
     let parsed: Vec<ParseOutput> = candidates
         .par_iter()
         .map(|(abs, rel, lang)| {
-            parse_one_file(
+            let out = parse_one_file(
                 abs,
                 rel,
                 lang,
                 force,
                 stored_hashes.get(rel).map(String::as_str),
                 redact,
-            )
+            );
+            let n = parsed_count.fetch_add(1, Ordering::Relaxed) + 1;
+            if n % PROGRESS_STRIDE == 0 || n == parse_total {
+                // fetch_max returns the prior high; only emit if we raised it,
+                // so emitted `done` is non-decreasing despite out-of-order calls.
+                if reported_high.fetch_max(n, Ordering::Relaxed) < n {
+                    emit(ProgressUpdate::Parsing {
+                        done: n,
+                        total: parse_total,
+                    });
+                }
+            }
+            out
         })
         .collect();
 
@@ -530,6 +561,7 @@ pub fn index_directory(
         .count() as u32;
     check_cancel()?;
     emit(ProgressUpdate::Storing {
+        done: 0,
         total: storing_total,
     });
     let tx = db.begin_indexing_tx()?;
@@ -674,6 +706,12 @@ pub fn index_directory(
         })?;
 
         result.files_indexed += 1;
+        if result.files_indexed % PROGRESS_STRIDE == 0 || result.files_indexed == storing_total {
+            emit(ProgressUpdate::Storing {
+                done: result.files_indexed,
+                total: storing_total,
+            });
+        }
     }
 
     // Remove files that no longer exist. Treat deletions as "dirty" so the
@@ -744,9 +782,16 @@ pub fn index_directory(
         if lsp_ran {
             // Watch (lsp=false) may have sealed edges at state=4; give LSP a shot.
             db.reopen_heuristic_exhausted()?;
-            emit(ProgressUpdate::ResolvingLsp);
-            let stats = cartog_lsp::lsp_resolve_edges(db, &root, None, lsp_overrides)
-                .with_context(|| format!("resolving LSP edges for root {}", root.display()))?;
+            // No phase event is forced here: lsp_resolve_edges fires the first
+            // ResolvingLsp tick only when there are edges to resolve. A run with
+            // zero unresolved edges intentionally shows no "resolving" phase
+            // rather than a misleading "resolving 0 edges" marker.
+            let lsp_progress = |done: u32, total: u32| {
+                emit(ProgressUpdate::ResolvingLsp { done, total });
+            };
+            let stats =
+                cartog_lsp::lsp_resolve_edges(db, &root, None, lsp_overrides, Some(&lsp_progress))
+                    .with_context(|| format!("resolving LSP edges for root {}", root.display()))?;
             result.edges_lsp_resolved = stats.resolved;
             result.edges_marked_unresolvable = stats.marked_unresolvable;
             result.edges_marked_external = stats.marked_external;
@@ -2737,10 +2782,26 @@ We use PostgreSQL with connection pooling via pgbouncer.
 
         assert!(result.files_indexed >= 2);
         let events = events.into_inner().unwrap();
-        assert_eq!(events.len(), 3, "expected 3 phase events, got {events:?}");
         assert_eq!(events[0], ProgressUpdate::Walking);
-        assert!(matches!(events[1], ProgressUpdate::Parsing { total } if total >= 2));
-        assert!(matches!(events[2], ProgressUpdate::Storing { total } if total >= 2));
+        // Each phase opens with done == 0 and later reports done == total.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ProgressUpdate::Parsing { done: 0, total } if *total >= 2)));
+        assert!(events.iter().any(
+            |e| matches!(e, ProgressUpdate::Parsing { done, total } if done == total && *total >= 2)
+        ));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ProgressUpdate::Storing { done: 0, total } if *total >= 2)));
+        assert!(events.iter().any(
+            |e| matches!(e, ProgressUpdate::Storing { done, total } if done == total && *total >= 2)
+        ));
+        // Phase order: last Walking < first Parsing < first Storing.
+        let pos = |pred: fn(&ProgressUpdate) -> bool| events.iter().position(pred).unwrap();
+        let walking = pos(|e| matches!(e, ProgressUpdate::Walking));
+        let parsing = pos(|e| matches!(e, ProgressUpdate::Parsing { .. }));
+        let storing = pos(|e| matches!(e, ProgressUpdate::Storing { .. }));
+        assert!(walking < parsing && parsing < storing);
     }
 
     #[test]
@@ -2816,14 +2877,77 @@ We use PostgreSQL with connection pooling via pgbouncer.
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, ProgressUpdate::Parsing { total } if *total > 0)),
+                .any(|e| matches!(e, ProgressUpdate::Parsing { total, .. } if *total > 0)),
             "must emit a Parsing event with a positive total"
         );
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, ProgressUpdate::Storing { total } if *total > 0)),
+                .any(|e| matches!(e, ProgressUpdate::Storing { total, .. } if *total > 0)),
             "must emit a Storing event with a positive total"
+        );
+    }
+
+    #[test]
+    fn progress_counter_climbs_mid_phase_for_large_repo() {
+        use cartog_db::Database;
+        use std::sync::Mutex;
+
+        // More than PROGRESS_STRIDE files so the in-loop stride emit fires at
+        // least one intermediate `done` (0 < done < total) — the path the small
+        // 2-file fixtures never exercise.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap().join("project");
+        std::fs::create_dir(&root).unwrap();
+        let n = PROGRESS_STRIDE * 3 + 5; // 197 files
+        for i in 0..n {
+            std::fs::write(
+                root.join(format!("m{i}.py")),
+                format!("def f{i}():\n    return {i}\n"),
+            )
+            .unwrap();
+        }
+
+        let db = Database::open_memory().unwrap();
+        let events: Mutex<Vec<ProgressUpdate>> = Mutex::new(Vec::new());
+        let cb = |u: ProgressUpdate| events.lock().unwrap().push(u);
+        index_directory(
+            &db,
+            &root,
+            true,
+            false,
+            Some(&cb),
+            None,
+            crate::RedactionConfig::disabled(),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+
+        let events = events.into_inner().unwrap();
+        // A climbing parse event with done strictly between 0 and total.
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                ProgressUpdate::Parsing { done, total } if *done > 0 && *done < *total
+            )),
+            "expected a mid-climb Parsing event, got {events:?}"
+        );
+        // Same for storing.
+        assert!(events.iter().any(|e| matches!(
+            e,
+            ProgressUpdate::Storing { done, total } if *done > 0 && *done < *total
+        )));
+        // Emitted parse `done` values never decrease (out-of-order rayon clamp).
+        let parse_dones: Vec<u32> = events
+            .iter()
+            .filter_map(|e| match e {
+                ProgressUpdate::Parsing { done, .. } => Some(*done),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            parse_dones.windows(2).all(|w| w[0] <= w[1]),
+            "parse done must be non-decreasing, got {parse_dones:?}"
         );
     }
 

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -15,10 +15,14 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use cartog_core::detect_language;
+use cartog_core::{detect_language, PROGRESS_STRIDE};
 use cartog_db::{Database, UnresolvedEdge};
 
 use manager::{DefinitionOutcome, LspManager};
+
+/// Per-edge progress callback for [`lsp_resolve_edges`]: `(done, total)`.
+/// Called synchronously from the resolution loop; keep it cheap.
+pub type LspProgress<'a> = &'a (dyn Fn(u32, u32) + Send + Sync);
 
 /// Summary of an LSP resolution pass.
 #[derive(Debug, Default, Clone, Copy)]
@@ -42,17 +46,36 @@ pub struct LspResolveStats {
 /// Returns counts for `resolved` (state=0 → 1), `marked_unresolvable`
 /// (state=0 → 2, definitive LSP negative), and `marked_external` (state=0 → 3,
 /// LSP located the target outside the indexed root).
+///
+/// `progress`, when `Some`, fires `(done, total)` as edges are processed.
+/// `done` can end below `total` when a language server fails to start or when
+/// an edge's target column can't be located (those edges are never queried).
 pub fn lsp_resolve_edges(
     db: &Database,
     root: &Path,
     shared_manager: Option<&mut LspManager>,
     overrides: &HashMap<String, Vec<String>>,
+    progress: Option<LspProgress<'_>>,
 ) -> Result<LspResolveStats> {
     let unresolved = db.unresolved_edges()?;
 
     if unresolved.is_empty() {
         return Ok(LspResolveStats::default());
     }
+
+    // Total candidate edges before grouping; drives the (done, total) callback.
+    let total = unresolved.len() as u32;
+    let mut processed = 0u32;
+    // Dedup so the post-loop final tick never repeats the last in-loop value
+    // (last edge on a stride boundary, or no server started so it stays 0).
+    let last_emitted = std::cell::Cell::new(u32::MAX);
+    let emit = |processed: u32| {
+        if let Some(cb) = progress {
+            if last_emitted.replace(processed) != processed {
+                cb(processed, total);
+            }
+        }
+    };
 
     // Group by language (derived from file extension)
     let mut by_language: HashMap<String, Vec<UnresolvedEdge>> = HashMap::new();
@@ -84,6 +107,8 @@ pub fn lsp_resolve_edges(
     let mut marked_unresolvable = 0u32;
     let mut marked_external = 0u32;
     let mut any_server_started = false;
+
+    emit(0); // phase-start tick, so the total shows before the first stride
 
     for (language, edges) in &by_language {
         match manager.start(language) {
@@ -177,6 +202,10 @@ pub fn lsp_resolve_edges(
             };
 
             for ((edge, _pos), outcome) in batch.iter().zip(outcomes) {
+                processed += 1;
+                if processed % PROGRESS_STRIDE == 0 {
+                    emit(processed);
+                }
                 match outcome {
                     Ok(Some(DefinitionOutcome::InRoot(loc))) => {
                         match db.find_symbol_at_location(&loc.file_path, loc.line) {
@@ -292,6 +321,8 @@ pub fn lsp_resolve_edges(
             );
         }
     }
+
+    emit(processed); // final tick (deduped): lands on total when every edge ran
 
     if !any_server_started {
         tracing::debug!("LSP: no servers found on PATH, skipping");
@@ -425,7 +456,13 @@ mod tests {
         let edge_id = db.unresolved_edges().unwrap()[0].edge_id;
 
         let tmp = tempfile::tempdir().unwrap();
-        let stats = lsp_resolve_edges(&db, tmp.path(), None, &HashMap::new()).unwrap();
+        let ticks: std::sync::Mutex<Vec<(u32, u32)>> = std::sync::Mutex::new(Vec::new());
+        let cb = |done, total| ticks.lock().unwrap().push((done, total));
+        let stats = lsp_resolve_edges(&db, tmp.path(), None, &HashMap::new(), Some(&cb)).unwrap();
+        // No server ran, so no edges were processed. The phase-start emit(0) and
+        // the post-loop final emit(0) carry the same value; the dedup collapses
+        // them to a single (0, 1) tick rather than a duplicate pair.
+        assert_eq!(ticks.into_inner().unwrap(), vec![(0, 1)]);
         assert_eq!(stats.resolved, 0, "no servers must mean zero resolutions");
         assert_eq!(
             stats.marked_unresolvable, 0,

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -364,15 +364,25 @@ fn index_with_optional_lsp(
     };
 
     if result.dirty_files > 0 {
-        if let Some(tx) = progress_tx.as_ref() {
-            let _ = tx.try_send(progress::Phase::Custom("resolving with LSP"));
-        }
         let mut mgr = lsp_manager.lock().map_err(|_| {
             mcp_err("internal error: LSP manager lock poisoned (server restart required)")
         })?;
         let db = db.lock().map_err(|_| {
             mcp_err("internal error: database lock poisoned (server restart required)")
         })?;
+        // Map (done, total) into a counting ResolvingLsp phase; reuses the
+        // indexer label so the wording stays single-sourced.
+        let lsp_progress = progress_tx.as_ref().map(|tx| {
+            let tx = tx.clone();
+            move |done: u32, total: u32| {
+                let _ = tx.try_send(progress::Phase::Indexer(
+                    cartog_indexer::ProgressUpdate::ResolvingLsp { done, total },
+                ));
+            }
+        });
+        let lsp_progress_ref: Option<cartog_lsp::LspProgress<'_>> = lsp_progress
+            .as_ref()
+            .map(|f| f as &(dyn Fn(u32, u32) + Send + Sync));
         // Overrides live on the shared `mgr` (set at construction), so the
         // map passed here is ignored — pass empty.
         match cartog_lsp::lsp_resolve_edges(
@@ -380,6 +390,7 @@ fn index_with_optional_lsp(
             root,
             Some(&mut mgr),
             &std::collections::HashMap::new(),
+            lsp_progress_ref,
         ) {
             Ok(stats) => {
                 result.edges_lsp_resolved = stats.resolved;

--- a/crates/cartog-mcp/src/progress.rs
+++ b/crates/cartog-mcp/src/progress.rs
@@ -15,38 +15,84 @@ use rmcp::model::{ProgressNotificationParam, ProgressToken};
 use tokio::sync::mpsc;
 
 /// Internal, transport-neutral phase event shipped from a blocking task to
-/// the async forwarder. Each variant maps to a `ProgressNotificationParam`
-/// via [`Phase::into_message_and_total`].
+/// the async forwarder, which renders it (via `Phase::render`) and accumulates
+/// it into a `ProgressNotificationParam`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Phase {
     Indexer(cartog_indexer::ProgressUpdate),
     Rag(cartog_rag::indexer::ProgressUpdate),
-    /// Free-form phase added by the MCP layer (e.g. `Resolving` after the
-    /// LSP edge-resolution pass). Only constructed when the `lsp` feature
-    /// is enabled; `#[allow(dead_code)]` keeps `cargo check
-    /// --no-default-features` clean.
-    #[allow(dead_code)]
-    Custom(&'static str),
+}
+
+/// A phase rendered for the wire: human label plus its in-phase `(done, total)`
+/// when the phase carries a counter. The forwarder turns these per-phase counts
+/// into a globally-monotonic `progress` (the MCP spec requires `progress` to
+/// strictly increase per token), so `done`/`total` here are phase-local, not
+/// cumulative.
+struct PhaseProgress {
+    message: String,
+    /// `Some((done, total))` for counting phases (parse/store/resolve/embed);
+    /// `None` for marker phases (walking, preparing, storing-embeddings).
+    counts: Option<(u32, u32)>,
+    /// Stable discriminant of the phase so the forwarder can tell one counting
+    /// phase from the next (two phases can both start at `done == 0`).
+    kind: PhaseKind,
+}
+
+/// Identity of a phase, used by the forwarder to detect boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PhaseKind {
+    Walking,
+    Parsing,
+    Storing,
+    ResolvingLsp,
+    Preparing,
+    Embedding,
+    StoringEmbeddings,
 }
 
 impl Phase {
-    /// Render `(message, total)` for [`ProgressNotificationParam`].
-    ///
-    /// The `progress` counter itself is owned by the forwarder so it can
-    /// stay monotonic across phases (the MCP spec requires this).
-    pub fn into_message_and_total(self) -> (String, Option<f64>) {
+    /// Render the phase for the wire. Labels come from `ProgressUpdate::label()`
+    /// (single source of truth in cartog-indexer / cartog-rag); the per-phase
+    /// `(done, total)` is extracted here for the forwarder to accumulate.
+    fn render(self) -> PhaseProgress {
         use cartog_indexer::ProgressUpdate as IxU;
         use cartog_rag::indexer::ProgressUpdate as RgU;
-        // Labels come from `ProgressUpdate::label()` (single source of truth in
-        // cartog-indexer / cartog-rag); only the `total` for the MCP progress
-        // bar is computed here.
         match self {
-            Phase::Indexer(u @ IxU::Parsing { total }) => (u.label(), Some(total as f64)),
-            Phase::Indexer(u @ IxU::Storing { total }) => (u.label(), Some(total as f64)),
-            Phase::Indexer(u) => (u.label(), None),
-            Phase::Rag(u @ RgU::Embedding { total, .. }) => (u.label(), Some(total as f64)),
-            Phase::Rag(u) => (u.label(), None),
-            Phase::Custom(s) => (s.into(), None),
+            Phase::Indexer(u @ IxU::Parsing { done, total }) => PhaseProgress {
+                message: u.label(),
+                counts: Some((done, total)),
+                kind: PhaseKind::Parsing,
+            },
+            Phase::Indexer(u @ IxU::Storing { done, total }) => PhaseProgress {
+                message: u.label(),
+                counts: Some((done, total)),
+                kind: PhaseKind::Storing,
+            },
+            Phase::Indexer(u @ IxU::ResolvingLsp { done, total }) => PhaseProgress {
+                message: u.label(),
+                counts: Some((done, total)),
+                kind: PhaseKind::ResolvingLsp,
+            },
+            Phase::Indexer(u @ IxU::Walking) => PhaseProgress {
+                message: u.label(),
+                counts: None,
+                kind: PhaseKind::Walking,
+            },
+            Phase::Rag(u @ RgU::Embedding { processed, total }) => PhaseProgress {
+                message: u.label(),
+                counts: Some((processed, total)),
+                kind: PhaseKind::Embedding,
+            },
+            Phase::Rag(u @ RgU::Preparing) => PhaseProgress {
+                message: u.label(),
+                counts: None,
+                kind: PhaseKind::Preparing,
+            },
+            Phase::Rag(u @ RgU::Storing) => PhaseProgress {
+                message: u.label(),
+                counts: None,
+                kind: PhaseKind::StoringEmbeddings,
+            },
         }
     }
 }
@@ -85,21 +131,57 @@ pub struct Forwarder {
 const CHANNEL_CAPACITY: usize = 64;
 
 /// Spawn an async forwarder that consumes [`Phase`] events from `rx` and
-/// pushes them to `notifier` as `notifications/progress` with the given
-/// token.
+/// pushes them to `notifier` as `notifications/progress` with the given token.
 ///
-/// `progress` is a monotonically-increasing counter incremented once per
-/// emitted event, per the MCP spec.
+/// The MCP spec requires `progress` to strictly increase per token, but each
+/// phase reports a `done` that resets to 0 at its start. The forwarder bridges
+/// this by accumulating a `base` (the summed totals of all completed phases):
+/// within a counting phase it reports `progress = base + done` against
+/// `total = base + phase_total`, so the bar climbs coherently across phases
+/// instead of resetting or overshooting. Marker phases with no counter (walking,
+/// preparing, storing-embeddings) step `progress` by one with no `total`. A new
+/// phase is recognized when the event's [`PhaseKind`] changes; `last_progress`
+/// then clamps the value up so neither a phase boundary nor an out-of-order
+/// rayon emit (which can make `done` jitter) ever makes `progress` dip.
 pub fn spawn_forwarder(token: ProgressToken, notifier: Notifier) -> Forwarder {
     let (tx, mut rx) = mpsc::channel::<Phase>(CHANNEL_CAPACITY);
     let join = tokio::spawn(async move {
-        let mut counter: f64 = 0.0;
+        let mut base: f64 = 0.0;
+        let mut cur: Option<(PhaseKind, u32)> = None; // (kind, total) of the phase in flight
+        let mut last_progress: f64 = 0.0;
         while let Some(phase) = rx.recv().await {
-            counter += 1.0;
-            let (message, total) = phase.into_message_and_total();
+            let PhaseProgress {
+                message,
+                counts,
+                kind,
+            } = phase.render();
+            // Phase boundary: a different kind arrived. Fold the finished phase's
+            // total (a counting phase) or its single marker unit into the base.
+            if let Some((prev_kind, prev_total)) = cur {
+                if prev_kind != kind {
+                    base += if prev_total > 0 {
+                        prev_total as f64
+                    } else {
+                        1.0
+                    };
+                }
+            }
+            let total = match counts {
+                Some((done, total)) => {
+                    cur = Some((kind, total));
+                    last_progress = last_progress.max(base + done as f64);
+                    Some(base + total as f64)
+                }
+                None => {
+                    // Marker phase: occupies one unit, no determinate total.
+                    cur = Some((kind, 0));
+                    last_progress = last_progress.max(base);
+                    None
+                }
+            };
             (notifier)(ProgressNotificationParam {
                 progress_token: token.clone(),
-                progress: counter,
+                progress: last_progress,
                 total,
                 message: Some(message),
             })
@@ -167,8 +249,8 @@ mod tests {
 
         let cb = indexer_callback(fwd.tx.clone());
         cb(IxU::Walking);
-        cb(IxU::Parsing { total: 7 });
-        cb(IxU::Storing { total: 5 });
+        cb(IxU::Parsing { done: 0, total: 7 });
+        cb(IxU::Storing { done: 0, total: 5 });
 
         drop(cb);
         drop(fwd.tx);
@@ -176,21 +258,26 @@ mod tests {
 
         let events = events.lock().unwrap();
         assert_eq!(events.len(), 3);
+        // progress is globally monotonic across phases; totals are cumulative
+        // (base + phase total) so the bar climbs instead of resetting per phase.
         assert!(events[0].progress < events[1].progress);
         assert!(events[1].progress < events[2].progress);
         assert_eq!(events[0].message.as_deref(), Some("scanning files"));
         assert_eq!(events[1].message.as_deref(), Some("parsing 7 files"));
         assert_eq!(events[2].message.as_deref(), Some("storing 5 files"));
-        assert_eq!(events[0].total, None);
-        assert_eq!(events[1].total, Some(7.0));
-        assert_eq!(events[2].total, Some(5.0));
+        assert_eq!(events[0].total, None); // Walking marker
+        assert_eq!(events[1].total, Some(8.0)); // base 1 (walking) + 7
+        assert_eq!(events[2].total, Some(13.0)); // base 8 (walking+parsing) + 5
     }
 
     #[test]
-    fn resolving_lsp_phase_maps_to_message() {
-        let (msg, total) = Phase::Indexer(IxU::ResolvingLsp).into_message_and_total();
-        assert_eq!(msg, "resolving edges with LSP");
-        assert_eq!(total, None);
+    fn resolving_lsp_phase_renders_message_and_counts() {
+        let start = Phase::Indexer(IxU::ResolvingLsp { done: 0, total: 9 }).render();
+        assert_eq!(start.message, "resolving 9 edges with LSP");
+        assert_eq!(start.counts, Some((0, 9)));
+        let mid = Phase::Indexer(IxU::ResolvingLsp { done: 3, total: 9 }).render();
+        assert_eq!(mid.message, "resolving 3/9 edges with LSP");
+        assert_eq!(mid.counts, Some((3, 9)));
     }
 
     #[tokio::test]
@@ -214,25 +301,87 @@ mod tests {
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].message.as_deref(), Some("preparing"));
         assert_eq!(events[1].message.as_deref(), Some("embedding 512/1024"));
-        assert_eq!(events[1].total, Some(1024.0));
+        assert_eq!(events[1].total, Some(1025.0)); // base 1 (preparing) + 1024
         assert_eq!(events[2].message.as_deref(), Some("storing embeddings"));
+        // progress never dips across the marker→counting→marker boundaries.
+        assert!(events[0].progress <= events[1].progress);
+        assert!(events[1].progress <= events[2].progress);
     }
 
     #[tokio::test]
-    async fn custom_phase_is_forwarded() {
+    async fn progress_climbs_within_phase_and_stays_monotonic_across_phases() {
         let (notifier, events) = capturing_notifier();
         let fwd = spawn_forwarder(token(), notifier);
+        let cb = indexer_callback(fwd.tx.clone());
 
-        fwd.tx
-            .send(Phase::Custom("resolving with LSP"))
-            .await
-            .unwrap();
+        // A full parse phase that climbs, then a store phase that also climbs.
+        cb(IxU::Parsing {
+            done: 0,
+            total: 100,
+        });
+        cb(IxU::Parsing {
+            done: 64,
+            total: 100,
+        });
+        cb(IxU::Parsing {
+            done: 100,
+            total: 100,
+        });
+        cb(IxU::Storing { done: 0, total: 40 });
+        cb(IxU::Storing {
+            done: 40,
+            total: 40,
+        });
+
+        drop(cb);
         drop(fwd.tx);
         fwd.join.await.unwrap();
 
-        let events = events.lock().unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].message.as_deref(), Some("resolving with LSP"));
+        let e = events.lock().unwrap();
+        assert_eq!(e.len(), 5);
+        // Within the parse phase: 0 → 64 → 100 against total 100.
+        assert_eq!((e[0].progress, e[0].total), (0.0, Some(100.0)));
+        assert_eq!((e[1].progress, e[1].total), (64.0, Some(100.0)));
+        assert_eq!((e[2].progress, e[2].total), (100.0, Some(100.0)));
+        // Store phase folds the finished parse total (100) into the base, so it
+        // climbs 100 → 140 against cumulative total 140 — never resets to 0.
+        assert_eq!((e[3].progress, e[3].total), (100.0, Some(140.0)));
+        assert_eq!((e[4].progress, e[4].total), (140.0, Some(140.0)));
+        // Globally non-decreasing.
+        for w in e.windows(2) {
+            assert!(w[0].progress <= w[1].progress);
+        }
+    }
+
+    #[tokio::test]
+    async fn out_of_order_done_never_makes_progress_dip() {
+        let (notifier, events) = capturing_notifier();
+        let fwd = spawn_forwarder(token(), notifier);
+        let cb = indexer_callback(fwd.tx.clone());
+
+        // Rayon workers can emit out of order: a higher done arrives before a
+        // lower one. The clamp must keep progress non-decreasing.
+        cb(IxU::Parsing {
+            done: 0,
+            total: 100,
+        });
+        cb(IxU::Parsing {
+            done: 64,
+            total: 100,
+        });
+        cb(IxU::Parsing {
+            done: 32,
+            total: 100,
+        }); // late straggler, lower done
+
+        drop(cb);
+        drop(fwd.tx);
+        fwd.join.await.unwrap();
+
+        let e = events.lock().unwrap();
+        assert_eq!(e.len(), 3);
+        assert_eq!(e[1].progress, 64.0);
+        assert_eq!(e[2].progress, 64.0); // clamped up, not 32
     }
 
     #[tokio::test]
@@ -249,6 +398,6 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Phase>(1);
         let cb = indexer_callback(tx);
         cb(IxU::Walking);
-        cb(IxU::Parsing { total: 1 });
+        cb(IxU::Parsing { done: 0, total: 1 });
     }
 }

--- a/crates/cartog-rag/src/indexer.rs
+++ b/crates/cartog-rag/src/indexer.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use tracing::info;
+use tracing::{debug, info};
 
 use cartog_db::Database;
 
@@ -331,8 +331,10 @@ pub fn index_embeddings<P: EmbeddingProvider + ?Sized>(
             total: progress_total,
         });
 
+        // debug, not info: the spinner already shows this on a TTY; an info
+        // line would collide with the spinner's `\r`-rewritten progress.
         if processed % 1000 < CHUNK_SIZE {
-            info!("  {processed}/{total} symbols embedded");
+            debug!("  {processed}/{total} symbols embedded");
         }
     }
 

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -20,6 +20,40 @@ pub mod init;
 pub mod mermaid;
 pub mod remote;
 
+/// True while a TTY spinner is painting the bottom line of stderr. The tracing
+/// writer ([`SpinnerSafeWriter`]) reads this to clear the spinner line before
+/// emitting a log, so a `\r`-rewritten spinner and a `\n`-terminated log no
+/// longer garble each other — the spinner simply repaints on its next tick.
+static SPINNER_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// `MakeWriter` for tracing that coexists with the spinner. When a spinner is
+/// active it prefixes each record with `\r\x1b[K` (carriage return + clear to
+/// end of line) so the log overwrites the spinner line cleanly; the spinner's
+/// 100ms repaint then redraws below the log. Always writes to stderr.
+pub struct SpinnerSafeWriter;
+
+impl std::io::Write for SpinnerSafeWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut err = std::io::stderr().lock();
+        if SPINNER_ACTIVE.load(Ordering::Relaxed) {
+            err.write_all(b"\r\x1b[K")?;
+        }
+        err.write_all(buf)?;
+        // Report the caller's full buffer as written; the prefix is our own.
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        std::io::stderr().lock().flush()
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SpinnerSafeWriter {
+    type Writer = SpinnerSafeWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        SpinnerSafeWriter
+    }
+}
+
 /// Stderr progress reporter for long-running CLI commands.
 ///
 /// On a TTY it renders an animated spinner whose label tracks the current
@@ -27,10 +61,15 @@ pub mod remote;
 /// it prints a plain line on each phase change plus a periodic heartbeat, so a
 /// multi-minute first index is never silent. Use [`Spinner::set_phase`] from a
 /// progress callback to update the label/heartbeat.
+///
+/// While a TTY spinner lives it sets [`SPINNER_ACTIVE`] so [`SpinnerSafeWriter`]
+/// keeps concurrent tracing logs from colliding with the spinner line.
 struct Spinner {
     stop: Arc<AtomicBool>,
     phase: Arc<Mutex<String>>,
     handle: Option<std::thread::JoinHandle<()>>,
+    /// Set only on the TTY path, so `Drop` clears `SPINNER_ACTIVE` exactly once.
+    tty: bool,
 }
 
 impl Spinner {
@@ -46,6 +85,11 @@ impl Spinner {
         let phase = Arc::new(Mutex::new(label.to_string()));
         let stop_clone = Arc::clone(&stop);
         let phase_clone = Arc::clone(&phase);
+        // Only the TTY path paints a `\r`-rewritten line that logs can collide
+        // with; the plain heartbeat is newline-terminated and needs no guard.
+        if is_tty {
+            SPINNER_ACTIVE.store(true, Ordering::Relaxed);
+        }
         let handle = std::thread::spawn(move || {
             if is_tty {
                 Self::run_tty(&stop_clone, &phase_clone);
@@ -57,6 +101,7 @@ impl Spinner {
             stop,
             phase,
             handle: Some(handle),
+            tty: is_tty,
         })
     }
 
@@ -122,6 +167,11 @@ impl Drop for Spinner {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(h) = self.handle.take() {
             let _ = h.join();
+        }
+        // Cleared after the painter joins (it has emitted its final line clear),
+        // so later logs write plainly. `stop()` consumes self and also lands here.
+        if self.tty {
+            SPINNER_ACTIVE.store(false, Ordering::Relaxed);
         }
     }
 }
@@ -1529,9 +1579,21 @@ mod tests {
         use indexer::ProgressUpdate as U;
         let cap = |u: &U| capitalize_phase(u.label());
         assert_eq!(cap(&U::Walking), "Scanning files");
-        assert_eq!(cap(&U::Parsing { total: 12 }), "Parsing 12 files");
-        assert_eq!(cap(&U::Storing { total: 5 }), "Storing 5 files");
-        assert_eq!(cap(&U::ResolvingLsp), "Resolving edges with LSP");
+        assert_eq!(cap(&U::Parsing { done: 0, total: 12 }), "Parsing 12 files");
+        assert_eq!(
+            cap(&U::Parsing { done: 4, total: 12 }),
+            "Parsing 4/12 files"
+        );
+        assert_eq!(cap(&U::Storing { done: 0, total: 5 }), "Storing 5 files");
+        assert_eq!(cap(&U::Storing { done: 3, total: 5 }), "Storing 3/5 files");
+        assert_eq!(
+            cap(&U::ResolvingLsp { done: 0, total: 9 }),
+            "Resolving 9 edges with LSP"
+        );
+        assert_eq!(
+            cap(&U::ResolvingLsp { done: 3, total: 9 }),
+            "Resolving 3/9 edges with LSP"
+        );
     }
 
     #[test]

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -140,13 +140,12 @@ fn main() -> Result<()> {
         "warn"
     };
 
-    // Initialize tracing to stderr for all commands.
-    // - CLI mode: only warnings (e.g., unparseable files) show by default
-    // - Serve / RAG index / Watch mode (TTY): info-level for progress
-    // - Serve / RAG index / Watch mode (piped, e.g. MCP child): warn-only
-    // Stdout stays clean for CLI output and MCP protocol.
+    // Initialize tracing to stderr via `SpinnerSafeWriter`, which clears the
+    // spinner line before each record so info logs and a live spinner coexist
+    // without garbling each other (no more level-based suppression). Stdout
+    // stays clean for CLI output and MCP protocol.
     tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
+        .with_writer(commands::SpinnerSafeWriter)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level)),


### PR DESCRIPTION
## Summary

Parse, store, and LSP-resolution phases now report a climbing `done/total` counter instead of a static phase label, so a long index is no longer a silent or seemingly-stuck wait. Fixes the spinner/log collision and the MCP progress bar along the way.

## Changes

- **`ProgressUpdate::Parsing/Storing/ResolvingLsp`** carry `{ done, total }`; `label()` renders `parsing M/N files`, falling back to `parsing N files` at phase start.
- **Indexer parse loop** throttles emits at a shared `PROGRESS_STRIDE` (moved to `cartog-core`) and uses a `fetch_max` guard so out-of-order rayon workers never emit a backward `done`.
- **`lsp_resolve_edges`** takes a `(done, total)` callback, deduped so the final tick never repeats the last in-loop value.
- **MCP forwarder rewrite**: `progress` was a per-event counter paired with a per-phase `total`, so a client's bar sat near 0% during a phase and overshot >100% at boundaries. It now accumulates a base of completed-phase totals and reports `progress = base + done` / `total = base + phase_total`, clamped non-decreasing per the MCP spec. Removed the now-dead `Phase::Custom`.
- **Spinner/log coexistence**: a `SpinnerSafeWriter` clears the spinner line before each tracing record while a spinner is active, so info logs and the spinner no longer garble each other. Demoted the per-batch rag embed log to `debug` (the spinner already shows that count).

## Tests

Added coverage for the stride mid-climb path (197-file fixture), out-of-order `done` clamping, and cross-phase monotonic progress.

## Verification

Full workspace tests (32 suites), `cargo fmt --check`, `clippy --all-targets -D warnings` (default + `--no-default-features`), doctests (both), and `cargo doc` all clean. Verified live on a ~1660-file repo: parse/store counters climb; on a ~98k-edge repo the LSP counter climbs through resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More detailed progress reporting with per-phase done/total counts and configurable emission cadence.
  * CLI now forwards fine-grained LSP resolution progress into overall indexing progress.

* **Bug Fixes**
  * Terminal logging no longer garbles the live spinner; logs clear/rewrite spinner line before printing.
  * Embedded-symbol messages reduced to avoid noisy info-level output.

* **Tests**
  * Progress tests updated to the new structured done/total shape and monotonic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->