### PR TITLE
perf(lsp): pipeline definition requests in bounded windows

### DIFF
--- a/crates/cartog-lsp/src/client.rs
+++ b/crates/cartog-lsp/src/client.rs
@@ -525,4 +525,78 @@ mod tests {
             "batch took {elapsed:?}; deadline should be shared, not per-id"
         );
     }
+
+    /// Spawn a fake server that writes `frames` then EXITS (closing stdout),
+    /// so the reader sees EOF and the channel disconnects.
+    #[cfg(unix)]
+    fn fake_server_then_exit(frames: &str) -> LspClient {
+        use std::process::{Command, Stdio};
+        let script = format!("printf '%s' '{frames}'");
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn fake server");
+        LspClient::new(child).expect("client over fake server")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_batch_fails_remaining_slots_fast_on_disconnect() {
+        // Server answers id 1 then exits, so ids 2 and 3 disconnect rather than
+        // wait out the deadline. With a long timeout, a fast return proves the
+        // Disconnected arm short-circuits every outstanding slot.
+        let r1 = framed(r#"{"jsonrpc":"2.0","id":1,"result":{"v":1}}"#);
+        let mut client = fake_server_then_exit(&r1);
+        client.set_timeout(Duration::from_secs(30)); // would dominate if we waited
+
+        let started = Instant::now();
+        let replies = client
+            .request_batch(&[
+                ("m", serde_json::json!({})),
+                ("m", serde_json::json!({})),
+                ("m", serde_json::json!({})),
+            ])
+            .expect("batch sends");
+        let elapsed = started.elapsed();
+
+        assert_eq!(replies.len(), 3);
+        assert_eq!(replies[0].as_ref().unwrap()["v"], 1);
+        assert!(replies[1].is_err() && replies[2].is_err());
+        assert!(
+            replies[1]
+                .as_ref()
+                .unwrap_err()
+                .to_string()
+                .contains("disconnect"),
+            "got: {:?}",
+            replies[1]
+        );
+        // Disconnect must short-circuit, not burn the 30s deadline.
+        assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_batch_drains_notifications_and_server_requests() {
+        // A notification and a server-initiated request are interleaved with the
+        // real replies. Both must be handled (auto-responded / discarded) without
+        // disturbing reply matching, so the batch still completes.
+        let note = framed(r#"{"jsonrpc":"2.0","method":"$/progress","params":{}}"#);
+        let srv_req = framed(
+            r#"{"jsonrpc":"2.0","id":999,"method":"window/workDoneProgress/create","params":{}}"#,
+        );
+        let r1 = framed(r#"{"jsonrpc":"2.0","id":1,"result":{"v":1}}"#);
+        let r2 = framed(r#"{"jsonrpc":"2.0","id":2,"result":{"v":2}}"#);
+        let mut client = fake_server(&format!("{note}{srv_req}{r1}{r2}"));
+
+        let replies = client
+            .request_batch(&[("m", serde_json::json!({})), ("m", serde_json::json!({}))])
+            .expect("batch sends");
+        assert_eq!(replies.len(), 2);
+        assert_eq!(replies[0].as_ref().unwrap()["v"], 1);
+        assert_eq!(replies[1].as_ref().unwrap()["v"], 2);
+    }
 }

--- a/crates/cartog-lsp/src/client.rs
+++ b/crates/cartog-lsp/src/client.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Child, ChildStdin, ChildStdout};
 use std::sync::mpsc;
@@ -25,7 +25,8 @@ pub struct LspClient {
     _reader_handle: JoinHandle<()>,
     next_id: i64,
     timeout: Duration,
-    /// Notifications buffered during `read_response` for later consumption by `recv_until`.
+    /// Notifications buffered during a synchronous `send_request` for later
+    /// consumption by `recv_until` (used only during the initialize handshake).
     buffered_notifications: VecDeque<Value>,
 }
 
@@ -48,8 +49,18 @@ impl LspClient {
         })
     }
 
-    /// Send a JSON-RPC request and wait for the matching response.
+    /// Send a JSON-RPC request and wait for the matching response. Used for the
+    /// one-at-a-time handshake traffic (`initialize`, `shutdown`); pipelined
+    /// definition queries go through [`Self::request_batch`].
     pub fn send_request<P: Serialize>(&mut self, method: &str, params: P) -> Result<Value> {
+        let id = self.write_request(method, params)?;
+        self.collect_responses(&[id], Instant::now() + self.timeout)
+            .pop()
+            .expect("collect_responses returns one result per id")
+    }
+
+    /// Write a request frame and return its id, without waiting for the reply.
+    fn write_request<P: Serialize>(&mut self, method: &str, params: P) -> Result<i64> {
         let id = self.next_id;
         self.next_id += 1;
         let msg = serde_json::json!({
@@ -59,7 +70,35 @@ impl LspClient {
             "params": params,
         });
         self.write_message(&msg)?;
-        self.read_response(id)
+        Ok(id)
+    }
+
+    /// Send a batch of `(method, params)` requests pipelined — all are written
+    /// before any response is read, so their round-trips overlap — then collect
+    /// the replies in input order. Returns one `Result<Value>` per request.
+    ///
+    /// A single shared deadline (`self.timeout`) bounds the whole batch, so a
+    /// stalled or out-of-order server cannot make the cost scale with the batch
+    /// size: once it elapses, every still-missing request resolves to a timeout
+    /// `Err`. Notifications are drained and discarded (no unbounded buffering),
+    /// and responses for ids not in this batch are ignored — nothing leaks past
+    /// the call. The caller is responsible for keeping the batch small enough to
+    /// bound in-flight memory and stdin backpressure (see `definitions_batch`).
+    pub fn request_batch<P: Serialize>(
+        &mut self,
+        requests: &[(&str, P)],
+    ) -> Result<Vec<Result<Value>>> {
+        let mut ids = Vec::with_capacity(requests.len());
+        for (method, params) in requests {
+            ids.push(self.write_request(method, params)?);
+        }
+        Ok(self.collect_responses(&ids, Instant::now() + self.timeout))
+    }
+
+    /// Shorten the per-batch timeout (tests only) so stall paths don't wait 10s.
+    #[cfg(test)]
+    fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
     }
 
     /// Send a JSON-RPC notification (no response expected).
@@ -127,52 +166,91 @@ impl LspClient {
         Ok(())
     }
 
-    fn read_response(&mut self, expected_id: i64) -> Result<Value> {
-        let deadline = Instant::now() + self.timeout;
+    /// Read replies for `ids` (already sent) under one shared `deadline`,
+    /// returning one `Result<Value>` per id in input order.
+    ///
+    /// Out-of-order replies are matched by id, so the server may answer in any
+    /// order. Once `deadline` elapses, every still-unfilled slot is a timeout
+    /// `Err` — a single bound for the whole batch, not per id, so a stalled
+    /// server costs one `timeout`, never `n × timeout`. A disconnect fails all
+    /// remaining slots at once. Notifications are buffered for `recv_until` only
+    /// in the single-id (handshake) case; in batch mode they are discarded so a
+    /// chatty server can't grow `buffered_notifications` without bound. Replies
+    /// for ids not in this batch are dropped, so nothing leaks past the call.
+    fn collect_responses(&mut self, ids: &[i64], deadline: Instant) -> Vec<Result<Value>> {
+        let buffer_notifications = ids.len() == 1; // handshake path feeds recv_until
+        let mut slot: HashMap<i64, usize> =
+            ids.iter().enumerate().map(|(i, &id)| (id, i)).collect();
+        let mut out: Vec<Option<Result<Value>>> = (0..ids.len()).map(|_| None).collect();
+        let mut filled = 0usize;
 
-        loop {
+        while filled < ids.len() {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                bail!("timeout waiting for response to request {expected_id}");
+                break; // deadline hit — leftover slots become timeouts below
             }
 
             let msg = match self.receiver.recv_timeout(remaining) {
                 Ok(msg) => msg,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    bail!("timeout waiting for response to request {expected_id}");
-                }
+                Err(mpsc::RecvTimeoutError::Timeout) => break,
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    bail!("LSP server disconnected");
+                    // Server gone: fail every outstanding slot now, no waiting.
+                    for entry in out.iter_mut() {
+                        if entry.is_none() {
+                            *entry = Some(Err(anyhow::anyhow!("LSP server disconnected")));
+                        }
+                    }
+                    return out.into_iter().map(Option::unwrap).collect();
                 }
             };
 
-            // Server-initiated request — auto-respond per LSP spec
             if is_server_request(&msg) {
                 let _ = self.auto_respond(&msg);
                 continue;
             }
-
-            // Server notification — buffer for later consumption by recv_until
             if is_notification(&msg) {
-                self.buffered_notifications.push_back(msg);
+                if buffer_notifications {
+                    self.buffered_notifications.push_back(msg);
+                }
+                // batch mode: drop it — nothing drains buffered_notifications
+                // during resolution, so buffering would grow without bound.
                 continue;
             }
 
-            // Response with matching ID — return it
-            if let Some(id) = msg.get("id") {
-                if id.as_i64() == Some(expected_id) {
-                    if let Some(error) = msg.get("error") {
-                        let message = error
-                            .get("message")
-                            .and_then(|m| m.as_str())
-                            .unwrap_or("unknown LSP error");
-                        bail!("LSP error: {message}");
-                    }
-                    return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
-                }
-            }
-            // Response with wrong ID — discard (shouldn't happen in practice)
+            // A response. Match it to a slot in this batch; ignore any other id
+            // (a stale/duplicate/late reply for a request we no longer await).
+            let Some(id) = msg.get("id").and_then(Value::as_i64) else {
+                continue;
+            };
+            let Some(i) = slot.remove(&id) else {
+                continue;
+            };
+            let outcome = match msg.get("error") {
+                Some(error) => Err(anyhow::anyhow!(
+                    "LSP error: {}",
+                    error
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown LSP error")
+                )),
+                None => Ok(msg.get("result").cloned().unwrap_or(Value::Null)),
+            };
+            out[i] = Some(outcome);
+            filled += 1;
         }
+
+        // Any slot still empty timed out (or the deadline elapsed before send).
+        out.into_iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                entry.unwrap_or_else(|| {
+                    Err(anyhow::anyhow!(
+                        "timeout waiting for response to request {}",
+                        ids[i]
+                    ))
+                })
+            })
+            .collect()
     }
 
     /// Respond to a server-initiated request with `result: null`.
@@ -351,5 +429,100 @@ mod tests {
             .map(|s| s.success())
             .unwrap_or(false);
         assert!(!still_alive, "Drop must kill+reap the child (pid {pid})");
+    }
+
+    /// Frame a JSON body the way an LSP server would, for the fake-server tests.
+    #[cfg(unix)]
+    fn framed(body: &str) -> String {
+        format!("Content-Length: {}\r\n\r\n{body}", body.len())
+    }
+
+    /// Spawn a fake LSP server that writes `frames` to stdout then idles.
+    /// `exec sleep` REPLACES the shell (no forked child), so `LspClient::Drop`
+    /// kill+reap of the single process leaves nothing orphaned. stdin stays
+    /// open (the client owns the write end), so the reader sees no EOF until
+    /// the process is killed on Drop.
+    #[cfg(unix)]
+    fn fake_server(frames: &str) -> LspClient {
+        use std::process::{Command, Stdio};
+        let script = format!("printf '%s' '{frames}'; exec sleep 600");
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn fake server");
+        LspClient::new(child).expect("client over fake server")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_batch_matches_out_of_order_replies_by_id() {
+        // Server answers the SECOND request (id 2) before the first (id 1).
+        // request_batch must still return them in input order.
+        let r2 = framed(r#"{"jsonrpc":"2.0","id":2,"result":{"v":2}}"#);
+        let r1 = framed(r#"{"jsonrpc":"2.0","id":1,"result":{"v":1}}"#);
+        let mut client = fake_server(&format!("{r2}{r1}"));
+
+        let replies = client
+            .request_batch(&[("m", serde_json::json!({})), ("m", serde_json::json!({}))])
+            .expect("batch sends");
+        assert_eq!(replies.len(), 2);
+        assert_eq!(replies[0].as_ref().unwrap()["v"], 1);
+        assert_eq!(replies[1].as_ref().unwrap()["v"], 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_batch_isolates_per_request_error() {
+        // id 1 errors, id 2 succeeds — the error must not sink id 2.
+        let e1 = framed(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"boom"}}"#);
+        let r2 = framed(r#"{"jsonrpc":"2.0","id":2,"result":{"v":2}}"#);
+        let mut client = fake_server(&format!("{e1}{r2}"));
+
+        let replies = client
+            .request_batch(&[("m", serde_json::json!({})), ("m", serde_json::json!({}))])
+            .expect("batch sends");
+        assert!(replies[0]
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("boom"));
+        assert_eq!(replies[1].as_ref().unwrap()["v"], 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_batch_shares_one_deadline_for_missing_replies() {
+        // Server answers only id 2; ids 1 and 3 never come. A single shared
+        // deadline must cap the whole batch at ~one timeout (not 3×), and the
+        // missing slots return timeout Errs in input order.
+        let r2 = framed(r#"{"jsonrpc":"2.0","id":2,"result":{"v":2}}"#);
+        let mut client = fake_server(&r2);
+        // Generous enough to clear process-spawn latency, tight enough that
+        // 3 × timeout would blow the assertion below.
+        let timeout = Duration::from_millis(1500);
+        client.set_timeout(timeout);
+
+        let started = Instant::now();
+        let replies = client
+            .request_batch(&[
+                ("m", serde_json::json!({})),
+                ("m", serde_json::json!({})),
+                ("m", serde_json::json!({})),
+            ])
+            .expect("batch sends");
+        let elapsed = started.elapsed();
+
+        assert_eq!(replies.len(), 3);
+        assert!(replies[0].is_err(), "id 1 missing → timeout");
+        assert_eq!(replies[1].as_ref().unwrap()["v"], 2);
+        assert!(replies[2].is_err(), "id 3 missing → timeout");
+        // One shared deadline: the whole batch waits ~timeout, never 3×.
+        assert!(
+            elapsed < timeout * 2,
+            "batch took {elapsed:?}; deadline should be shared, not per-id"
+        );
     }
 }

--- a/crates/cartog-lsp/src/lib.rs
+++ b/crates/cartog-lsp/src/lib.rs
@@ -143,15 +143,41 @@ pub fn lsp_resolve_edges(
 
             let lines: Vec<&str> = content.lines().collect();
 
-            for edge in file_edges {
-                let col = match find_column_in_line(&lines, edge.line, &edge.target_name) {
-                    Some(c) => c,
-                    None => continue,
-                };
+            // Pair each edge whose target column we can locate with its LSP
+            // position in ONE vec, so the edge↔position↔outcome correspondence
+            // can't drift, then resolve the batch (round-trips overlap).
+            let batch: Vec<(&UnresolvedEdge, (u32, u32))> = file_edges
+                .iter()
+                .filter_map(|&edge| {
+                    find_column_in_line(&lines, edge.line, &edge.target_name)
+                        .map(|col| (edge, (edge.line.saturating_sub(1), col))) // 1-based → 0-based
+                })
+                .collect();
+            let positions: Vec<(u32, u32)> = batch.iter().map(|&(_, pos)| pos).collect();
 
-                let lsp_line = edge.line.saturating_sub(1); // cartog 1-based → LSP 0-based
+            let outcomes = match manager.definitions_batch(language, file_path, &positions) {
+                Ok(o) => o,
+                Err(e) => {
+                    // The send pipe broke mid-batch (server gone). Treat like a
+                    // death: never mark, stop this language.
+                    tracing::debug!("definition batch failed for {file_path}: {e:#}");
+                    if !manager.is_alive(language) {
+                        tracing::warn!(
+                            "{language} LSP server died — remaining {language} edges resolved \
+                             via heuristics only. Rerun with --no-lsp to skip LSP entirely."
+                        );
+                        server_died = true;
+                    }
+                    let _ = manager.close_file(language, file_path);
+                    if server_died {
+                        break;
+                    }
+                    continue;
+                }
+            };
 
-                match manager.definition(language, file_path, lsp_line, col) {
+            for ((edge, _pos), outcome) in batch.iter().zip(outcomes) {
+                match outcome {
                     Ok(Some(DefinitionOutcome::InRoot(loc))) => {
                         match db.find_symbol_at_location(&loc.file_path, loc.line) {
                             Ok(Some(symbol_id)) => {

--- a/crates/cartog-lsp/src/manager.rs
+++ b/crates/cartog-lsp/src/manager.rs
@@ -13,6 +13,11 @@ use super::servers::{find_servers, is_binary_available};
 /// Override with `CARTOG_LSP_READY_TIMEOUT_SECS`.
 const DEFAULT_READY_TIMEOUT_SECS: u64 = 20;
 
+/// How many `textDocument/definition` requests `definitions_batch` keeps in
+/// flight at once. Caps in-flight memory and stdin backpressure while still
+/// overlapping round-trips; large files resolve in windows of this size.
+const DEFINITION_BATCH_WINDOW: usize = 64;
+
 /// Read the ready-timeout from env, falling back to the default.
 fn ready_timeout_secs() -> u64 {
     std::env::var("CARTOG_LSP_READY_TIMEOUT_SECS")
@@ -209,37 +214,56 @@ impl LspManager {
         Ok(())
     }
 
-    /// Send textDocument/definition and return the target outcome.
+    /// Resolve many `textDocument/definition` positions in one file. Requests
+    /// are pipelined in windows of `DEFINITION_BATCH_WINDOW` (sent together,
+    /// then collected) so round-trips overlap without an unbounded number of
+    /// in-flight requests flooding the server's stdin or this client's memory.
+    /// Returns one result per input position, in order; a per-position `Err`
+    /// (timeout, LSP error) is isolated to that position. Positions are
+    /// `(line, character)`, LSP 0-based.
     ///
-    /// `Ok(None)` means the server gave no parseable answer (truly unresolvable —
-    /// typo, dyn dispatch, macro, or a non-`file://` URI like jdtls's `jdt://`).
-    /// `Ok(Some(InRoot(..)))` means the target lives inside the indexed root.
-    /// `Ok(Some(External))` means the target lives outside the root (stdlib,
-    /// deps, node_modules) — caller should mark `state=3`. See
-    /// [`DefinitionOutcome::External`].
-    pub fn definition(
+    /// Each successful outcome: `Ok(None)` = no parseable answer (truly
+    /// unresolvable — typo, dyn dispatch, macro, or a non-`file://` URI like
+    /// jdtls's `jdt://`); `Ok(Some(InRoot(..)))` = target inside the indexed
+    /// root; `Ok(Some(External))` = target outside the root (stdlib, deps,
+    /// node_modules), caller should mark `state=3`.
+    pub fn definitions_batch(
         &mut self,
         language: &str,
         file_path: &str,
-        line: u32,
-        character: u32,
-    ) -> Result<Option<DefinitionOutcome>> {
+        positions: &[(u32, u32)],
+    ) -> Result<Vec<Result<Option<DefinitionOutcome>>>> {
+        // Clone root so the per-window parse can borrow it while `client` holds
+        // a `&mut` of `self.clients`.
+        let root = self.root.clone();
+        let uri = path_to_uri(&root.join(file_path));
         let (client, _) = self
             .clients
             .get_mut(language)
             .with_context(|| format!("no running LSP client for {language}"))?;
 
-        let uri = path_to_uri(&self.root.join(file_path));
-
-        let result = client.send_request(
-            "textDocument/definition",
-            serde_json::json!({
-                "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character },
-            }),
-        )?;
-
-        parse_definition_response(&result, &self.root)
+        let mut out = Vec::with_capacity(positions.len());
+        for window in positions.chunks(DEFINITION_BATCH_WINDOW) {
+            let params: Vec<(&str, Value)> = window
+                .iter()
+                .map(|&(line, character)| {
+                    (
+                        "textDocument/definition",
+                        serde_json::json!({
+                            "textDocument": { "uri": uri },
+                            "position": { "line": line, "character": character },
+                        }),
+                    )
+                })
+                .collect();
+            // A write failure aborts the whole call (the pipe is broken); the
+            // caller treats that as a likely server death.
+            let replies = client.request_batch(&params)?;
+            for reply in replies {
+                out.push(reply.and_then(|result| parse_definition_response(&result, &root)));
+            }
+        }
+        Ok(out)
     }
 
     /// Notify the server that a file is open (required before definition requests).


### PR DESCRIPTION
## Summary

Resolve a file's `textDocument/definition` queries in windows of 64 sent together then collected, so round-trips overlap instead of serializing. **~33% faster full re-index** on a mixed ~98k-edge repo (5:12 → 3:29), same resolution counts within server-warmup variance.

## Changes

- **`LspClient::request_batch`** encapsulates send-all-then-collect. The previous public `send_request_async`/`await_response` split (which leaked protocol state and an unbounded `buffered_responses` map) is gone.
- **`collect_responses`** matches replies by id in any order under **one shared per-window deadline**, so a stalled or out-of-order server costs one timeout, not `N`. A disconnect fails every outstanding slot at once.
- **Notifications** are discarded in batch mode (only the single-id handshake path buffers them for `recv_until`), closing the `buffered_notifications` growth a chatty server caused during resolution.
- **`definitions_batch`** chunks positions into windows of `DEFINITION_BATCH_WINDOW` (64) to bound in-flight memory and stdin backpressure.
- Removed the now-dead `LspManager::definition` (singular); `lib.rs` pairs each edge with its position in one vec so edge/position/outcome can't drift.

## Tests

Added: out-of-order reply matching, per-request error isolation, and a shared-deadline test (a partial batch caps at ~one timeout, not N×). Fake-server tests use `exec sleep` so no child process is orphaned on teardown.

## Verification

Full workspace tests (32 suites), `cargo fmt --check`, `clippy --all-targets -D warnings` (default + `--no-default-features`), doctests, and `cargo doc` all clean. Benchmarked on a ~98k-edge mixed repo: 312s → 209s wall, CPU 56% → 77%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)