### PR TITLE
feat(output): add --compact JSON mode + MCP compact-by-default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ Consequences to respect on every change:
 - **CI/CD**: fmt, clippy, test, coverage, release to crates.io + GitHub Releases
 - **Centrality**: in-degree ranking — search results prefer highly-referenced symbols
 - **Codebase map**: `cartog map --tokens N` produces budget-aware file tree + top symbols
-- **Token budget**: `--tokens N` global flag for context-window-aware output truncation
+- **Token budget**: `--tokens N` global flag for context-window-aware output truncation (human output only). `--compact` global flag strips heavy fields (bodies, docstrings, cache hashes) from `--json` to save agent tokens (keeps ids/names/kinds/locations/signatures/scores; no-op without `--json`). MCP is **compact by default** (symbol noise trimmed; `cartog_rag_search`/`cartog_trace` bodies bounded to a snippet; `cartog_context` keeps budgeted bodies) — set `CARTOG_MCP_COMPACT=0` to restore full bodies
 - **Recent changes**: `cartog changes` shows symbols affected by recent git commits
 - **Call-path trace**: `cartog trace <from> <to>` / `cartog_trace` returns the shortest `calls` path between two symbols with each hop's body inline (forward BFS, static call edges only)
 - **Task-context bundle**: `cartog context <task>` / `cartog_context` fuses hybrid search seeds + 1-hop neighbors + seed-file centrality into a token-budgeted bundle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "proptest",
  "schemars",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/cartog-core/Cargo.toml
+++ b/crates/cartog-core/Cargo.toml
@@ -18,6 +18,7 @@ schemars = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cartog-core/src/lib.rs
+++ b/crates/cartog-core/src/lib.rs
@@ -47,7 +47,9 @@ pub struct Symbol {
     pub is_async: bool,
     pub docstring: Option<String>,
     pub in_degree: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub subtree_hash: Option<String>,
 }
 
@@ -127,6 +129,32 @@ impl Symbol {
     pub fn with_docstring(mut self, docstring: Option<String>) -> Self {
         self.docstring = docstring;
         self
+    }
+}
+
+/// Strip heavy, low-value fields from a value before JSON serialization to save
+/// agent tokens. Compact output keeps the navigable shape (ids, names, kinds,
+/// locations, scores) and drops bodies, docstrings, and cache hashes.
+pub trait Compact {
+    /// Drop heavy fields in place. Idempotent.
+    fn compact_in_place(&mut self);
+}
+
+impl Compact for Symbol {
+    /// Drops `docstring` and the cache hashes; keeps `signature` (a small,
+    /// high-value shape hint when the body is gone).
+    fn compact_in_place(&mut self) {
+        self.docstring = None;
+        self.content_hash = None;
+        self.subtree_hash = None;
+    }
+}
+
+impl<T: Compact> Compact for Vec<T> {
+    fn compact_in_place(&mut self) {
+        for item in self.iter_mut() {
+            item.compact_in_place();
+        }
     }
 }
 
@@ -407,6 +435,32 @@ pub fn detect_language(path: &Path) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compact_clears_drop_set_keeps_signature() {
+        let mut sym = Symbol::new("f", SymbolKind::Function, "a.rs", 1, 2, 0, 10, None)
+            .with_signature(Some("fn f() -> u32".into()))
+            .with_docstring(Some("does a thing".into()));
+        sym.content_hash = Some("abc".into());
+        sym.subtree_hash = Some("def".into());
+
+        sym.compact_in_place();
+
+        assert_eq!(sym.signature.as_deref(), Some("fn f() -> u32"));
+        assert_eq!(sym.name, "f");
+        assert_eq!(sym.docstring, None);
+        assert_eq!(sym.content_hash, None);
+        assert_eq!(sym.subtree_hash, None);
+    }
+
+    #[test]
+    fn hash_fields_skip_serializing_when_none() {
+        let sym = Symbol::new("f", SymbolKind::Function, "a.rs", 1, 2, 0, 10, None);
+        let v = serde_json::to_value(&sym).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("content_hash"));
+        assert!(!obj.contains_key("subtree_hash"));
+    }
 
     #[test]
     fn is_cancelled_matches_bare_and_context_wrapped() {

--- a/crates/cartog-mcp/src/lib.rs
+++ b/crates/cartog-mcp/src/lib.rs
@@ -23,7 +23,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use cartog_core::EdgeKind;
+use cartog_core::{Compact, EdgeKind};
 use cartog_db::{Database, PinnedAttach, MAX_SEARCH_LIMIT};
 use cartog_indexer as indexer;
 use cartog_rag as rag;
@@ -608,6 +608,23 @@ fn mcp_max_bytes() -> usize {
         .and_then(|v| v.parse().ok())
         .filter(|&n: &usize| n > 256) // sanity: don't let a typo trim everything
         .unwrap_or(DEFAULT_MCP_MAX_BYTES)
+}
+
+/// Whether MCP tools strip heavy fields from their JSON output.
+///
+/// Agents are the only MCP consumer and the server already assumes token
+/// pressure (the [`mcp_max_bytes`] cap). Compact is therefore the default:
+/// drop docstrings and cache hashes from symbols, and bound `rag_search` bodies
+/// to a snippet. Set `CARTOG_MCP_COMPACT=0` (or `false`/`no`/`off`) to restore
+/// full bodies.
+fn mcp_compact() -> bool {
+    match std::env::var("CARTOG_MCP_COMPACT") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => true,
+    }
 }
 
 /// Suggest a narrower tool when we've truncated a large response.
@@ -1404,9 +1421,12 @@ impl CartogServer {
             let db = db.lock().map_err(|_| {
                 mcp_err("internal error: database lock poisoned (server restart required)")
             })?;
-            let symbols = db
+            let mut symbols = db
                 .outline(&file)
                 .map_err(|e| mcp_err(format!("outline query failed: {e}")))?;
+            if mcp_compact() {
+                symbols.compact_in_place();
+            }
 
             let json = serde_json::to_string_pretty(&symbols)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -1457,9 +1477,17 @@ impl CartogServer {
                 .refs(&name, kind_filter)
                 .map_err(|e| mcp_err(format!("refs query failed: {e}")))?;
 
+            let compact = mcp_compact();
             let entries: Vec<RefEntry> = results
                 .into_iter()
-                .map(|(edge, sym)| RefEntry { edge, source: sym })
+                .map(|(edge, mut sym)| {
+                    if compact {
+                        if let Some(s) = sym.as_mut() {
+                            s.compact_in_place();
+                        }
+                    }
+                    RefEntry { edge, source: sym }
+                })
                 .collect();
 
             let json = serde_json::to_string_pretty(&entries)
@@ -1579,11 +1607,20 @@ impl CartogServer {
                 .trace(&from, &to, depth)
                 .map_err(|e| mcp_err(format!("trace query failed: {e}")))?;
 
+            let compact = mcp_compact();
             let hops: Vec<TraceHop> = path
                 .iter()
                 .flatten()
                 .map(|h| TraceHop {
-                    body: trace_hop_body(&db, &cwd, &h.source_id),
+                    // Compact bounds each hop body to a snippet (preview), keeping
+                    // the path readable without shipping full function bodies.
+                    body: trace_hop_body(&db, &cwd, &h.source_id).map(|b| {
+                        if compact {
+                            rag::search::snippet(&b)
+                        } else {
+                            b
+                        }
+                    }),
                     source_name: h.source_name.clone(),
                     target_name: h.target_name.clone(),
                     kind: h.kind.to_string(),
@@ -1738,9 +1775,12 @@ impl CartogServer {
             let file_filter = validated_file.as_deref();
             debug!(query = %query, kind = ?kind_filter, limit, "search");
             let db = db.lock().map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
-            let symbols = db
+            let mut symbols = db
                 .search(&query, kind_filter, file_filter, limit)
                 .map_err(|e| mcp_err(format!("search failed: {e}")))?;
+            if mcp_compact() {
+                symbols.compact_in_place();
+            }
 
             let json = serde_json::to_string_pretty(&symbols)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -1872,9 +1912,12 @@ impl CartogServer {
             let files = db
                 .all_files()
                 .map_err(|e| mcp_err(format!("files query failed: {e}")))?;
-            let top_symbols = db
+            let mut top_symbols = db
                 .top_symbols(limit)
                 .map_err(|e| mcp_err(format!("top_symbols query failed: {e}")))?;
+            if mcp_compact() {
+                top_symbols.compact_in_place();
+            }
 
             let result = MapResult { files, top_symbols };
 
@@ -1927,9 +1970,12 @@ impl CartogServer {
                 .map_err(|e| mcp_err(format!("git changes failed: {e}")))?;
 
             let db = db.lock().map_err(|_| mcp_err("internal error: database lock poisoned (server restart required)"))?;
-            let symbols = db
+            let mut symbols = db
                 .symbols_for_files(&changed_files, kind_filter)
                 .map_err(|e| mcp_err(format!("symbols query failed: {e}")))?;
+            if mcp_compact() {
+                symbols.compact_in_place();
+            }
 
             let result = cartog_core::ChangesResult {
                 changed_files,
@@ -2088,7 +2134,7 @@ impl CartogServer {
             let mut reranker = reranker
                 .lock()
                 .map_err(|_| mcp_err("internal error: reranker lock poisoned (server restart required)"))?;
-            let result = match reranker.as_mut() {
+            let mut result = match reranker.as_mut() {
                 Some(r) => rag::search::hybrid_search(
                     &db, &query, limit, kind_filter, provider.as_mut(), Some(r.as_mut()),
                 ),
@@ -2096,6 +2142,11 @@ impl CartogServer {
                     &db, &query, limit, kind_filter, provider.as_mut(), None,
                 ),
             }.map_err(|e| mcp_err(format!("semantic search failed: {e}")))?;
+            // Compact-by-default: bound each body to a snippet (the tool advertises
+            // "snippet excerpts"). CARTOG_MCP_COMPACT=0 restores full bodies.
+            if mcp_compact() {
+                result.snippet_in_place();
+            }
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -2167,6 +2218,12 @@ impl CartogServer {
                 ),
             }
             .map_err(|e| mcp_err(format!("context build failed: {e}")))?;
+            // Compact trims per-entry symbol noise but KEEPS the budgeted bodies —
+            // this tool's whole value is its inline bodies.
+            let mut result = result;
+            if mcp_compact() {
+                result.compact_in_place();
+            }
 
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| mcp_err(format!("serialization failed: {e}")))?;
@@ -2227,6 +2284,37 @@ mod tests {
             stdout: stdout.as_bytes().to_vec(),
             stderr: stderr.as_bytes().to_vec(),
         }
+    }
+
+    #[test]
+    fn mcp_compact_defaults_on_and_parses_opt_out() {
+        let _g = test_validate_call_counter::SERIAL.blocking_lock();
+        let prev = std::env::var_os("CARTOG_MCP_COMPACT");
+
+        std::env::remove_var("CARTOG_MCP_COMPACT");
+        assert!(mcp_compact(), "compact is the default when unset");
+
+        for off in ["0", "false", "no", "off", "OFF", " false "] {
+            std::env::set_var("CARTOG_MCP_COMPACT", off);
+            assert!(!mcp_compact(), "{off:?} must disable compact");
+        }
+        for on in ["1", "true", "yes", "anything"] {
+            std::env::set_var("CARTOG_MCP_COMPACT", on);
+            assert!(mcp_compact(), "{on:?} must keep compact on");
+        }
+
+        match prev {
+            Some(v) => std::env::set_var("CARTOG_MCP_COMPACT", v),
+            None => std::env::remove_var("CARTOG_MCP_COMPACT"),
+        }
+    }
+
+    #[test]
+    fn rag_snippet_bounds_body_length() {
+        // The MCP rag_search default snips bodies via rag::search::snippet.
+        let long = "y".repeat(rag::search::SNIPPET_MAX_BYTES * 3);
+        let s = rag::search::snippet(&long);
+        assert!(s.len() <= rag::search::SNIPPET_MAX_BYTES);
     }
 
     // ── discover_plugin_pin tests (cartog_update arms the pin) ──

--- a/crates/cartog-rag/src/context.rs
+++ b/crates/cartog-rag/src/context.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use serde::Serialize;
 
-use cartog_core::Symbol;
+use cartog_core::{Compact, Symbol};
 use cartog_db::Database;
 
 use crate::provider::{EmbeddingProvider, RerankerProvider};
@@ -45,6 +45,21 @@ pub struct TaskContext {
     /// Approximate tokens occupied by the attached bodies (`bytes / 4`, min 1
     /// per non-empty body).
     pub approx_tokens: u32,
+}
+
+impl Compact for ContextEntry {
+    /// Trims the inner symbol only. Unlike [`crate::search::SearchResult`], the
+    /// body `content` is **kept** — a task-context bundle's whole value is its
+    /// budgeted bodies, and the budget already caps them.
+    fn compact_in_place(&mut self) {
+        self.symbol.compact_in_place();
+    }
+}
+
+impl Compact for TaskContext {
+    fn compact_in_place(&mut self) {
+        self.entries.compact_in_place();
+    }
 }
 
 /// Tunables for [`build_task_context`].
@@ -243,6 +258,27 @@ mod tests {
     use super::*;
     use crate::provider::test_utils::MockEmbeddingProvider;
     use cartog_core::{Edge, EdgeKind, Symbol, SymbolKind};
+
+    #[test]
+    fn compact_context_keeps_body_but_trims_symbol() {
+        let mut sym = Symbol::new("f", SymbolKind::Function, "a.py", 1, 2, 0, 10, None);
+        sym.docstring = Some("doc".into());
+        sym.content_hash = Some("h".into());
+        let mut entry = ContextEntry {
+            symbol: sym,
+            reason: ContextReason::Seed,
+            score: 1.0,
+            content: Some("def f(): ...".into()),
+        };
+
+        entry.compact_in_place();
+
+        // Body is kept (context's whole value is budgeted bodies)...
+        assert_eq!(entry.content.as_deref(), Some("def f(): ..."));
+        // ...but the inner symbol's noise is trimmed.
+        assert_eq!(entry.symbol.docstring, None);
+        assert_eq!(entry.symbol.content_hash, None);
+    }
 
     fn insert(db: &Database, name: &str, kind: SymbolKind, file: &str, content: &str) -> Symbol {
         let sym = Symbol::new(name, kind, file, 1, 11, 0, content.len() as u32, None);

--- a/crates/cartog-rag/src/search.rs
+++ b/crates/cartog-rag/src/search.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use serde::Serialize;
 
-use cartog_core::{Symbol, SymbolKind};
+use cartog_core::{Compact, Symbol, SymbolKind};
 use cartog_db::Database;
 
 /// Filter for symbol kinds in search results.
@@ -81,6 +81,67 @@ pub struct HybridSearchResult {
     pub fts_count: u32,
     pub vec_count: u32,
     pub merged_count: u32,
+}
+
+/// Maximum bytes for a compact-mode body preview snippet (MCP `rag_search`
+/// default). Keeps a code preview while bounding token cost; the tool advertises
+/// "snippet excerpts", so this makes the output match the description.
+pub const SNIPPET_MAX_BYTES: usize = 500;
+
+/// Truncate `content` to a [`SNIPPET_MAX_BYTES`] preview at a UTF-8 boundary,
+/// appending an ellipsis marker when cut. Unlike [`super::indexer::compact_embedding_text`],
+/// this preserves the raw code (including comments) — it is a human/agent preview,
+/// not embedding text.
+#[must_use]
+pub fn snippet(content: &str) -> String {
+    if content.len() <= SNIPPET_MAX_BYTES {
+        return content.to_string();
+    }
+    let marker = "\n…";
+    let target = SNIPPET_MAX_BYTES.saturating_sub(marker.len());
+    let cut = (target.saturating_sub(3)..=target)
+        .rev()
+        .find(|&i| content.is_char_boundary(i))
+        .unwrap_or(0);
+    let mut out = content[..cut].to_string();
+    out.push_str(marker);
+    out
+}
+
+impl cartog_core::Compact for SearchResult {
+    /// Drops the full body `content` and trims the inner symbol. Use [`SearchResult::snippet_in_place`]
+    /// to keep a bounded preview instead of dropping the body entirely.
+    fn compact_in_place(&mut self) {
+        self.content = None;
+        self.symbol.compact_in_place();
+    }
+}
+
+impl SearchResult {
+    /// Compact variant that keeps a bounded body preview (snippet) instead of
+    /// dropping `content` entirely. Trims the inner symbol like [`SearchResult::compact_in_place`].
+    pub fn snippet_in_place(&mut self) {
+        if let Some(body) = self.content.take() {
+            self.content = Some(snippet(&body));
+        }
+        self.symbol.compact_in_place();
+    }
+}
+
+impl cartog_core::Compact for HybridSearchResult {
+    fn compact_in_place(&mut self) {
+        self.results.compact_in_place();
+    }
+}
+
+impl HybridSearchResult {
+    /// Compact variant that keeps bounded body previews for each result
+    /// (MCP `rag_search` default).
+    pub fn snippet_in_place(&mut self) {
+        for r in &mut self.results {
+            r.snippet_in_place();
+        }
+    }
 }
 
 /// Reciprocal Rank Fusion: merge multiple ranked lists into a single ranking.
@@ -1463,6 +1524,44 @@ mod tests {
             rerank_score: rerank,
             sources: vec![Source::Fts5],
         }
+    }
+
+    #[test]
+    fn compact_drops_content_and_trims_symbol() {
+        let mut r = make_result("f", 0.5, Some(1.0), Some("fn f() { body }"));
+        r.symbol.docstring = Some("doc".into());
+        r.symbol.content_hash = Some("h".into());
+
+        r.compact_in_place();
+
+        assert_eq!(r.content, None);
+        assert_eq!(r.symbol.docstring, None);
+        assert_eq!(r.symbol.content_hash, None);
+        // Scores and locations are preserved.
+        assert_eq!(r.rrf_score, 0.5);
+        assert_eq!(r.symbol.name, "f");
+    }
+
+    #[test]
+    fn snippet_keeps_short_body_and_truncates_long_body() {
+        let short = "fn f() {}";
+        assert_eq!(snippet(short), short);
+
+        let long = "x".repeat(SNIPPET_MAX_BYTES * 2);
+        let s = snippet(&long);
+        assert!(s.len() <= SNIPPET_MAX_BYTES);
+        assert!(s.ends_with('…'));
+    }
+
+    #[test]
+    fn snippet_in_place_keeps_bounded_preview() {
+        let body = "fn f() {\n".to_string() + &"    let x = 1;\n".repeat(100);
+        let mut r = make_result("f", 0.5, Some(1.0), Some(&body));
+
+        r.snippet_in_place();
+
+        let content = r.content.expect("snippet keeps a preview");
+        assert!(content.len() <= SNIPPET_MAX_BYTES);
     }
 
     #[test]

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -36,6 +36,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub tokens: Option<u32>,
 
+    /// Drop heavy fields (bodies, docstrings, cache hashes) from --json output to
+    /// save agent tokens. No-op without --json.
+    #[arg(long, global = true)]
+    pub compact: bool,
+
     /// Path to the cartog database (overrides .cartog.toml and auto-detection)
     #[arg(long, global = true, value_name = "PATH", env = "CARTOG_DB")]
     pub db: Option<PathBuf>,

--- a/crates/cartog/src/commands/mod.rs
+++ b/crates/cartog/src/commands/mod.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::cli::{EdgeKindFilter, SymbolKindFilter};
 use crate::config::CartogConfig;
-use cartog_core::{EdgeKind, SymbolKind};
+use cartog_core::{Compact, EdgeKind, SymbolKind};
 use cartog_db::{Database, MAX_SEARCH_LIMIT};
 use cartog_indexer as indexer;
 use cartog_rag as rag;
@@ -445,15 +445,19 @@ pub fn cmd_outline(
     db_path: &Path,
     file: &str,
     json: bool,
+    compact: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
     let db = open_db(db_path, embedding_dim)?;
-    let symbols = db.outline(file)?;
+    let mut symbols = db.outline(file)?;
     // Don't count empty results — an empty-index call or a typo'd file path
     // didn't actually save the user any tokens vs grep + read.
     if !symbols.is_empty() {
         db.log_query("outline", "cli");
+    }
+    if compact {
+        symbols.compact_in_place();
     }
     let file = file.to_string();
     output(&symbols, json, token_budget, |syms| {
@@ -571,12 +575,14 @@ pub fn cmd_impact(
 }
 
 /// Find a call path between two symbols, with each hop's body inline.
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_trace(
     db_path: &Path,
     from: &str,
     to: &str,
     depth: u32,
     json: bool,
+    compact: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -616,7 +622,12 @@ pub fn cmd_trace(
         .iter()
         .flatten()
         .map(|h| HydratedHop {
-            body: hop_body(&db, &index_root, &h.source_id),
+            // Compact drops the inline body (the heaviest part of a trace).
+            body: if compact {
+                None
+            } else {
+                hop_body(&db, &index_root, &h.source_id)
+            },
             source_name: h.source_name.clone(),
             target_name: h.target_name.clone(),
             kind: h.kind,
@@ -716,6 +727,7 @@ pub fn cmd_refs(
     name: &str,
     kind: Option<EdgeKindFilter>,
     json: bool,
+    compact: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -735,7 +747,14 @@ pub fn cmd_refs(
 
     let items: Vec<RefEntry> = results
         .into_iter()
-        .map(|(edge, sym)| RefEntry { edge, source: sym })
+        .map(|(edge, mut sym)| {
+            if compact {
+                if let Some(s) = sym.as_mut() {
+                    s.compact_in_place();
+                }
+            }
+            RefEntry { edge, source: sym }
+        })
         .collect();
 
     output(&items, json, token_budget, |items| {
@@ -885,6 +904,7 @@ pub fn cmd_search(
     file: Option<&str>,
     limit: u32,
     json: bool,
+    compact: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -894,9 +914,12 @@ pub fn cmd_search(
         Some(k) => Some(cartog_core::SymbolKind::from(k)),
     };
     let limit = limit.min(MAX_SEARCH_LIMIT);
-    let symbols = db.search(query, kind_filter, file, limit)?;
+    let mut symbols = db.search(query, kind_filter, file, limit)?;
     if !symbols.is_empty() {
         db.log_query("search", "cli");
+    }
+    if compact {
+        symbols.compact_in_place();
     }
     let query = query.to_string();
 
@@ -1003,6 +1026,7 @@ pub fn cmd_map(
     db_path: &Path,
     tokens: u32,
     json: bool,
+    compact: bool,
     mermaid: bool,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -1083,7 +1107,10 @@ pub fn cmd_map(
 
     if json {
         // For JSON, return structured data without budget constraints
-        let symbols = db.top_symbols(200)?;
+        let mut symbols = db.top_symbols(200)?;
+        if compact {
+            symbols.compact_in_place();
+        }
 
         #[derive(Serialize)]
         struct MapResult {
@@ -1163,6 +1190,7 @@ pub fn cmd_changes(
     commits: u32,
     kind: Option<SymbolKindFilter>,
     json: bool,
+    compact: bool,
     token_budget: Option<u32>,
     embedding_dim: usize,
 ) -> Result<()> {
@@ -1187,7 +1215,10 @@ pub fn cmd_changes(
         Some(SymbolKindFilter::All) | None => None,
         Some(k) => Some(cartog_core::SymbolKind::from(k)),
     };
-    let symbols = db.symbols_for_files(&changed_files, kind_filter)?;
+    let mut symbols = db.symbols_for_files(&changed_files, kind_filter)?;
+    if compact {
+        symbols.compact_in_place();
+    }
 
     let result = cartog_core::ChangesResult {
         changed_files,
@@ -1366,6 +1397,7 @@ pub fn cmd_rag_search(
     kind: Option<SymbolKindFilter>,
     limit: u32,
     json: bool,
+    compact: bool,
     token_budget: Option<u32>,
     provider_config: &rag::EmbeddingProviderConfig,
     tuning: &rag::search::SearchTuning,
@@ -1398,7 +1430,7 @@ pub fn cmd_rag_search(
         let threads = provider_config.intra_threads;
         Some(move || rag::create_reranker_provider(&name, model.as_deref(), threads))
     };
-    let search_result = rag::search::hybrid_search_tuned_lazy(
+    let mut search_result = rag::search::hybrid_search_tuned_lazy(
         &db,
         query,
         limit,
@@ -1407,6 +1439,9 @@ pub fn cmd_rag_search(
         reranker_factory,
         tuning,
     )?;
+    if compact {
+        search_result.compact_in_place();
+    }
     db.log_query("rag_search", "cli");
     let query = query.to_string();
     // Gate the "build the index" hint on whether embeddings actually exist, not
@@ -1491,6 +1526,7 @@ pub fn cmd_context(
     task: &str,
     tokens: u32,
     json: bool,
+    compact: bool,
     provider_config: &rag::EmbeddingProviderConfig,
     tuning: &rag::search::SearchTuning,
 ) -> Result<()> {
@@ -1499,7 +1535,7 @@ pub fn cmd_context(
 
     // Build the bundle in its own scope so the provider/reranker borrows end
     // before the `output` closure (which re-borrows `&db`) runs.
-    let ctx = {
+    let mut ctx = {
         let mut reranker = if provider_config.reranker_provider == "none" {
             None
         } else {
@@ -1531,6 +1567,11 @@ pub fn cmd_context(
     };
     if !ctx.entries.is_empty() {
         db.log_query("context", "cli");
+    }
+    // Compact trims the per-entry symbol noise but keeps the budgeted bodies —
+    // a context bundle's whole value is its inline bodies.
+    if compact {
+        ctx.compact_in_place();
     }
     let task = task.to_string();
 
@@ -1932,7 +1973,7 @@ def main():
     fn cmd_outline_runs_a_query_for_a_populated_file() {
         let (_tmp, db) = indexed_db();
         let before = queries_logged(&db);
-        cmd_outline(&db, "lib.py", false, None, 384).expect("outline ok");
+        cmd_outline(&db, "lib.py", false, false, None, 384).expect("outline ok");
         assert_eq!(
             queries_logged(&db),
             before + 1,
@@ -1943,22 +1984,32 @@ def main():
     #[test]
     fn cmd_outline_json_branch_does_not_error() {
         let (_tmp, db) = indexed_db();
-        cmd_outline(&db, "lib.py", true, None, 384).expect("outline --json ok");
+        cmd_outline(&db, "lib.py", true, false, None, 384).expect("outline --json ok");
+        cmd_outline(&db, "lib.py", true, true, None, 384).expect("outline --json --compact ok");
     }
 
     #[test]
     fn cmd_outline_unknown_file_does_not_error() {
         let (_tmp, db) = indexed_db();
-        cmd_outline(&db, "missing.py", false, None, 384).expect("outline of unknown file is ok");
+        cmd_outline(&db, "missing.py", false, false, None, 384)
+            .expect("outline of unknown file is ok");
     }
 
     #[test]
     fn cmd_refs_runs_a_query_per_invocation_with_and_without_kind_filter() {
         let (_tmp, db) = indexed_db();
         let before = queries_logged(&db);
-        cmd_refs(&db, "helper", None, false, None, 384).expect("refs ok");
-        cmd_refs(&db, "helper", Some(EdgeKindFilter::Calls), false, None, 384)
-            .expect("refs --kind calls ok");
+        cmd_refs(&db, "helper", None, false, false, None, 384).expect("refs ok");
+        cmd_refs(
+            &db,
+            "helper",
+            Some(EdgeKindFilter::Calls),
+            false,
+            false,
+            None,
+            384,
+        )
+        .expect("refs --kind calls ok");
         assert_eq!(
             queries_logged(&db),
             before + 2,
@@ -1970,7 +2021,8 @@ def main():
     fn cmd_refs_near_miss_name_takes_the_did_you_mean_branch_without_error() {
         let (_tmp, db) = indexed_db();
         // Empty result triggers the did_you_mean / empty_index_hint branch.
-        cmd_refs(&db, "helpe", None, false, None, 384).expect("refs of near-miss name is ok");
+        cmd_refs(&db, "helpe", None, false, false, None, 384)
+            .expect("refs of near-miss name is ok");
     }
 
     #[test]
@@ -2000,9 +2052,9 @@ def main():
     fn cmd_trace_logs_a_query_only_when_a_path_is_found() {
         let (_tmp, db) = indexed_db();
         let before = queries_logged(&db);
-        cmd_trace(&db, "speak", "helper", 8, false, None, 384).expect("trace ok");
+        cmd_trace(&db, "speak", "helper", 8, false, false, None, 384).expect("trace ok");
         let after_hit = queries_logged(&db);
-        cmd_trace(&db, "speak", "no_such_symbol", 8, false, None, 384)
+        cmd_trace(&db, "speak", "no_such_symbol", 8, false, false, None, 384)
             .expect("no-path trace is ok");
         let after_miss = queries_logged(&db);
 
@@ -2016,7 +2068,14 @@ def main():
     #[test]
     fn cmd_trace_json_branch_does_not_error() {
         let (_tmp, db) = indexed_db();
-        cmd_trace(&db, "speak", "helper", 8, true, None, 384).expect("trace --json ok");
+        cmd_trace(&db, "speak", "helper", 8, true, false, None, 384).expect("trace --json ok");
+    }
+
+    #[test]
+    fn cmd_trace_json_compact_branch_does_not_error() {
+        let (_tmp, db) = indexed_db();
+        cmd_trace(&db, "speak", "helper", 8, true, true, None, 384)
+            .expect("trace --json --compact ok");
     }
 
     // No CLI test for `cmd_context`: it builds a real embedding provider
@@ -2043,7 +2102,7 @@ def main():
     fn cmd_search_runs_a_query_for_each_filter_and_budget_branch() {
         let (_tmp, db) = indexed_db();
         let before = queries_logged(&db);
-        cmd_search(&db, "Anim", None, None, 30, false, None, 384).expect("search ok");
+        cmd_search(&db, "Anim", None, None, 30, false, false, None, 384).expect("search ok");
         cmd_search(
             &db,
             "speak",
@@ -2051,12 +2110,14 @@ def main():
             Some("lib.py"),
             30,
             false,
+            false,
             None,
             384,
         )
         .expect("search with kind + file filter ok");
         // Token-budget branch.
-        cmd_search(&db, "e", None, None, 30, false, Some(50), 384).expect("search --tokens ok");
+        cmd_search(&db, "e", None, None, 30, false, false, Some(50), 384)
+            .expect("search --tokens ok");
         assert_eq!(
             queries_logged(&db),
             before + 3,
@@ -2067,8 +2128,15 @@ def main():
     #[test]
     fn cmd_search_empty_result_does_not_error() {
         let (_tmp, db) = indexed_db();
-        cmd_search(&db, "zzz_no_match", None, None, 30, false, None, 384)
+        cmd_search(&db, "zzz_no_match", None, None, 30, false, false, None, 384)
             .expect("empty search is ok");
+    }
+
+    #[test]
+    fn cmd_search_json_compact_branch_does_not_error() {
+        let (_tmp, db) = indexed_db();
+        cmd_search(&db, "Anim", None, None, 30, true, true, None, 384)
+            .expect("search --json --compact ok");
     }
 
     #[test]
@@ -2082,9 +2150,10 @@ def main():
     #[test]
     fn cmd_map_plain_json_and_mermaid_branches_do_not_error() {
         let (_tmp, db) = indexed_db();
-        cmd_map(&db, 1000, false, false, 384).expect("map ok");
-        cmd_map(&db, 1000, true, false, 384).expect("map --json ok");
-        cmd_map(&db, 1000, false, true, 384).expect("map --mermaid ok");
+        cmd_map(&db, 1000, false, false, false, 384).expect("map ok");
+        cmd_map(&db, 1000, true, false, false, 384).expect("map --json ok");
+        cmd_map(&db, 1000, true, true, false, 384).expect("map --json --compact ok");
+        cmd_map(&db, 1000, false, false, true, 384).expect("map --mermaid ok");
     }
 
     // ── lsp_defer_peer gate ──

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -164,6 +164,9 @@ fn main() -> Result<()> {
     // Token budget only applies to human-readable output
     let token_budget = if cli.json { None } else { cli.tokens };
 
+    // Field-stripping only applies to JSON output (a no-op for human text).
+    let compact = cli.json && cli.compact;
+
     // Classify before the match consumes cli.command.
     let command_kind = classify_command(&cli.command);
 
@@ -182,9 +185,14 @@ fn main() -> Result<()> {
             redact,
             &lsp_overrides,
         ),
-        Command::Outline { file } => {
-            commands::cmd_outline(&db_path, &file, cli.json, token_budget, embedding_dim)
-        }
+        Command::Outline { file } => commands::cmd_outline(
+            &db_path,
+            &file,
+            cli.json,
+            compact,
+            token_budget,
+            embedding_dim,
+        ),
         Command::Callees { name } => {
             commands::cmd_callees(&db_path, &name, cli.json, token_budget, embedding_dim)
         }
@@ -201,6 +209,7 @@ fn main() -> Result<()> {
             &task,
             tokens,
             cli.json,
+            compact,
             &provider_config,
             &search_tuning,
         ),
@@ -210,12 +219,19 @@ fn main() -> Result<()> {
             &to,
             depth,
             cli.json,
+            compact,
             token_budget,
             embedding_dim,
         ),
-        Command::Refs { name, kind } => {
-            commands::cmd_refs(&db_path, &name, kind, cli.json, token_budget, embedding_dim)
-        }
+        Command::Refs { name, kind } => commands::cmd_refs(
+            &db_path,
+            &name,
+            kind,
+            cli.json,
+            compact,
+            token_budget,
+            embedding_dim,
+        ),
         Command::Hierarchy { name, mermaid } => commands::cmd_hierarchy(
             &db_path,
             &name,
@@ -281,17 +297,19 @@ fn main() -> Result<()> {
             file.as_deref(),
             limit,
             cli.json,
+            compact,
             token_budget,
             embedding_dim,
         ),
         Command::Map { tokens, mermaid } => {
-            commands::cmd_map(&db_path, tokens, cli.json, mermaid, embedding_dim)
+            commands::cmd_map(&db_path, tokens, cli.json, compact, mermaid, embedding_dim)
         }
         Command::Changes { commits, kind } => commands::cmd_changes(
             &db_path,
             commits,
             kind,
             cli.json,
+            compact,
             token_budget,
             embedding_dim,
         ),
@@ -364,6 +382,7 @@ fn main() -> Result<()> {
                 kind,
                 limit,
                 cli.json,
+                compact,
                 token_budget,
                 &provider_config,
                 &search_tuning,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -279,6 +279,7 @@ Runtime overrides (per-machine / per-invocation), in addition to `.cartog.toml`:
 | `CARTOG_WATCH_RAG` | unset | Force watcher auto-embed; overrides `[embedding] auto_embed` and `--rag`:<br>`1` = force on<br>`0` = force off<br>unset = auto-detect from the DB |
 | `CARTOG_SINGLE_WRITER` | `1` | `0` disables MCP single-writer election (every `cartog serve` opens read-write). |
 | `CARTOG_MCP_MAX_BYTES` | `65536` | Max bytes per MCP tool response before truncation. |
+| `CARTOG_MCP_COMPACT` | `1` (on) | MCP tools strip heavy fields by default (symbol cache hashes + docstrings; `cartog_rag_search`/`cartog_trace` bodies bounded to a ~500-byte snippet; `cartog_context` keeps budgeted bodies). Set `0`/`false`/`no`/`off` to return full bodies. |
 | `CARTOG_NO_UPDATE_CHECK` | unset | Set to skip the background self-update check. |
 | `CARTOG_UPDATE_CHECK` | unset | Force an update check regardless of cadence. |
 | `CARTOG_INSTALL_DIR` | `~/.local/bin` | Install location used by `install.sh`. |
@@ -1306,6 +1307,18 @@ cartog --json stats
 ```
 
 Returns arrays of objects with fields like `name`, `kind`, `file_path`, `start_line`, `end_line`, `signature`, etc. Empty results return `[]`.
+
+### Compact JSON (`--compact`)
+
+`--compact` strips heavy, low-value fields from `--json` output to save agent tokens, while keeping every field needed to locate and rank a result. It is a no-op without `--json`.
+
+```bash
+cartog --json --compact rag search "authentication"   # ~60% smaller payload
+```
+
+Dropped in compact mode: symbol bodies (`content` in `rag search`/`trace`), `docstring`, and the `content_hash`/`subtree_hash` cache fields. Kept: `id`, `name`, `kind`, `file_path`, line/byte spans, `signature`, scores, `sources`, and edge `provenance`. `cartog context` is the exception — it keeps its inline bodies (already budgeted by `--tokens`), trimming only the per-entry symbol noise. The output stays valid JSON of the same shape (omitting optional fields), so it validates against the same schema as full output.
+
+MCP tools are **compact by default** (agents are the consumer and the response cap already implies token pressure); set `CARTOG_MCP_COMPACT=0` to restore full bodies. There, `cartog_rag_search` and `cartog_trace` bound bodies to a ~500-byte snippet rather than dropping them, matching their "snippet excerpt" contract.
 
 **Errors**: if the index doesn't exist yet, query commands print an error message and exit with a non-zero status. Run `cartog index .` first. If a symbol or file isn't found, the result is an empty array (not an error).
 

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -200,6 +200,7 @@ provider = "ollama"              <span class="comment"># default is "local"</spa
             <tr><td><code>CARTOG_WATCH_RAG</code></td><td>unset</td><td>Force watcher auto-embed; overrides <code>[embedding] auto_embed</code> and <code>--rag</code>:<br><code>1</code> = force on<br><code>0</code> = force off<br>unset = auto-detect from the DB</td></tr>
             <tr><td><code>CARTOG_SINGLE_WRITER</code></td><td><code>1</code></td><td><code>0</code> disables MCP single-writer election (every <code>serve</code> opens read-write).</td></tr>
             <tr><td><code>CARTOG_MCP_MAX_BYTES</code></td><td><code>65536</code></td><td>Max bytes per MCP tool response before truncation.</td></tr>
+            <tr><td><code>CARTOG_MCP_COMPACT</code></td><td><code>1</code> (on)</td><td>MCP tools strip heavy fields by default (cache hashes + docstrings; <code>cartog_rag_search</code>/<code>cartog_trace</code> bodies bounded to a ~500-byte snippet; <code>cartog_context</code> keeps budgeted bodies). Set <code>0</code> to return full bodies.</td></tr>
             <tr><td><code>CARTOG_NO_UPDATE_CHECK</code></td><td>unset</td><td>Set to skip the background self-update check.</td></tr>
             <tr><td><code>CARTOG_UPDATE_CHECK</code></td><td>unset</td><td>Force an update check regardless of cadence.</td></tr>
             <tr><td><code>CARTOG_INSTALL_DIR</code></td><td><code>~/.local/bin</code></td><td>Install location used by <code>install.sh</code>.</td></tr>
@@ -1161,6 +1162,11 @@ cartog --json stats</pre>
         <pre>cartog --tokens 500 search validate
 cartog --tokens 200 outline src/db.rs</pre>
         <p>Uses <code>len / 4</code> byte-to-token approximation. Ignored when <code>--json</code> is used.</p>
+
+        <h2 id="compact-json">Compact JSON</h2>
+        <p>Add <code>--compact</code> to strip heavy fields from <code>--json</code> and save agent tokens (~60% smaller). Symbol bodies, docstrings, and cache hashes are dropped; ids, names, kinds, locations, signatures, and scores are kept. No-op without <code>--json</code>; <code>cartog context</code> keeps its budgeted bodies.</p>
+        <pre>cartog --json --compact rag search "authentication"</pre>
+        <p style="font-size: 13px; color: var(--text-tertiary);">MCP tools are compact by default — <code>cartog_rag_search</code>/<code>cartog_trace</code> bodies are bounded to a ~500-byte snippet and <code>cartog_context</code> keeps full budgeted bodies. Set <code>CARTOG_MCP_COMPACT=0</code> to restore full bodies on every tool.</p>
 
         <h2 id="languages">Supported Languages</h2>
         <table>

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -475,6 +475,13 @@ cartog --json outline src/auth/tokens.py
 cartog --json rag search "authentication"
 ```
 
+Add `--compact` to strip heavy fields from `--json` and save tokens: symbol bodies
+(`content`), docstrings, and cache hashes are dropped; ids, names, kinds, locations,
+signatures, and scores are kept (`context` keeps its budgeted bodies). No-op without `--json`.
+```bash
+cartog --json --compact rag search "authentication"   # ~60% smaller, still locatable
+```
+
 Edge results (`refs`, `callees`, `impact`, `deps`, `trace`) carry a `provenance` field naming which tier resolved the edge: a heuristic tier (`same_file`, `import_path`, `same_dir`, `parent_scope`, `unique_global`, `kind_disambig`) or an LSP outcome (`lsp`, `lsp_external`, `lsp_unresolvable`). Treat `lsp`/`same_file`/`import_path` as high-confidence; `unique_global`/`kind_disambig` as best-effort guesses. Omitted for unresolved edges and indexes built before provenance tracking.
 
 ## Refactoring Workflow


### PR DESCRIPTION
## Context

Benchmarking cartog against [grepai](https://github.com/yoanbernabeu/grepai) surfaced a clear token-economy gap: cartog's `--json` embeds full symbol bodies plus `signature`, `docstring`, and internal `content_hash`/`subtree_hash` cache fields in every response — ~8–9 KB for 5 RAG results vs grepai's ~0.6 KB compact output. For LLM coding agents (the primary consumer, especially over MCP), that's wasted context budget. `--tokens N` was explicitly ignored under `--json`, so there was no way to slim machine-readable output.

## What changed

- **CLI** — new global `--compact` flag. `cartog --json --compact <cmd>` drops symbol bodies (`content`), `docstring`, and the `content_hash`/`subtree_hash` cache fields, while keeping `id`/`name`/`kind`/`file_path`/lines/`signature`/scores/`sources`/`provenance`. No-op without `--json`. `--tokens` stays JSON-ignored (truncating a JSON array mid-element yields unparseable output — field omission keeps it valid).
- **core** — `Compact` trait + `Symbol` impl + blanket `Vec<T>` impl. `content_hash`/`subtree_hash` gain `skip_serializing_if` (they're always populated, so **default JSON is unchanged**; only `--compact` omits them).
- **rag** — `Compact` for `SearchResult`/`HybridSearchResult` (drop body) and a `snippet()` helper (500-byte preview). `ContextEntry`/`TaskContext` trim the inner symbol but **keep budgeted bodies** (context's whole value).
- **MCP** — **compact by default** (agents are the consumer; the 64 KB response cap already implies token pressure). `cartog_rag_search`/`cartog_trace` bound bodies to a ~500-byte snippet (matching their "snippet excerpt" contract); `cartog_context` keeps bodies. `CARTOG_MCP_COMPACT=0` restores full bodies. Output schemas unchanged (omitting optional fields stays schema-valid).
- **docs** — `skills/cartog/SKILL.md`, `AGENTS.md`/`CLAUDE.md`, `docs/usage.md`, and the site (`usage.astro`).

## No-regression boundary

- **CLI** `cartog rag search --json` (no `--compact`) keeps full bodies, **byte-identical** to before.
- **MCP** `cartog_rag_search` default is a deliberate behavior change (snippet), reversible with `CARTOG_MCP_COMPACT=0`.

## Verification

Release binary on a real corpus (`rag search`, 3 results): **5599 B → 2249 B (59% smaller)**; default body byte-identical; scores/locations preserved.

- `cargo test --workspace` → 1493 passed, 3 ignored (new unit tests in core/rag/CLI/MCP: drop-set, snippet bounds, `mcp_compact()` env parsing, JSON-validity)
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- `cargo test --doc` + `cargo doc` → clean
- `site/ npm run build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--compact` global flag to reduce JSON output size by stripping heavy fields (bodies, docstrings, cache hashes) while preserving metadata and scores
  * MCP tool responses now default to compact mode; set `CARTOG_MCP_COMPACT=0` to restore full payload bodies

* **Documentation**
  * Updated documentation for compact mode, token budget controls, and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->