### PR TITLE
feat(site): docs search (Pagefind) + mobile-friendly fixes

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from "astro/config";
+import pagefind from "astro-pagefind";
 
 // Deployed to GitHub Pages at https://jrollin.github.io/cartog/.
 // build.format "file" keeps the original flat URLs (usage.html, not usage/),
@@ -15,4 +16,9 @@ export default defineConfig({
     format: "file",
     assets: "_astro",
   },
+  // Pagefind builds a static search index from the built HTML at `astro build`
+  // and serves the UI client-side (no server) — fits GitHub Pages. Only regions
+  // tagged `data-pagefind-body` are indexed; the docs page (usage.astro) carries
+  // it, so search is scoped to the docs.
+  integrations: [pagefind()],
 });

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,7 +8,9 @@
       "name": "cartog-site",
       "version": "0.0.0",
       "dependencies": {
+        "@pagefind/default-ui": "^1.5.2",
         "astro": "^6.4.2",
+        "astro-pagefind": "^1.8.6",
         "mermaid": "^11.15.0"
       }
     },
@@ -1128,6 +1130,109 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.5.2.tgz",
+      "integrity": "sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -2037,6 +2142,20 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro-pagefind": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-1.8.6.tgz",
+      "integrity": "sha512-pofDcWMgA3qLQX9gSJ1mc3NSJDv6o1PDs68MrtdupxMFIlAFT2yckFSiOoaab2stSDmKyX/wVaTObyj5FuBulA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/default-ui": "^1.2.0",
+        "pagefind": "^1.2.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5 || ^6"
       }
     },
     "node_modules/axobject-query": {
@@ -4646,6 +4765,24 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -5189,6 +5326,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5309,6 +5460,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/trim-lines": {

--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,9 @@
     "check": "astro check"
   },
   "dependencies": {
+    "@pagefind/default-ui": "^1.5.2",
     "astro": "^6.4.2",
+    "astro-pagefind": "^1.8.6",
     "mermaid": "^11.15.0"
   }
 }

--- a/site/public/style.css
+++ b/site/public/style.css
@@ -127,6 +127,38 @@ pre,
   fill: var(--text);
 }
 
+/* Right-side action cluster: always visible in the bar (so search stays
+   reachable on mobile, not buried behind the hamburger). The toggle inside
+   is hidden on desktop by the existing .nav-toggle rule. */
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.search-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  /* Comfortable touch target (>=40px) without enlarging the icon. */
+  padding: 10px;
+  margin: -10px;
+}
+
+.search-link svg {
+  width: 19px;
+  height: 19px;
+  stroke: var(--text-secondary);
+  transition: stroke 0.2s;
+}
+
+.search-link:hover svg {
+  stroke: var(--text);
+}
+
 .nav-toggle {
   display: none;
   background: none;
@@ -1413,6 +1445,9 @@ td .badge {
   padding: 2px 6px;
   border-radius: 4px;
   color: var(--accent);
+  /* Long inline tokens (cartog_rag_index, env var names) break instead of
+     widening their container (summary rows, list items) on narrow screens. */
+  overflow-wrap: break-word;
 }
 
 .docs-content pre code {
@@ -1423,6 +1458,12 @@ td .badge {
 
 .docs-content table {
   margin-bottom: 16px;
+  /* Wide reference tables (MCP tool shape, config keys) must scroll within
+     their own box on narrow screens instead of widening the whole page.
+     display:block lets overflow-x:auto take effect on the table element. */
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .mcp-client {

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -7,9 +7,6 @@ import { withBase } from "../lib/url";
 <header class="nav">
   <div class="nav-inner">
     <a href={withBase("index.html")} class="nav-logo">Cartog</a>
-    <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.nav-links').classList.toggle('open')">
-      <span></span><span></span><span></span>
-    </button>
     <ul class="nav-links">
       <li><a href={withBase("index.html#features")}>Features</a></li>
       <li><a href={withBase("index.html#why")}>Why Cartog</a></li>
@@ -24,5 +21,13 @@ import { withBase } from "../lib/url";
         </a>
       </li>
     </ul>
+    <div class="nav-actions">
+      <button type="button" class="search-link" data-open-search aria-label="Search docs" aria-keyshortcuts="Meta+K Control+K">
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"></circle><path stroke-linecap="round" d="M21 21l-4.3-4.3"></path></svg>
+      </button>
+      <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.nav-links').classList.toggle('open')">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </header>

--- a/site/src/components/SearchModal.astro
+++ b/site/src/components/SearchModal.astro
@@ -1,0 +1,273 @@
+---
+// Docs search overlay, opened from the nav search icon (or Cmd/Ctrl+K).
+// Pagefind builds the static index at `astro build`; this file owns the modal
+// shell + open/close + keyboard handling and instantiates PagefindUI lazily on
+// first open. The index is scoped to regions tagged `data-pagefind-body` (only
+// usage.astro carries it), so results are docs-only. We instantiate PagefindUI
+// directly (rather than the <Search> component) only to point `bundlePath` at
+// the deployment base; Pagefind already resolves result URLs against the loaded
+// bundle, so they come back base-prefixed (`/cartog/usage.html#...`).
+import "@pagefind/default-ui/css/ui.css";
+const base = import.meta.env.BASE_URL; // "/cartog/"
+---
+
+<div id="search-backdrop" class="search-backdrop" aria-hidden="true"></div>
+
+<div
+  id="search-modal"
+  class="search-modal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="search-modal-title"
+  data-base={base}
+>
+  <div class="search-modal-inner">
+    <div class="search-modal-head">
+      <h2 id="search-modal-title">Search the docs</h2>
+      <button id="search-close" class="search-close" aria-label="Close search">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+    </div>
+    <div class="search-modal-body">
+      <div id="docs-search" class="pagefind-ui cartog-search"></div>
+    </div>
+    <p class="search-hint">Press <kbd>Esc</kbd> to close · <kbd>⌘</kbd><kbd>K</kbd> to open</p>
+  </div>
+</div>
+
+<script>
+  import { PagefindUI } from "@pagefind/default-ui";
+
+  const backdrop = document.getElementById("search-backdrop");
+  const modal = document.getElementById("search-modal");
+  const closeBtn = document.getElementById("search-close");
+  const openBtns = document.querySelectorAll("[data-open-search]");
+
+  // Astro's BASE_URL, e.g. "/cartog/". Normalized to a single trailing slash.
+  const base = (modal?.dataset.base ?? "/").replace(/\/+$/, "") + "/";
+
+  let initialized = false;
+  function initPagefind() {
+    if (initialized) return;
+    initialized = true;
+    new PagefindUI({
+      element: "#docs-search",
+      bundlePath: base + "pagefind/",
+      showImages: false,
+      showSubResults: true,
+    });
+  }
+
+  function open() {
+    if (!backdrop || !modal) return;
+    initPagefind();
+    document.body.style.overflow = "hidden";
+    backdrop.classList.add("is-open");
+    modal.classList.add("is-open");
+    // Focus the Pagefind input once it has rendered.
+    setTimeout(() => {
+      modal.querySelector<HTMLInputElement>('input[type="text"]')?.focus();
+    }, 60);
+  }
+
+  function close() {
+    if (!backdrop || !modal) return;
+    backdrop.classList.remove("is-open");
+    modal.classList.remove("is-open");
+    document.body.style.overflow = "";
+  }
+
+  openBtns.forEach((b) =>
+    b.addEventListener("click", (e) => {
+      e.preventDefault();
+      open();
+    }),
+  );
+  closeBtn?.addEventListener("click", close);
+  backdrop?.addEventListener("click", close);
+
+  // Close the modal when a result is chosen. Pagefind only renders a link on
+  // the title, so clicking the excerpt body does nothing and would leave the
+  // modal open; here the whole row routes to its link. Also needed for
+  // same-page anchor links (#section), which don't reload the page. Sub-results
+  // each sit in a `.pagefind-ui__result-nested` with their own link, so resolve
+  // the nearest nested block first, then fall back to the card's main title.
+  const results = document.getElementById("docs-search");
+  results?.addEventListener("click", (e) => {
+    const el = e.target as HTMLElement;
+    if (el.closest(".pagefind-ui__result-link")) {
+      close();
+      return;
+    }
+    const scope =
+      el.closest(".pagefind-ui__result-nested") ??
+      el.closest(".pagefind-ui__result");
+    const link = scope?.querySelector<HTMLAnchorElement>(
+      ".pagefind-ui__result-link",
+    );
+    if (link) {
+      link.click(); // navigate, which our link handler above then closes
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    const isOpen = modal?.classList.contains("is-open");
+    if (e.key === "Escape" && isOpen) {
+      close();
+      return;
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      const t = e.target as HTMLElement;
+      if (t.tagName === "INPUT" || t.tagName === "TEXTAREA") return;
+      e.preventDefault();
+      isOpen ? close() : open();
+    }
+  });
+</script>
+
+<style is:global>
+  .search-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    background: rgba(3, 6, 15, 0.7);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.18s ease, visibility 0.18s ease;
+  }
+  .search-backdrop.is-open {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .search-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 201;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 12vh 16px 16px;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
+  }
+  .search-modal.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .search-modal-inner {
+    width: 100%;
+    max-width: 640px;
+    max-height: 76vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+  }
+
+  .search-modal-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border);
+  }
+  .search-modal-head h2 {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0;
+  }
+  .search-close {
+    display: flex;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary);
+    padding: 4px;
+    border-radius: 6px;
+    transition: color 0.2s, background 0.2s;
+  }
+  .search-close:hover {
+    color: var(--text);
+    background: var(--bg-tertiary);
+  }
+
+  .search-modal-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 18px;
+  }
+
+  .search-hint {
+    margin: 0;
+    padding: 8px 18px;
+    border-top: 1px solid var(--border);
+    color: var(--text-tertiary);
+    font-size: 12px;
+  }
+  .search-hint kbd {
+    font-family: "JetBrains Mono", "Fira Code", Menlo, monospace;
+    font-size: 11px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1px 5px;
+    color: var(--text-secondary);
+  }
+
+  /* Theme Pagefind's default UI to the cartog palette. */
+  .cartog-search.pagefind-ui {
+    --pagefind-ui-primary: var(--accent);
+    --pagefind-ui-text: var(--text);
+    --pagefind-ui-background: var(--bg-secondary);
+    --pagefind-ui-border: var(--border);
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 8px;
+    --pagefind-ui-font: inherit;
+  }
+  .cartog-search .pagefind-ui__search-input {
+    background: var(--bg);
+    color: var(--text);
+    border-color: var(--border);
+    font-size: 15px;
+  }
+  .cartog-search .pagefind-ui__search-input:focus {
+    border-color: var(--accent);
+    outline: none;
+  }
+  .cartog-search .pagefind-ui__search-clear {
+    color: var(--text-secondary);
+    background: transparent;
+  }
+  .cartog-search .pagefind-ui__result {
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+  }
+  .cartog-search .pagefind-ui__result:hover {
+    background: var(--bg-tertiary);
+  }
+  .cartog-search .pagefind-ui__result-link {
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .cartog-search .pagefind-ui__result-excerpt,
+  .cartog-search .pagefind-ui__message {
+    color: var(--text-secondary);
+  }
+  .cartog-search mark {
+    background: color-mix(in srgb, var(--accent) 24%, transparent);
+    color: var(--text);
+  }
+</style>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
+import SearchModal from "../components/SearchModal.astro";
 import { withBase } from "../lib/url";
 
 interface Props {
@@ -48,6 +49,7 @@ const favicon =
     <Nav />
     <slot />
     <Footer variant={footerVariant} />
+    <SearchModal />
 
     <script is:inline>
       function copyCmd(btn, text) {

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -90,7 +90,7 @@ import Base from "../layouts/Base.astro";
       </aside>
 
       <!-- Content -->
-      <main class="docs-content">
+      <main class="docs-content" data-pagefind-body>
 
         <p style="margin-bottom: 24px;">
           <a href="https://github.com/jrollin/cartog/releases/latest" class="badge" style="text-decoration: none;">Latest release</a>


### PR DESCRIPTION
## Summary

Adds client-side search over the docs to the marketing site, plus mobile-responsiveness fixes found while testing it.

### Docs search
- Static **Pagefind** index built at `astro build` (`astro-pagefind` + `@pagefind/default-ui`) — no server, fits GitHub Pages.
- Opened from a **search icon in the top nav** or **Cmd/Ctrl+K**; closes on Esc / backdrop click.
- `SearchModal` component themed to the cartog palette (CSS vars, no Tailwind).
- **Docs-only scope** via `data-pagefind-body` on `usage.astro`'s main content — the home page is not indexed.
- `bundlePath` honors the `/cartog/` base so result URLs resolve on Pages.
- Whole result row (including sub-result excerpt text, not just the title) routes to its link and closes the modal.

### Mobile-friendly
Empirically tested with a headless browser at 320 / 375 px on both pages:
- **Fixed horizontal page overflow** on the docs page: wide reference tables (MCP tool shape, config keys) now scroll within their own box (`display:block; overflow-x:auto`) instead of widening the page (~628px overflow before). Long inline code wraps.
- **Search reachable on mobile**: moved the icon into an always-visible `.nav-actions` cluster instead of inside the collapsed hamburger menu; ~40px touch target.
- Verified: no horizontal overflow, search icon + hamburger correct per breakpoint, modal fits and opens, tables/`<pre>` scroll internally.

## Testing
- `npm run build` (site) — clean; Pagefind indexes 1 docs page.
- Browser-driven checks at 320/360/375/1280px: `horizontalOverflow: false`, 0 uncontained overflowers, modal open/close + Cmd-K/Esc verified.

Rebased on `main` after #129 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)