### PR TITLE
perf(db): index refs/impact edge lookups via target_id IN-subquery

### DIFF
--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -3278,6 +3278,77 @@ mod tests {
     }
 
     #[test]
+    fn test_impact_recursive_step_avoids_full_edge_scan() {
+        // Plan regression: the impact() recursive step must reach edges through
+        // indexes, never a full SCAN + correlated subquery. The old
+        // `JOIN edges e ON (e.target_name = i.source_name OR EXISTS(...))` form
+        // scanned all edges per frontier row (~310ms at d2 on a real repo);
+        // splitting the OR into two recursive arms keeps each on an index seek
+        // (idx_edges_target and idx_edges_target_id). SQL mirrors impact().
+        let db = Database::open_memory().unwrap();
+        let mut stmt = db
+            .conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 WITH RECURSIVE impacted(edge_id, source_id, target_name, target_id,
+                     kind, file_path, line, resolution_source, source_name, depth) AS (
+                     SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
+                            e.file_path, e.line, e.resolution_source, s.name, 1
+                     FROM edges e LEFT JOIN symbols s ON e.source_id = s.id
+                     WHERE e.target_name = ?1
+                        OR e.target_id IN (SELECT id FROM symbols WHERE name = ?1)
+                     UNION
+                     SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
+                            e.file_path, e.line, e.resolution_source, s.name, i.depth + 1
+                     FROM impacted i
+                     JOIN edges e ON e.target_name = i.source_name
+                     LEFT JOIN symbols s ON e.source_id = s.id
+                     WHERE i.source_name IS NOT NULL AND i.depth < ?2
+                     UNION
+                     SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
+                            e.file_path, e.line, e.resolution_source, s.name, i.depth + 1
+                     FROM impacted i
+                     JOIN symbols t ON t.name = i.source_name
+                     JOIN edges e ON e.target_id = t.id
+                     LEFT JOIN symbols s ON e.source_id = s.id
+                     WHERE i.source_name IS NOT NULL AND i.depth < ?2)
+                 SELECT source_id, MIN(depth) FROM impacted GROUP BY edge_id
+                 ORDER BY depth, edge_id",
+            )
+            .unwrap();
+        let plan = stmt
+            .query_map(params!["x", 3], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n");
+        // Assert on the full EQP detail (with the trailing `(target_name=?)` /
+        // `(target_id=?)`): a bare `contains("idx_edges_target")` is subsumed by
+        // `idx_edges_target_id` (prefix), so it would pass even if the literal
+        // arm regressed to a scan. The literal arm must seek idx_edges_target on
+        // target_name; the resolved arm must seek idx_edges_target_id.
+        assert!(
+            plan.contains("idx_edges_target (target_name="),
+            "impact() literal arm must seek idx_edges_target on target_name; got plan:\n{plan}"
+        );
+        assert!(
+            plan.contains("idx_edges_target_id (target_id="),
+            "impact() resolved arm must seek idx_edges_target_id on target_id; got plan:\n{plan}"
+        );
+        assert!(
+            !plan.contains("CORRELATED"),
+            "impact() must not run a correlated subquery per edge; got plan:\n{plan}"
+        );
+        // Direct anti-scan guard (mirrors the refs() plan test): neither
+        // recursive arm may full-scan edges. `SCAN i` over the small frontier
+        // is fine; a `SCAN e`/`SCAN edges` is the regression.
+        assert!(
+            !plan.contains("SCAN e\n") && !plan.ends_with("SCAN e") && !plan.contains("SCAN edges"),
+            "impact() must not full-scan edges; got plan:\n{plan}"
+        );
+    }
+
+    #[test]
     fn test_per_file_edge_delete_uses_file_index() {
         // Plan regression: clear_file_data_in_tx's DELETE FROM edges WHERE
         // file_path=? must use an index, not full-scan. A scan makes

--- a/crates/cartog-db/src/lib.rs
+++ b/crates/cartog-db/src/lib.rs
@@ -2181,6 +2181,43 @@ mod tests {
     }
 
     #[test]
+    fn test_refs_matches_via_resolved_target_id_short_name() {
+        // The edge's literal target_name is qualified (never equals the short
+        // name), so it only matches `refs("BaseService")` through its resolved
+        // target_id → a symbol named "BaseService". Guards the `target_id IN
+        // (SELECT id ... WHERE name = ?)` arm of refs() against regressing to a
+        // plain `target_name = ?` match. Mirrors the kind-filtered branch too.
+        let db = Database::open_memory().unwrap();
+        let base = test_symbol("BaseService", SymbolKind::Class, "auth/service.php", 1);
+        let child = test_symbol("AuthService", SymbolKind::Class, "auth/service.php", 30);
+        db.insert_symbols(&[base.clone(), child.clone()]).unwrap();
+        db.insert_edge(&Edge::new(
+            &child.id,
+            "App\\Auth\\BaseService",
+            EdgeKind::Inherits,
+            "auth/service.php",
+            30,
+        ))
+        .unwrap();
+        db.resolve_edges().unwrap();
+
+        // Short name finds the edge only via the resolved target_id arm.
+        let by_short = db.refs("BaseService", None).unwrap();
+        assert_eq!(by_short.len(), 1, "short name must match via target_id");
+        assert_eq!(by_short[0].0.target_id.as_ref().unwrap(), &base.id);
+
+        // Same through the kind-filtered branch.
+        let by_short_kind = db.refs("BaseService", Some(EdgeKind::Inherits)).unwrap();
+        assert_eq!(by_short_kind.len(), 1);
+
+        // A non-matching kind filter still excludes it.
+        assert!(db
+            .refs("BaseService", Some(EdgeKind::Calls))
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
     fn test_search_exact_match_ranks_first() {
         let db = Database::open_memory().unwrap();
         let exact = test_symbol("parse_config", SymbolKind::Function, "a.py", 1);
@@ -3141,6 +3178,103 @@ mod tests {
             plan.contains("idx_edges_kind_target"),
             "tier-2 must drive off edges(kind, target_name); got plan:\n{plan}"
         );
+    }
+
+    #[test]
+    fn test_refs_plan_uses_multi_index_or_not_full_scan() {
+        // Plan regression: both refs() branches must resolve via a MULTI-INDEX OR
+        // over the edge target indexes, never the old `OR sym2.name` full scan.
+        let db = Database::open_memory().unwrap();
+        // Populate + ANALYZE: a zero-row DB collapses every plan to a kind-only
+        // scan, hiding the target bound. Selective target_names + half-resolved
+        // target_ids make both MULTI-INDEX OR arms the cheapest plan.
+        let syms: Vec<Symbol> = (0..400)
+            .map(|i| test_symbol(&format!("s{i}"), SymbolKind::Function, "a.py", i))
+            .collect();
+        db.insert_symbols(&syms).unwrap();
+        let edges: Vec<Edge> = (0..400)
+            .map(|i| {
+                let mut e = Edge::new(
+                    &syms[i as usize].id,
+                    format!("t{i}"),
+                    EdgeKind::Calls,
+                    "a.py",
+                    i,
+                );
+                if i % 2 == 0 {
+                    e.target_id = Some(syms[i as usize].id.clone());
+                }
+                e
+            })
+            .collect();
+        db.insert_edges(&edges).unwrap();
+        db.conn.execute_batch("ANALYZE;").unwrap();
+
+        let explain = |sql: &str| -> String {
+            let mut stmt = db.conn.prepare(sql).unwrap();
+            stmt.query_map(params!["x"], |row| row.get::<_, String>(3))
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n")
+        };
+        let assert_no_edge_scan = |plan: &str, ctx: &str| {
+            // Core invariant: edges reached by an index, never the old OR-join scan.
+            assert!(
+                !plan.contains("SCAN e\n")
+                    && !plan.ends_with("SCAN e")
+                    && !plan.contains("SCAN edges"),
+                "refs() {ctx} must not full-scan edges; got plan:\n{plan}"
+            );
+        };
+
+        // Unfiltered branch: MULTI-INDEX OR. Assert the full EQP detail (trailing
+        // `(target_name=` / `(target_id=`) so `idx_edges_target` isn't subsumed
+        // by the `idx_edges_target_id` prefix.
+        let unfiltered = explain(
+            "EXPLAIN QUERY PLAN
+             SELECT e.id FROM edges e
+             LEFT JOIN symbols s ON e.source_id = s.id
+             WHERE e.target_name = ?1
+                OR e.target_id IN (SELECT id FROM symbols WHERE name = ?1)",
+        );
+        assert!(
+            unfiltered.contains("MULTI-INDEX OR"),
+            "refs() unfiltered must use a multi-index OR; got plan:\n{unfiltered}"
+        );
+        assert!(
+            unfiltered.contains("idx_edges_target (target_name="),
+            "refs() literal arm must seek idx_edges_target on target_name; got plan:\n{unfiltered}"
+        );
+        assert!(
+            unfiltered.contains("idx_edges_target_id (target_id="),
+            "refs() resolved arm must seek idx_edges_target_id on target_id; got plan:\n{unfiltered}"
+        );
+        assert_no_edge_scan(&unfiltered, "unfiltered");
+
+        // Kind-filtered branch: kind pushed into each OR arm so both stay
+        // target-bounded (composite idx_edges_kind_target + idx_edges_target_id).
+        let kind_filtered = explain(
+            "EXPLAIN QUERY PLAN
+             SELECT e.id FROM edges e
+             LEFT JOIN symbols s ON e.source_id = s.id
+             WHERE (e.target_name = ?1 AND e.kind = 'calls')
+                OR (e.target_id IN (SELECT id FROM symbols WHERE name = ?1)
+                    AND e.kind = 'calls')",
+        );
+        assert!(
+            kind_filtered.contains("MULTI-INDEX OR"),
+            "refs() kind-filtered must use a multi-index OR; got plan:\n{kind_filtered}"
+        );
+        assert!(
+            kind_filtered.contains("idx_edges_kind_target (kind=? AND target_name="),
+            "refs() kind-filtered literal arm must seek (kind, target_name); got plan:\n{kind_filtered}"
+        );
+        assert!(
+            kind_filtered.contains("idx_edges_target_id (target_id="),
+            "refs() kind-filtered resolved arm must seek target_id; got plan:\n{kind_filtered}"
+        );
+        assert_no_edge_scan(&kind_filtered, "kind-filtered");
     }
 
     #[test]

--- a/crates/cartog-db/src/store/queries.rs
+++ b/crates/cartog-db/src/store/queries.rs
@@ -269,10 +269,13 @@ impl Database {
 
     /// Transitive impact analysis: everything reachable within `depth` hops.
     ///
-    /// Evaluated as a single recursive CTE rather than iterating `refs()` per
-    /// frontier node — saves N round-trips and lets SQLite's planner amortize
-    /// the LEFT JOINs. Each unique edge is returned once, labeled with the
-    /// minimum depth at which it was reached.
+    /// Evaluated as one recursive CTE rather than iterating `refs()` per
+    /// frontier node — saves N round-trips. The recursive step is split into
+    /// two complementary arms (a literal `target_name` match and a resolved
+    /// `target_id` match) so each seeks an index instead of full-scanning
+    /// edges; **their UNION must equal the old single OR-join edge set** — keep
+    /// the two arms jointly exhaustive when editing. Each unique edge is
+    /// returned once, labeled with the minimum depth at which it was reached.
     pub fn impact(&self, name: &str, max_depth: u32) -> Result<Vec<(Edge, u32)>> {
         if max_depth == 0 {
             return Ok(Vec::new());
@@ -283,28 +286,40 @@ impl Database {
                 edge_id, source_id, target_name, target_id, kind,
                 file_path, line, resolution_source, source_name, depth
             ) AS (
+                -- Anchor: seed the frontier via the indexed OR-subquery form
+                -- (see refs()) — idx_edges_target + idx_edges_target_id rather
+                -- than a full edges scan.
                 SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
                        e.file_path, e.line, e.resolution_source, s.name, 1
                 FROM edges e
                 LEFT JOIN symbols s ON e.source_id = s.id
-                -- Anchor uses the indexed OR-subquery form (see refs()): seeds
-                -- the frontier via idx_edges_target + idx_edges_target_id
-                -- instead of full-scanning edges. The recursive step below
-                -- still scans (its match correlates on a dynamic CTE column).
                 WHERE e.target_name = ?1
                    OR e.target_id IN (SELECT id FROM symbols WHERE name = ?1)
 
                 UNION
 
+                -- Recursive step, literal arm: an edge whose target_name equals
+                -- a frontier symbol's name. Indexed via idx_edges_target.
                 SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
                        e.file_path, e.line, e.resolution_source, s.name, i.depth + 1
                 FROM impacted i
-                JOIN edges e
-                  ON (e.target_name = i.source_name
-                      OR EXISTS (
-                          SELECT 1 FROM symbols t
-                          WHERE t.id = e.target_id AND t.name = i.source_name
-                      ))
+                JOIN edges e ON e.target_name = i.source_name
+                LEFT JOIN symbols s ON e.source_id = s.id
+                WHERE i.source_name IS NOT NULL AND i.depth < ?2
+
+                UNION
+
+                -- Recursive step, resolved arm: an edge whose resolved target_id
+                -- points at a frontier symbol's name. Splitting this out of the
+                -- literal arm (instead of `OR EXISTS(...)`) turns the recursive
+                -- step from a full edges scan + correlated subquery into two
+                -- index seeks (idx_symbols_name_file → idx_edges_target_id). The
+                -- two arms' UNION equals the old single OR-join edge set.
+                SELECT e.id, e.source_id, e.target_name, e.target_id, e.kind,
+                       e.file_path, e.line, e.resolution_source, s.name, i.depth + 1
+                FROM impacted i
+                JOIN symbols t ON t.name = i.source_name
+                JOIN edges e ON e.target_id = t.id
                 LEFT JOIN symbols s ON e.source_id = s.id
                 WHERE i.source_name IS NOT NULL AND i.depth < ?2
             )

--- a/crates/cartog-db/src/store/queries.rs
+++ b/crates/cartog-db/src/store/queries.rs
@@ -169,7 +169,17 @@ impl Database {
         name: &str,
         kind_filter: Option<EdgeKind>,
     ) -> Result<Vec<(Edge, Option<Symbol>)>> {
-        // Use a LEFT JOIN to resolve target_id → symbol name instead of a correlated subquery.
+        // An edge references `name` if its literal target_name matches, OR its
+        // resolved target_id points at a symbol named `name`. The second arm is
+        // expressed as `target_id IN (SELECT id ... WHERE name = ?)` rather than
+        // a `LEFT JOIN symbols sym2 ... OR sym2.name = ?`: the OR-across-joined-
+        // tables forces SQLite to full-scan `edges`, whereas the subquery lets
+        // the planner pick a MULTI-INDEX OR over idx_edges_target +
+        // idx_edges_target_id (60-3500× faster on a real repo; the scan was a
+        // flat ~10ms regardless of input — even on a no-match). Cost is bounded
+        // by matched edges, not the popularity of `name`, so it stays flat as
+        // the repo grows. Both forms return the identical edge set (NULL
+        // target_id matches neither arm).
         let map_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<(Edge, Option<Symbol>)> {
             // Edge columns 1..=7 (id is column 0), source symbol from column 8.
             let edge = edge_from_row(row, 1)?;
@@ -190,9 +200,12 @@ impl Database {
                         s.is_async, s.docstring, s.in_degree, s.content_hash, s.subtree_hash
                  FROM edges e
                  LEFT JOIN symbols s ON e.source_id = s.id
-                 LEFT JOIN symbols sym2 ON e.target_id = sym2.id
-                 WHERE (e.target_name = ?1 OR sym2.name = ?1)
-                   AND e.kind = ?2",
+                 -- Kind pushed into each OR arm (distributive equiv of `(A OR B)
+                 -- AND k`) so both arms seek a target index even unanalyzed; the
+                 -- outer-AND form scans all edges of that kind without stats.
+                 WHERE (e.target_name = ?1 AND e.kind = ?2)
+                    OR (e.target_id IN (SELECT id FROM symbols WHERE name = ?1)
+                        AND e.kind = ?2)",
             )?;
             let rows = stmt
                 .query_map(params![name, kind.as_str()], map_row)?
@@ -207,8 +220,8 @@ impl Database {
                         s.is_async, s.docstring, s.in_degree, s.content_hash, s.subtree_hash
                  FROM edges e
                  LEFT JOIN symbols s ON e.source_id = s.id
-                 LEFT JOIN symbols sym2 ON e.target_id = sym2.id
-                 WHERE e.target_name = ?1 OR sym2.name = ?1",
+                 WHERE e.target_name = ?1
+                    OR e.target_id IN (SELECT id FROM symbols WHERE name = ?1)",
             )?;
             let rows = stmt
                 .query_map(params![name], map_row)?
@@ -274,8 +287,12 @@ impl Database {
                        e.file_path, e.line, e.resolution_source, s.name, 1
                 FROM edges e
                 LEFT JOIN symbols s ON e.source_id = s.id
-                LEFT JOIN symbols sym2 ON e.target_id = sym2.id
-                WHERE e.target_name = ?1 OR sym2.name = ?1
+                -- Anchor uses the indexed OR-subquery form (see refs()): seeds
+                -- the frontier via idx_edges_target + idx_edges_target_id
+                -- instead of full-scanning edges. The recursive step below
+                -- still scans (its match correlates on a dynamic CTE column).
+                WHERE e.target_name = ?1
+                   OR e.target_id IN (SELECT id FROM symbols WHERE name = ?1)
 
                 UNION
 


### PR DESCRIPTION
## Summary

`refs()` and `impact()` full-scanned the `edges` table because their resolved-target
match was expressed as an `OR` spanning two joined tables
(`LEFT JOIN symbols sym2 ON e.target_id = sym2.id ... OR sym2.name = ?`), which SQLite
cannot serve from an index. Rewriting the resolved-target arm as
`OR e.target_id IN (SELECT id FROM symbols WHERE name = ?)` lets the planner pick a
MULTI-INDEX OR over the existing `idx_edges_target` + `idx_edges_target_id` indexes.

For `impact()`, the recursive step's `JOIN edges ON (... OR EXISTS(correlated subquery))`
was split into two recursive UNION arms (a literal `target_name` arm and a resolved
`target_id` arm) so each seeks an index instead of full-scanning edges every iteration.

No schema change, no migration — uses indexes already present. Both rewrites return the
identical edge set as before (verified by symmetric-difference over edge_id + min-depth
across many names and depths).

## Changes

- `refs()`: replace the `sym2` OR-join with an indexed `target_id IN (subquery)` (both
  the unfiltered and kind-filtered branches).
- `impact()`: indexed OR-subquery anchor + split the recursive OR into two indexed UNION
  arms; refresh the docstring to flag the load-bearing "two arms' UNION == old OR-join"
  invariant.
- Add plan-regression tests asserting the queries seek the edge indexes (full EQP detail,
  so `idx_edges_target` can't be subsumed by `idx_edges_target_id`) and never full-scan
  edges; cover both `refs()` branches.

## Measured (real index: skello-app, ~15.5K symbols / 60K edges)

| query | before | after | speedup |
|---|---|---|---|
| `refs(create)` | 19.6 ms | 32 µs | ~600× |
| `refs(Shop)` | 19.5 ms | 3.3 µs | ~5900× |
| `impact(find, d2)` | 295 ms | 233 µs | ~1266× |
| `impact(find, d3)` | 1.18 s | 2.7 ms | ~442× |
| `impact(create, d2)` | 113 ms | 415 µs | ~273× |

Cost is bounded by matched edges, not the popularity of the name, so it stays flat as the
repo grows (verified on the worst-case shared name `initialize`, 435 symbols).

## Checklist

- [x] `make check` passes locally (fmt, clippy `-D warnings`, full workspace tests)
- [x] Commit messages follow conventional commits format
- [x] Tests added/updated for new behavior (correctness + plan-regression)
- [x] Documentation updated if needed (impact() docstring; no user-facing API change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `refs()` to correctly match edges with qualified target names via resolved identifiers.

* **Tests**
  * Added regression tests to verify efficient index-driven query execution for `refs()` and `impact()` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->