### PR TITLE
feat(version): show git-describe build string in --version and self version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,11 @@ jobs:
             os: windows-latest
 
     steps:
+      # fetch-depth: 0 so build.rs `git describe` sees tags → release binary
+      # shows the clean tag in its version line, not `unknown`.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/crates/cartog/build.rs
+++ b/crates/cartog/build.rs
@@ -3,17 +3,29 @@
 use std::env;
 use std::process::Command;
 
-fn main() {
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short=10", "HEAD"])
+/// Run `git <args>` and return trimmed stdout, or `None` on failure / empty output.
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
         .output()
         .ok()
         .filter(|o| o.status.success())
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
+}
+
+fn main() {
+    let sha =
+        git_output(&["rev-parse", "--short=10", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=CARTOG_BUILD_SHA={sha}");
+
+    // Display-only `git describe` (e.g. `v0.29.1-2-g3e2822c`) so unreleased main
+    // builds are visibly distinct from a release. NOT the comparison key —
+    // CARGO_PKG_VERSION stays the clean semver `self update`/crates.io use.
+    let describe = git_output(&["describe", "--tags", "--dirty", "--always"])
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=CARTOG_BUILD_VERSION={describe}");
 
     let mut features: Vec<String> = env::vars()
         .filter_map(|(k, _)| {
@@ -42,18 +54,40 @@ fn main() {
     let target = env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
     println!("cargo:rustc-env=CARTOG_TARGET_TRIPLE={target}");
 
-    // Resolve via git so worktrees (.git as a file) work; fall back gracefully
-    // when not in a checkout (e.g. `cargo install` from crates.io).
-    let head_path = Command::new("git")
-        .args(["rev-parse", "--git-path", "HEAD"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-    match head_path {
-        Some(p) => println!("cargo:rerun-if-changed={p}"),
-        None => println!("cargo:rerun-if-env-changed=CARTOG_BUILD_SHA"),
+    // Re-run the build script when the commit changes. Emitting ANY rerun-if
+    // disables cargo's default "rebuild on any package file change", so the SHA
+    // and describe strings would otherwise freeze at first build. .git/HEAD only
+    // changes on branch switch — a plain `git commit` moves the branch ref, so
+    // we must also watch the resolved ref file and packed-refs. `git describe`'s
+    // `-dirty` flag tracks the working tree, which no .git path reflects; that
+    // suffix is therefore best-effort and may lag until a watched ref changes.
+    // Falls back to env-changed when not in a checkout (`cargo install`).
+    let mut watched = false;
+    for path in git_rerun_paths() {
+        println!("cargo:rerun-if-changed={path}");
+        watched = true;
     }
+    if !watched {
+        println!("cargo:rerun-if-env-changed=CARTOG_BUILD_SHA");
+    }
+}
+
+/// Git paths whose change should re-run the build script: `HEAD`, the branch
+/// ref `HEAD` points at, and `packed-refs`. Resolved via git so worktrees
+/// (`.git` as a file) and custom git dirs work. Missing paths are skipped.
+fn git_rerun_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+    if let Some(head) = git_output(&["rev-parse", "--git-path", "HEAD"]) {
+        paths.push(head);
+    }
+    // The branch ref that a plain `git commit` advances (e.g. refs/heads/main).
+    if let Some(symref) = git_output(&["symbolic-ref", "--quiet", "HEAD"]) {
+        if let Some(ref_path) = git_output(&["rev-parse", "--git-path", &symref]) {
+            paths.push(ref_path);
+        }
+    }
+    if let Some(packed) = git_output(&["rev-parse", "--git-path", "packed-refs"]) {
+        paths.push(packed);
+    }
+    paths
 }

--- a/crates/cartog/src/cli.rs
+++ b/crates/cartog/src/cli.rs
@@ -8,6 +8,8 @@ use cartog_core::{EdgeKind, SymbolKind};
 /// Short form (`-V`) keeps the bare semver. Populated by `build.rs`.
 pub const LONG_VERSION: &str = concat!(
     env!("CARGO_PKG_VERSION"),
+    "\ndescribe: ",
+    env!("CARTOG_BUILD_VERSION"),
     "\nbuild:    ",
     env!("CARTOG_BUILD_SHA"),
     "\nfeatures: ",

--- a/crates/cartog/src/commands/self_cmd.rs
+++ b/crates/cartog/src/commands/self_cmd.rs
@@ -23,6 +23,10 @@ const COMPILE_TIME_INSTALL_SOURCE: &str = env!("CARTOG_INSTALL_SOURCE");
 /// Compile-time target triple, e.g. `aarch64-apple-darwin`.
 const TARGET_TRIPLE: &str = env!("CARTOG_TARGET_TRIPLE");
 
+/// `git describe` display version (e.g. `v0.29.1-2-g3e2822c`); distinct from
+/// the clean semver in [`VersionInfo::version`] used for update comparisons.
+const BUILD_VERSION: &str = env!("CARTOG_BUILD_VERSION");
+
 /// Test seam: when set to `release-tarball`, `cargo`, or `dev`, the install
 /// source is forced to that value, bypassing the compile-time + path
 /// heuristics. Lets the integration suite drive the cargo-refusal branch
@@ -97,6 +101,10 @@ fn looks_like_cargo_install(binary_path: &Path, cargo_home: Option<&Path>) -> bo
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct VersionInfo {
     pub version: String,
+    /// `git describe` display string; additive JSON field (no `deny_unknown_fields`).
+    /// Serialized as `describe` to match the human label and docs.
+    #[serde(rename = "describe")]
+    pub build_version: String,
     pub target: String,
     pub install_source: String,
     /// RFC3339 timestamp of the last successful update check, or `None`.
@@ -114,6 +122,7 @@ impl VersionInfo {
     pub(crate) fn build(state: &State) -> Self {
         Self {
             version: env!("CARGO_PKG_VERSION").to_string(),
+            build_version: BUILD_VERSION.to_string(),
             target: TARGET_TRIPLE.to_string(),
             install_source: effective_install_source().to_string(),
             last_update_check: state.last_update_check.clone(),
@@ -124,9 +133,12 @@ impl VersionInfo {
     /// Render the human-readable form printed when `--json` is not set.
     pub(crate) fn render_human(&self) -> String {
         let last = self.last_update_check.as_deref().unwrap_or("never");
+        // Values aligned to the widest label (`last update check:`) so all four
+        // detail lines start their value at the same column.
         format!(
-            "cartog {version}\n  target:           {target}\n  install source:   {source}\n  last update check: {last}\n",
+            "cartog {version}\n  describe:          {build}\n  target:            {target}\n  install source:    {source}\n  last update check: {last}\n",
             version = self.version,
+            build = self.build_version,
             target = self.target,
             source = self.install_source,
             last = last,
@@ -1544,6 +1556,25 @@ fn emit_migrate_result(
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn render_human_shows_describe_value_separately_from_version() {
+        let info = VersionInfo {
+            version: "0.29.1".into(),
+            build_version: "v0.29.1-2-g3e2822c".into(),
+            target: "x".into(),
+            install_source: "dev".into(),
+            last_update_check: None,
+            pending_update: None,
+        };
+        let out = info.render_human();
+        // The version line carries the bare semver, the describe line its own value
+        // — assert on the values, not the column padding.
+        assert!(out.lines().any(|l| l == "cartog 0.29.1"));
+        assert!(out
+            .lines()
+            .any(|l| l.trim_start().starts_with("describe:") && l.contains("v0.29.1-2-g3e2822c")));
+    }
 
     #[test]
     fn update_mode_from_flags_maps_each_combination() {

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -10,7 +10,7 @@
 | `cartog self update --check` | Check whether an update exists; do nothing else |
 | `cartog self update --defer` | Arm a deferred update (record the target, do **not** swap); succeeds even while a peer runs |
 | `cartog self update --apply-pending` | Apply a previously-armed deferred update once no peer holds the lock |
-| `cartog self version` | Print version, target triple, install source, last check timestamp, pending update |
+| `cartog self version` | Print version, `describe` build string, target triple, install source, last check timestamp, pending update |
 | `cartog self rollback` | Restore the previous binary (the `<bin>.old` sibling) |
 
 ## Upgrade in place
@@ -112,7 +112,7 @@ cartog self version
 cartog self version --json
 ```
 
-Reports the bare semver, target triple (e.g. `aarch64-apple-darwin`), install source, and the timestamp of the last successful update check (`never` if none).
+Reports the bare semver, a `describe` string (`git describe` output, e.g. `v0.29.1-2-g3e2822c` for an unreleased main build vs `v0.29.1` for a release), target triple (e.g. `aarch64-apple-darwin`), install source, and the timestamp of the last successful update check (`never` if none). The semver, not `describe`, is what `cartog self update` compares against the latest release.
 
 `install_source` is one of:
 - `release-tarball` — downloaded from a GitHub release (or installed via `install.sh`)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1320,7 +1320,7 @@ Manage the installed cartog binary in place: upgrade, inspect, roll back, or mig
 ```bash
 cartog self update             # upgrade to the latest stable
 cartog self update --check     # report whether an update exists; exit 1 if outdated
-cartog self version            # version + target + install source + last check
+cartog self version            # version + describe build string + target + install source + last check
 cartog self rollback           # restore the previous binary saved at <bin>.old
 cartog self migrate-db         # move legacy .cartog.db (+ -wal/-shm/.bak) into .cartog/
 cartog self migrate-db --dry-run  # preview the planned moves without touching the filesystem

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -1152,12 +1152,13 @@ Dry run only. Re-run without --dry-run to apply.</pre>
         <p>Manage the installed cartog binary in place: upgrade, inspect, or roll back. <code>cargo install cartog</code> users get an exit-3 refusal pointing at <code>cargo install cartog --force</code>; release-tarball installs swap atomically with SHA256 verification and a <code>&lt;bin&gt;.old</code> rollback slot.</p>
         <pre>cartog self update              <span class="comment"># upgrade to the latest stable</span>
 cartog self update --check      <span class="comment"># exit 1 if outdated, 0 if current</span>
-cartog self version             <span class="comment"># target + install source + last check</span>
+cartog self version             <span class="comment"># version + describe + target + install source + last check</span>
 cartog self rollback            <span class="comment"># restore the previous binary</span>
 cartog self migrate-db          <span class="comment"># move legacy .cartog.db into .cartog/db.sqlite</span>
 cartog self migrate-db --dry-run <span class="comment"># preview the move without touching disk</span></pre>
         <p class="example-label">Example output (<code>cartog self version</code>)</p>
-        <pre class="example-output">cartog 0.18.0
+        <pre class="example-output">cartog 0.29.1
+  describe:          v0.29.1
   target:            aarch64-apple-darwin
   install source:    release-tarball
   last update check: 2026-05-27T14:50:47Z</pre>


### PR DESCRIPTION
Unreleased main builds now report a `describe:` string so they are visibly distinct from a release tarball.

## What changed

- **`build.rs`** — emit `CARTOG_BUILD_VERSION` from `git describe --tags --dirty --always` (read-only, falls back to `unknown` outside a checkout). Extracted a `git_output()` helper (3 git chains → 1). The `rerun-if-changed` set now watches `.git/HEAD`, the resolved branch ref, and `packed-refs`, so the describe string recomputes on commit/tag instead of freezing at first build.
- **`cli.rs`** — add a `describe:` line to `--version` long form. `-V` short stays the bare semver.
- **`self_cmd.rs`** — `VersionInfo.build_version` field (JSON key `describe` via `serde(rename)`), rendered in `cartog self version`. Detail-line values aligned to a single column. New behaviour test.
- **`release.yml`** — `fetch-depth: 0` on the build-job checkout so the released binary shows the clean tag.
- **docs + site** — `docs/usage.md`, `docs/updates.md`, and `site/src/pages/usage.astro` (comment + example-output block) document the `describe` field.

## Design invariant

`describe` / `build_version` is **display-only**. `CARGO_PKG_VERSION` stays the sole comparison key. Verified no impact on:
- `cartog self update` / `--check` / `--defer` / `--apply-pending` (compare `CARGO_PKG_VERSION` only)
- `scripts/install.sh` (prints `--version`, never parses)
- `skills/cartog/scripts/ensure_indexed.sh` drift check (reads `version`/`install_source`; the rename also removed a latent `"version"` regex-collision)

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full `cartog` suite (388), self-update integration (40), skill tests (40), `npm run build` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version commands (`cartog --version` and `cartog self version`) now display build metadata including a git describe string for enhanced version identification.

* **Documentation**
  * Updated usage documentation to reflect the new describe field in version output across multiple reference guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->