### PR TITLE
chore(deps): bump rusqlite 0.39 → 0.40 (bundled SQLite 3.53.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,14 +1529,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2030,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2996,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 thiserror = "2"
 globset = "0.4"
 ignore = "0.4"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 sqlite-vec = "0.1"
 tree-sitter = "0.26"
 streaming-iterator = "0.1"


### PR DESCRIPTION
## What

Bumps `rusqlite` `0.39 → 0.40` (one line in `Cargo.toml` + lockfile). Pulls in:

- `rusqlite` 0.39.0 → 0.40.1
- `libsqlite3-sys` 0.37.0 → 0.38.1 → **bundled SQLite 3.51.3 → 3.53.2**
- `hashlink` 0.11.1 → 0.12.0 (transitive)

## Why

- Newer bundled SQLite (3.53.2).
- rusqlite 0.40 includes a fix for **SQL injection when a `SAVEPOINT` name is tainted**.
- Routine dependency hygiene.

## Code impact: none

cartog only *consumes* virtual tables (FTS5, sqlite-vec `vec0`) via SQL — it does not
`impl VTab` in Rust, so 0.40's breaking VTab API changes need **zero source edits**. The
workspace builds unchanged.

## No migration for existing DBs

- cartog's `SCHEMA_VERSION` (7) and `EMBEDDING_FORMAT_VERSION` (4) are **unchanged** — no
  migration path fires.
- `sqlite-vec` stays 0.1.9, so the vector storage format is identical.
- Verified: a real `.cartog/db.sqlite` written by the old SQLite 3.51.3 opens cleanly with
  the new 3.53.2 binary — `stats` reads 33k symbols/99k edges and `rag search` returns
  live vec0/FTS5 results, no re-index needed.

## Verification

- ✅ `cargo build` — clean, no source changes
- ✅ Default features: **1698 tests pass**, `clippy --all-targets -D warnings` clean, `fmt --check` clean
- ✅ `--no-default-features`: clippy clean, tests pass
  (one LSP timing test flaked once under concurrent machine load — `request_batch_shares_one_deadline_for_missing_replies`, a 1.5s wall-clock deadline vs a slow subprocess; 5/5 green in isolation, unrelated to SQLite)
- ℹ️ `cargo audit` / `cargo deny check` run in CI on this PR (supply-chain gate for dep changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NHbzA7i2Z9L4GG9vHf3oK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database library dependency to the latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->