### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Lockfile-only bump of `quinn-proto` 0.11.14 → 0.11.15.

## Why

`cargo audit` started failing on all PRs/`main` after **RUSTSEC-2026-0185** was published (2026-06-22):

> **quinn-proto** 0.11.14 — Remote memory exhaustion from unbounded out-of-order stream reassembly. Severity 7.5 (high). Solution: upgrade to >=0.11.15.

It's a transitive dependency (`reqwest` → `quinn` → `quinn-proto`, reached via `self_update`, `rust-s3`, and `hf-hub`), so the fix is a `Cargo.lock` bump, not a manifest change.

## Verification

- `cargo audit` — was `error: 1 vulnerability found!`, now exits 0 (the 2 remaining `unmaintained` warnings, `number_prefix`/`paste`, are pre-existing and allowed).
- `cargo check --workspace` builds clean with the bumped lockfile.

Not related to any feature work — this unblocks CI for every open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)