### PR TITLE
fix(languages): bound parsing and AST-walk recursion to prevent stack-overflow aborts

### DIFF
--- a/crates/cartog-languages/src/dart.rs
+++ b/crates/cartog-languages/src/dart.rs
@@ -31,9 +31,7 @@ impl Default for DartExtractor {
 
 impl Extractor for DartExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let mut symbols = Vec::new();
@@ -60,6 +58,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "class_declaration" | "mixin_declaration" | "extension_declaration" => {
             extract_class_like(node, source, file_path, parent, symbols, edges);
@@ -971,6 +970,7 @@ fn walk_for_nested_decls(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     for child in node.named_children(&mut node.walk()) {
         match child.kind() {
             "local_function_declaration" | "function_declaration" => {

--- a/crates/cartog-languages/src/go.rs
+++ b/crates/cartog-languages/src/go.rs
@@ -27,9 +27,7 @@ impl Default for GoExtractor {
 
 impl Extractor for GoExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let mut symbols = Vec::new();
@@ -58,6 +56,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "function_declaration" => {
             extract_function(
@@ -346,6 +345,7 @@ fn extract_interface_embeds(
     line: u32,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     for child in node.named_children(&mut node.walk()) {
         match child.kind() {
             // Direct embedded type at any nesting level
@@ -401,6 +401,7 @@ fn extract_import(
 }
 
 fn collect_import_specs<'a>(node: Node<'a>, specs: &mut Vec<Node<'a>>) {
+    crate::parse::guard_recursion!();
     for child in node.named_children(&mut node.walk()) {
         if child.kind() == "import_spec" {
             specs.push(child);
@@ -769,6 +770,7 @@ fn collect_type_refs_recursive(
     sym_id: &str,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "type_identifier" => {
             let name = node_text(node, source);
@@ -817,6 +819,7 @@ fn go_visibility(name: &str) -> Visibility {
 
 /// Extract the type name, stripping pointer indirection.
 fn extract_type_name(node: Node, source: &str) -> String {
+    crate::parse::guard_recursion!(String::new());
     match node.kind() {
         "pointer_type" => {
             // *Type → "Type"

--- a/crates/cartog-languages/src/java.rs
+++ b/crates/cartog-languages/src/java.rs
@@ -27,9 +27,7 @@ impl Default for JavaExtractor {
 
 impl Extractor for JavaExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let mut symbols = Vec::new();
@@ -58,6 +56,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "class_declaration" | "enum_declaration" | "annotation_type_declaration" => {
             extract_class_like(
@@ -280,6 +279,7 @@ fn extract_class_body(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     for child in node.named_children(&mut node.walk()) {
         match child.kind() {
             "method_declaration" => {
@@ -883,6 +883,7 @@ fn collect_type_refs(
     line: u32,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "type_identifier" => {
             let name = node_text(node, source);
@@ -924,6 +925,7 @@ fn is_primitive(name: &str) -> bool {
 
 /// Extract the simple (unqualified) type name from a type node.
 fn extract_simple_type_name(node: Node, source: &str) -> String {
+    crate::parse::guard_recursion!(String::new());
     match node.kind() {
         "type_identifier" => node_text(node, source).to_string(),
         "scoped_type_identifier" => {

--- a/crates/cartog-languages/src/js_shared.rs
+++ b/crates/cartog-languages/src/js_shared.rs
@@ -101,8 +101,7 @@ pub fn extract(
     source: &str,
     file_path: &str,
 ) -> Result<ExtractionResult> {
-    let tree = parser
-        .parse(source, None)
+    let tree = crate::parse_bounded(parser, source)
         .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
     let mut symbols = Vec::new();
@@ -130,6 +129,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         // Functions
         "function_declaration" => {

--- a/crates/cartog-languages/src/kotlin.rs
+++ b/crates/cartog-languages/src/kotlin.rs
@@ -40,9 +40,7 @@ impl Default for KotlinExtractor {
 
 impl crate::Extractor for KotlinExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("failed to parse {file_path}"))?;
 
         if tree_depth_exceeds(tree.root_node(), MAX_TREE_DEPTH) {
@@ -75,6 +73,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "class_declaration" => {
             extract_type_like(node, source, file_path, parent, symbols, edges);
@@ -651,6 +650,7 @@ fn collect_type_refs(
     source_id: &str,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "annotation" | "type_parameters" | "modifiers" => return,
         // A qualified `user_type` is ONE reference (its leaf), not one per dotted
@@ -700,6 +700,7 @@ fn collect_type_refs(
 /// Walk a subtree for `call_expression` nodes, emitting Calls edges. Recurses,
 /// skipping nested function/lambda bodies — their calls belong to the nested symbol.
 fn walk_calls(node: Node, source: &str, file_path: &str, source_id: &str, edges: &mut Vec<Edge>) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "function_declaration" | "lambda_literal" | "anonymous_function" => return,
         "call_expression" => {
@@ -729,6 +730,7 @@ fn walk_calls_through_lambdas(
     source_id: &str,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     if node.kind() == "call_expression" {
         if let Some(name) = callee_name(node, source) {
             edges.push(Edge::new(
@@ -757,6 +759,7 @@ fn walk_nested_decls(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -815,6 +818,7 @@ fn type_identifier_name(node: Node, source: &str) -> Option<String> {
 /// the leading ones are the package path, so we take the last segment, not the
 /// first (taking the first would resolve `com.example.Base` to `com`).
 fn type_name(node: Node, source: &str) -> Option<String> {
+    crate::parse::guard_recursion!(None);
     match node.kind() {
         "type_identifier" => Some(node_text(node, source).to_string()),
         "user_type" => {

--- a/crates/cartog-languages/src/lib.rs
+++ b/crates/cartog-languages/src/lib.rs
@@ -15,6 +15,7 @@ pub mod javascript;
 mod js_shared;
 pub mod kotlin;
 pub mod markdown;
+pub(crate) mod parse;
 pub mod php;
 pub mod python;
 pub(crate) mod queries;
@@ -64,36 +65,6 @@ pub(crate) fn qualified(parent_qname: Option<&str>, name: &str) -> String {
     }
 }
 
-/// Deepest AST nesting a recursive extractor will descend before bailing. Recursive
-/// walkers use one stack frame per level; pathological/generated source would
-/// otherwise overflow the worker stack and abort the whole index run.
-pub(crate) const MAX_TREE_DEPTH: usize = 600;
-
-/// Iterative (non-recursive) check that the tree's max depth stays within `limit`.
-/// Uses a `TreeCursor` so it can't itself overflow on the very input it guards.
-pub(crate) fn tree_depth_exceeds(root: Node, limit: usize) -> bool {
-    let mut cursor = root.walk();
-    let mut depth = 0usize;
-    loop {
-        if depth > limit {
-            return true;
-        }
-        if cursor.goto_first_child() {
-            depth += 1;
-            continue;
-        }
-        loop {
-            if cursor.goto_next_sibling() {
-                break;
-            }
-            if !cursor.goto_parent() {
-                return false;
-            }
-            depth -= 1;
-        }
-    }
-}
-
 /// Enclosing scope while extracting: `id` becomes the child's `parent_id`,
 /// `qname` its `parent_name`. Top level: `id` is `None`, `qname` the namespace.
 #[derive(Clone, Copy, Default)]
@@ -119,6 +90,8 @@ impl<'a> ParentScope<'a> {
         }
     }
 }
+
+pub(crate) use parse::{parse_bounded, tree_depth_exceeds, MAX_TREE_DEPTH};
 
 pub use cartog_core::detect_language;
 

--- a/crates/cartog-languages/src/parse.rs
+++ b/crates/cartog-languages/src/parse.rs
@@ -1,0 +1,217 @@
+//! Parse-safety guards: bound tree-sitter parsing so pathological input degrades
+//! instead of overflowing the worker stack or hanging (both abort the index run).
+
+use std::ops::ControlFlow;
+use std::time::{Duration, Instant};
+use tree_sitter::{Node, ParseOptions, Parser, Tree};
+
+/// Max AST-walker call depth before a recursive extractor bails (one frame/level).
+pub(crate) const MAX_TREE_DEPTH: usize = 600;
+
+/// Per-parse wall-clock budget; tree-sitter's GLR parser can recurse/run unbounded
+/// on adversarial input (a stack-overflow abort, not a catchable error). Normal
+/// files parse in well under this; it only ever trips on pathological input.
+pub(crate) const MAX_PARSE_TIME: Duration = Duration::from_secs(1);
+
+/// RAII call-depth limiter for the manual AST walkers; error-recovery trees can be
+/// walked far deeper than their node depth, so a node-depth pre-check is not enough.
+pub(crate) struct RecursionGuard;
+
+thread_local! {
+    static WALK_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+impl RecursionGuard {
+    /// Enter one recursion level, or `None` past [`MAX_TREE_DEPTH`] (caller bails).
+    pub(crate) fn enter() -> Option<Self> {
+        WALK_DEPTH.with(|d| {
+            if d.get() >= MAX_TREE_DEPTH {
+                None
+            } else {
+                d.set(d.get() + 1);
+                Some(Self)
+            }
+        })
+    }
+}
+
+impl Drop for RecursionGuard {
+    fn drop(&mut self) {
+        WALK_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    }
+}
+
+/// Bail out of a recursive AST walker once the call depth hits [`MAX_TREE_DEPTH`].
+/// Bind at the top of every self-recursive walker; the held guard decrements on
+/// return. `guard_recursion!()` returns `()`; `guard_recursion!(expr)` returns `expr`.
+macro_rules! guard_recursion {
+    () => {
+        let _depth_guard = match $crate::parse::RecursionGuard::enter() {
+            Some(g) => g,
+            None => return,
+        };
+    };
+    ($ret:expr) => {
+        let _depth_guard = match $crate::parse::RecursionGuard::enter() {
+            Some(g) => g,
+            None => return $ret,
+        };
+    };
+}
+pub(crate) use guard_recursion;
+
+/// Iterative depth check (uses a `TreeCursor`, so it can't itself overflow).
+pub(crate) fn tree_depth_exceeds(root: Node, limit: usize) -> bool {
+    let mut cursor = root.walk();
+    let mut depth = 0usize;
+    loop {
+        if depth > limit {
+            return true;
+        }
+        if cursor.goto_first_child() {
+            depth += 1;
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                break;
+            }
+            if !cursor.goto_parent() {
+                return false;
+            }
+            depth -= 1;
+        }
+    }
+}
+
+/// Parse `source`, aborting past [`MAX_PARSE_TIME`]. Returns `None` on cancel (the
+/// callback fires before the stack-blowing recursion), letting callers degrade.
+pub(crate) fn parse_bounded(parser: &mut Parser, source: &str) -> Option<Tree> {
+    parse_bounded_with(parser, source, MAX_PARSE_TIME)
+}
+
+/// [`parse_bounded`] with an explicit budget (tests pass a short one).
+fn parse_bounded_with(parser: &mut Parser, source: &str, budget: Duration) -> Option<Tree> {
+    let start = Instant::now();
+    let mut on_progress = |_: &tree_sitter::ParseState| {
+        if start.elapsed() > budget {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    };
+    let options = ParseOptions::new().progress_callback(&mut on_progress);
+    let bytes = source.as_bytes();
+    parser.parse_with_options(
+        &mut |offset, _| bytes.get(offset..).unwrap_or_default(),
+        None,
+        Some(options),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Language;
+
+    fn kotlin_parser() -> Parser {
+        let mut p = Parser::new();
+        p.set_language(&Language::new(tree_sitter_kotlin_sg::LANGUAGE))
+            .expect("kotlin grammar");
+        p
+    }
+
+    // Kotlin input that makes tree-sitter's parser recurse/run unbounded (regression
+    // for the CI stack overflow in `extractors_never_panic_on_arbitrary_source`).
+    const KOTLIN_PARSE_BOMB: &str =
+        "(0mf0l:!D4sE^_-Qg9A@y|\"E~=.ztkM!SJeP~@z\\I_\\-Ybf%hrP<1R(iz+&%jw}B`";
+
+    #[test]
+    fn cancels_pathological_parse_within_budget() {
+        // Unbounded, this input never returns; bounded, it cancels to None.
+        let tree = parse_bounded_with(
+            &mut kotlin_parser(),
+            KOTLIN_PARSE_BOMB,
+            Duration::from_millis(50),
+        );
+        assert!(tree.is_none(), "pathological parse must be cancelled");
+    }
+
+    #[test]
+    fn parses_normal_source_within_budget() {
+        let tree = parse_bounded_with(
+            &mut kotlin_parser(),
+            "fun greet(name: String) = println(name)",
+            MAX_PARSE_TIME,
+        );
+        assert!(tree.is_some_and(|t| !t.root_node().has_error()));
+    }
+
+    // TSX input whose error-recovery tree the walker descends far past its node depth.
+    const TSX_RECURSION_BOMB: &str = "'T|3FG!knfh}r&}d+WxkCizKB(m>t*-]`)p}Sm7E\\KfqtxyB:o6\\1pX[Z8tt9YF'l(u+-X'-)u^q$m=]S*5JZG7e8n.qd7FNgoD@L@B\\Ds,2}pOyr\\N>UUj[5.o|^rRG|y_8p!T Um{kcy~)'2l279G],Z_$FaS}n9D'2a;:Y&\\t<mwE9zV%Ltt~\"`49I`\"mYGH0ppC.tfrfQYy1vFK>n{jrw6dr?kZOC$i`06b6Y+^u?<`+\\|9WB+S6Z?Pn%9XW4;gxi]E}e=5;x:]SnD_XTF[v/@(4%V3k|.dX)[{GWbm>.~Zy~bvR>iS0.ZKaxg,fQ%tm5>*vD:-f!=/";
+
+    #[test]
+    fn walker_degrades_on_small_stack_instead_of_overflowing() {
+        // 256 KiB reliably overflows the unguarded walk; the guard caps recursion so
+        // the worker thread returns and joins cleanly. Regression for the same CI test.
+        let result = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let mut ex = crate::get_extractor("tsx").expect("tsx extractor");
+                ex.extract(TSX_RECURSION_BOMB, "bomb.tsx")
+                    .map(|r| r.symbols)
+            })
+            .expect("spawn")
+            .join()
+            .expect("walker must not overflow the worker stack");
+        assert!(result.is_ok_and(|s| s.is_empty()));
+    }
+
+    #[test]
+    fn recursion_guard_caps_depth_and_recovers() {
+        let mut guards = Vec::new();
+        for _ in 0..MAX_TREE_DEPTH {
+            guards.push(RecursionGuard::enter().expect("under the cap"));
+        }
+        assert!(RecursionGuard::enter().is_none(), "cap reached");
+        drop(guards);
+        assert!(RecursionGuard::enter().is_some(), "recovers after unwind");
+    }
+
+    // Moderately nested VALID code (well under the cap) must still extract — guards
+    // the silent-truncation regression if the cap or counter logic ever changes.
+    #[test]
+    fn legitimately_nested_code_is_not_truncated() {
+        let depth = 100;
+        let src = format!(
+            "fun outer() {{ {}{} }}",
+            "if (a) { ".repeat(depth),
+            "}".repeat(depth)
+        );
+        let mut ex = crate::get_extractor("kotlin").expect("kotlin extractor");
+        let result = ex.extract(&src, "nested.kt").expect("extracts");
+        assert!(
+            result.symbols.iter().any(|s| s.name == "outer"),
+            "valid {depth}-deep nesting must still yield its symbol"
+        );
+    }
+
+    // Deeply nested VALID code PAST the cap must degrade (return), never overflow —
+    // arch-independent: it exercises the cap directly rather than relying on a stack
+    // size that happens to overflow when unguarded.
+    #[test]
+    fn nesting_past_the_cap_degrades_without_overflowing() {
+        let depth = MAX_TREE_DEPTH + 200;
+        let src = format!("fun f() {{ {}{} }}", "{ ".repeat(depth), "}".repeat(depth));
+        let extracted = std::thread::Builder::new()
+            .stack_size(512 * 1024)
+            .spawn(move || {
+                let mut ex = crate::get_extractor("kotlin").expect("kotlin extractor");
+                ex.extract(&src, "deep.kt").is_ok()
+            })
+            .expect("spawn")
+            .join()
+            .expect("must not overflow the worker stack");
+        assert!(extracted, "over-cap nesting degrades, never aborts");
+    }
+}

--- a/crates/cartog-languages/src/php.rs
+++ b/crates/cartog-languages/src/php.rs
@@ -262,6 +262,7 @@ fn collect_type_names<'a>(node: Node<'a>, source: &'a str) -> Vec<(&'a str, u32)
 
 /// Recursively accumulates `name`/`qualified_name` nodes into `out`.
 fn collect_type_names_in<'a>(node: Node<'a>, source: &'a str, out: &mut Vec<(&'a str, u32)>) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "name" | "qualified_name" => {
             let text = node_text(node, source);
@@ -280,9 +281,7 @@ fn collect_type_names_in<'a>(node: Node<'a>, source: &'a str, out: &mut Vec<(&'a
 impl Extractor for PhpExtractor {
     /// Parses `source` as PHP and extracts symbols and edges into an [`ExtractionResult`].
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let ctx = collect_file_context(tree.root_node(), source);
@@ -311,6 +310,7 @@ fn extract_top_level(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     let parent = ParentScope::top_level(ctx.namespace.as_deref());
     for child in node.named_children(&mut node.walk()) {
         match child.kind() {
@@ -732,6 +732,7 @@ fn collect_injected_named_types<'a>(
     source: &'a str,
     out: &mut Vec<(&'a str, u32)>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "named_type" => {
             if let Some(child) = node.named_children(&mut node.walk()).next() {

--- a/crates/cartog-languages/src/python.rs
+++ b/crates/cartog-languages/src/python.rs
@@ -75,9 +75,7 @@ struct Queries<'a> {
 
 impl Extractor for PythonExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let mut symbols = Vec::new();
@@ -114,6 +112,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "function_definition" => {
             extract_function(queries, node, source, file_path, parent, symbols, edges);

--- a/crates/cartog-languages/src/ruby.rs
+++ b/crates/cartog-languages/src/ruby.rs
@@ -28,9 +28,7 @@ impl Default for RubyExtractor {
 
 impl Extractor for RubyExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let mut symbols = Vec::new();
@@ -57,6 +55,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "method" => {
             extract_method(node, source, file_path, parent, symbols, edges);
@@ -645,6 +644,7 @@ fn ruby_visibility(name: &str) -> Visibility {
 
 /// Extract a constant name from a node, handling `constant`, `scope_resolution`, etc.
 fn extract_constant_name(node: Node, source: &str) -> String {
+    crate::parse::guard_recursion!(String::new());
     match node.kind() {
         "constant" => node_text(node, source).to_string(),
         "scope_resolution" => {

--- a/crates/cartog-languages/src/rust_lang.rs
+++ b/crates/cartog-languages/src/rust_lang.rs
@@ -27,9 +27,7 @@ impl Default for RustExtractor {
 
 impl Extractor for RustExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {file_path}"))?;
 
         let mut symbols = Vec::new();
@@ -58,6 +56,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "function_item" => {
             extract_function(
@@ -472,6 +471,7 @@ fn extract_use_path(node: Node, source: &str) -> String {
 }
 
 fn extract_path_prefix(node: Node, source: &str) -> String {
+    crate::parse::guard_recursion!(String::new());
     match node.kind() {
         "scoped_identifier" => {
             // foo::bar::Baz — get "foo::bar"
@@ -505,6 +505,7 @@ fn collect_use_names(node: Node, source: &str) -> Vec<String> {
 }
 
 fn collect_use_names_recursive(node: Node, source: &str, names: &mut Vec<String>) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "use_as_clause" => {
             // use foo::Bar as Baz  →  collect "Bar"
@@ -783,6 +784,7 @@ fn collect_type_refs_recursive(
     sym_id: &str,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "type_identifier" => {
             let name = node_text(node, source);
@@ -905,6 +907,7 @@ fn extract_doc_comment(node: Node, source: &str) -> Option<String> {
 }
 
 fn extract_type_name(node: Node, source: &str) -> String {
+    crate::parse::guard_recursion!(String::new());
     match node.kind() {
         "type_identifier" | "identifier" => node_text(node, source).to_string(),
         "scoped_type_identifier" | "scoped_identifier" => {

--- a/crates/cartog-languages/src/sfc.rs
+++ b/crates/cartog-languages/src/sfc.rs
@@ -196,7 +196,7 @@ impl SfcExtractor {
 
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
         // Envelope parse failure on junk input degrades to empty, never errors.
-        let Some(tree) = self.envelope.parse(source, None) else {
+        let Some(tree) = crate::parse_bounded(&mut self.envelope, source) else {
             return Ok(ExtractionResult::default());
         };
         let spans = (self.find_scripts)(tree.root_node(), source);

--- a/crates/cartog-languages/src/swift.rs
+++ b/crates/cartog-languages/src/swift.rs
@@ -38,9 +38,7 @@ impl Default for SwiftExtractor {
 
 impl crate::Extractor for SwiftExtractor {
     fn extract(&mut self, source: &str, file_path: &str) -> Result<ExtractionResult> {
-        let tree = self
-            .parser
-            .parse(source, None)
+        let tree = crate::parse_bounded(&mut self.parser, source)
             .ok_or_else(|| anyhow::anyhow!("failed to parse {file_path}"))?;
 
         if tree_depth_exceeds(tree.root_node(), MAX_TREE_DEPTH) {
@@ -73,6 +71,7 @@ fn extract_node(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         "class_declaration" => {
             extract_type_like(node, source, file_path, parent, symbols, edges);
@@ -564,6 +563,7 @@ fn collect_type_refs(
     source_id: &str,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     if node.kind() == "type_identifier" {
         let name = node_text(node, source);
         if !name.is_empty() && !is_builtin_type(name) {
@@ -588,6 +588,7 @@ fn collect_type_refs(
 /// IS a call), then recurses, skipping nested function/closure bodies — their
 /// calls belong to the nested symbol.
 fn walk_calls(node: Node, source: &str, file_path: &str, source_id: &str, edges: &mut Vec<Edge>) {
+    crate::parse::guard_recursion!();
     match node.kind() {
         // Nested decls own their own calls; don't descend.
         "function_declaration"
@@ -626,6 +627,7 @@ fn walk_nested_decls(
     symbols: &mut Vec<Symbol>,
     edges: &mut Vec<Edge>,
 ) {
+    crate::parse::guard_recursion!();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -680,6 +682,7 @@ fn func_name(node: Node, source: &str) -> Option<String> {
 
 /// Leaf type name from a `type_identifier` / `user_type` node.
 fn type_name(node: Node, source: &str) -> Option<String> {
+    crate::parse::guard_recursion!(None);
     match node.kind() {
         "type_identifier" => Some(node_text(node, source).to_string()),
         "user_type" => {
@@ -704,6 +707,7 @@ fn type_name(node: Node, source: &str) -> Option<String> {
 /// All identifiers bound by a `pattern` node. A simple binding yields one name;
 /// a tuple-destructuring pattern (`(a, b)`) yields one per element.
 fn pattern_identifiers(pattern: Node, source: &str, out: &mut Vec<String>) {
+    crate::parse::guard_recursion!();
     match pattern.kind() {
         "simple_identifier" => out.push(node_text(pattern, source).to_string()),
         _ => {


### PR DESCRIPTION
## Problem

Adversarial source could drive tree-sitter's parser **or** the manual AST walkers into unbounded recursion, overflowing the worker stack. A stack overflow is a `SIGABRT`, not a catchable error, so no `Result` can save it. This:

- violated the documented "indexing must degrade, never abort the run" contract, and
- caused the intermittent CI failure in `extractors_never_panic_on_arbitrary_source` (the abort kills the process before proptest can shrink or save a seed, hence the random-looking, seedless failures).

Two distinct mechanisms, both confirmed by reproduction:
1. **Pathological parse** — a 65-char Kotlin input makes `tree_sitter::parse()` recurse/run unbounded.
2. **Walker over-recursion** — a 335-char TSX input whose error-recovery tree is only ~7 nodes deep, yet the walkers recurse hundreds deep via node revisitation (an lldb backtrace pinned it to `Node::named_children` in the `extract_node` cycle).

## Fix

New parse-safety module `crates/cartog-languages/src/parse.rs`:

- **`parse_bounded`** — caps every parse at a **1s** wall-clock budget via tree-sitter's progress callback (the callback fires before the stack-blowing recursion). Pathological input returns `None`; the extractor degrades to empty/`Err`. Applied at all parse sites.
- **`guard_recursion!` / `RecursionGuard`** — a thread-local RAII call-depth cap (`MAX_TREE_DEPTH = 600`) applied to **every** self-recursive walker, not just `extract_node`. A post-parse node-depth check is insufficient because error-recovery trees are walked far deeper than their node depth.

Move-only: `MAX_TREE_DEPTH` + `tree_depth_exceeds` relocate from `lib.rs` to `parse.rs`, re-exported under the same names — `lib.rs` stays logic-free.

## Tests

- pathological parse cancels within budget
- walker degrades on a small (256 KiB) stack instead of overflowing
- legitimately deep-but-valid nesting still extracts (silent-truncation guard)
- over-cap nesting degrades without overflowing (arch-independent — exercises the cap directly)

## Verification

- **256 KiB-stack × 40k-case fuzz** (the original-failing config, aborted in seconds before) now passes.
- **`index_full_force` criterion bench** before/after: *no measurable change* (p = 0.25–0.98) — the per-tick `elapsed()` is noise-level.
- fmt, clippy (default + `--no-default-features`), doctests, full workspace test suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)