### PR TITLE
docs: position cartog vs embedding-search tools (symbols, not chunks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 
 **Map your codebase. Navigate by graph, not grep.**
 
-**~280 tokens per query vs ~1,700 for grep+read · 97% recall · 8 µs–20 ms latency · 12 languages.**
+**Semantic search that returns named symbols, not text chunks — ranked, reranked, and budget-aware.**
 
-Cartog pre-computes a code graph — symbols, and the calls, imports, and inheritance between them — so you can query structure instantly instead of grepping for text. Ask "who calls this?", "what breaks if I change it?", or "find the auth logic" and get a ranked, structured answer in microseconds.
+**~280 tokens per query vs ~1,700 for grep+read · 97% recall · 8 µs–20 ms structural-query latency · 12 languages.**
+
+Cartog pre-computes a code graph — symbols, and the calls, imports, and inheritance between them — so you can query structure instantly instead of grepping for text. Ask "who calls this?", "what breaks if I change it?", or "find the auth logic" and get a ranked, structured answer: an exact function with its signature and span, not a file-and-line guess you have to open and read.
 
 Use it from the CLI for day-to-day navigation, or as an MCP server so AI agents query the graph instead of flooding their context with raw file dumps — at a fraction of the token cost. One static binary, one SQLite file. No Python, no pip, no Docker, no cloud: 100% local by default.
 
@@ -135,7 +137,7 @@ cartog serve                     # 16 tools over stdio
 cartog serve --watch --rag       # with live re-indexing + semantic search
 ```
 
-Works with Claude Code, Cursor, Windsurf, Zed, OpenCode — any MCP client.
+Works with Claude Code, Cursor, Windsurf, Zed, OpenCode — any MCP client. Tool output is **compact by default** (locations + signatures + snippet previews, not full bodies) so it stays within an agent's context budget; set `CARTOG_MCP_COMPACT=0` to restore full bodies. On the CLI, `cartog --json --compact …` does the same — ~60% smaller payloads that still carry symbols, signatures, and scores.
 
 ### LSP precision, built in
 
@@ -236,6 +238,8 @@ npx skills add jrollin/cartog
 **A language server?** LSPs give perfect precision but require per-language setup, take seconds to start, and only cover one language at a time. Cartog covers 12 languages with one binary and answers in microseconds. When you need LSP precision, cartog can use it as an optional layer.
 
 **Python-based graph tools?** They solve a similar problem but require a Python runtime, pip dependencies, and virtual environments. Cartog is a single static binary — download and run. It also queries 10-100x faster thanks to compiled Rust + SQLite.
+
+**An embedding-search tool (chunk + vector)?** Tools that chunk files and embed them find code by concept, but return **file-and-line windows** — you still open and read to learn *what* matched. Cartog returns the **named symbol** (function/class/method) with its kind, signature, and exact span, then sharpens ranking with a **cross-encoder re-ranker** and **centrality** that chunk-only tools lack. It also embeds **in-process** (local ONNX, zero external server — no Ollama daemon to keep running) and ships LSP-precise call/import edges, so the same query that finds code can also trace it. Add `--compact` and the JSON stays symbol-level while dropping ~60% of the bytes.
 
 ## MCP Server Setup
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -4,6 +4,8 @@
 
 **Tagline:** Map your codebase. Navigate by graph, not grep.
 
+**Positioning line:** Semantic search that returns named symbols, not text chunks — ranked, reranked, and budget-aware.
+
 ## What it does
 
 cartog is a code graph indexer that gives LLM coding agents instant structural understanding of a codebase. It replaces repeated grep/cat with targeted graph queries: **83% fewer tokens per query, 97% recall**.
@@ -36,6 +38,8 @@ Measured across 13 scenarios, 10 languages. Best gains on call chain tracing (88
 **vs language servers (LSP):** no startup time, no per-language server, no config. Single binary covers 12 languages (11 code languages + Markdown). Trade-off: ~90% name resolution accuracy vs LSP's full semantic analysis. LSP can be enabled as an optional precision layer.
 
 **vs Serena MCP / codanna / Aider repo-map:** single binary, no LSP requirement, pre-computed graph (not per-query), full query interface over SQLite.
+
+**vs embedding-search tools (chunk + vector):** tools that chunk files and embed them find code by concept but return file-and-line *chunks* — the agent still opens and reads to learn what matched, and ranking is vector-similarity only. cartog returns the **named symbol** (kind, signature, span), then adds a **cross-encoder re-ranker** and **in-degree centrality** that chunk-only ranking lacks, and **LSP-precise edges** so the same index that finds code also traces it. Embeddings run **in-process** (local ONNX) — no external Ollama/OpenAI server is required to index at all (it stays a clean opt-in). The symbol-level pipeline + AST-aware compaction also keep indexing fast: in internal benchmarking, holding the embedding backend constant, cartog's pipeline indexed materially faster than a chunk-based approach, and faster still on its default in-process ONNX.
 
 ## Distribution
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -21,8 +21,8 @@ import { withBase } from "../lib/url";
       </h1>
 
       <p class="subtitle">
-        Single Rust binary, answer in microseconds, 12 languages. <br/>
-        True local semantic search, 100% local. MCP server built in.
+        Semantic search that returns named symbols, not text chunks — ranked, reranked, budget-aware. <br/>
+        Single Rust binary, 12 languages, 100% local. MCP server built in.
       </p>
 
       <!-- Stats bar: anchor the value claim before showing the demo -->
@@ -395,8 +395,13 @@ import { withBase } from "../lib/url";
         </div>
         <div class="why-card" data-reveal style="--reveal-delay: 0.16s;">
           <div class="why-number">03</div>
+          <h3>An embedding-search tool</h3>
+          <p>Chunk-and-vector tools find code by concept but return <strong>file-and-line windows</strong> — you still open and read to learn what matched, and ranking is vector-similarity only. Cartog returns the <strong>named symbol</strong> (kind, signature, exact span), then sharpens it with a <strong>cross-encoder re-ranker</strong> and <strong>centrality</strong> they lack — and embeds <strong>in-process</strong> (local ONNX), so there's no Ollama daemon to keep running just to index.</p>
+        </div>
+        <div class="why-card" data-reveal style="--reveal-delay: 0.24s;">
+          <div class="why-number">04</div>
           <h3>Other code-graph indexers</h3>
-          <p>Most ship a runtime to install (Python, Node) and stop at keyword search. Cartog is a single static Rust binary with three things they lack: <strong>true embedding-based semantic search</strong> (vector KNN + cross-encoder re-ranking, not keyword matching), <strong>pluggable embedding providers</strong> (local ONNX, Ollama, or any OpenAI-compatible endpoint), and <strong>S3 index sync</strong> (<code>cartog push</code> / <code>pull</code>) to share a pre-built graph across a team or CI. All 100% local by default.</p>
+          <p>Most ship a runtime to install (Python, Node) and stop at keyword search. Cartog is a single static Rust binary with three things they lack: <strong>true embedding-based semantic search</strong> (vector KNN + cross-encoder re-ranking), <strong>pluggable embedding providers</strong> (local ONNX, Ollama, or any OpenAI-compatible endpoint), and <strong>S3 index sync</strong> (<code>cartog push</code> / <code>pull</code>) to share a pre-built graph across a team or CI. All 100% local by default.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Context

cartog's docs lead almost entirely with **grep** comparisons (speed, recall, token cost). But the category cartog actually competes with for "find code by concept" is **embedding-search tools** (chunk + vector). Against those, cartog's real edge isn't speed — it's **precision**: it returns *named symbols* (kind, signature, exact span) instead of file-and-line chunks, sharpens ranking with a cross-encoder re-ranker + centrality, embeds **in-process** (no external embedding server to run), and ships LSP-precise edges so the same index that finds code can also trace it. None of that was surfaced in the positioning.

## Changes

- **Lead positioning line** (README headline, `docs/product.md`, site hero): *"Semantic search that returns named symbols, not text chunks — ranked, reranked, budget-aware."* Keeps the existing "navigate by graph, not grep" as the recognizable tagline.
- **"vs embedding-search tools" comparison** added where it was missing: README "Why Not…", site "Why not…" grid (new card; the old mis-framed indexer card moved down), and `product.md` differentiation. Generic category framing — **no competitor is named**.
- **Document `--compact` / `CARTOG_MCP_COMPACT`** in the README MCP section (shipped in #122, previously unadvertised in marketing).
- **Honesty fix:** qualify the microsecond latency as *structural-query* latency (semantic `rag search` is not µs).

## Notes

- Docs-only, 3 files (+19/−6). No code changes.
- README is wired as the `cartog` crate's docs.rs landing page — verified no new code fences (doctest-safe) and `cargo doc --no-deps -p cartog` stays warning-clean.
- Site builds clean (`npm run build`). Pages workflow rebuilds `site/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)