### PR TITLE
fix(lsp): mark column-unlocatable edges unresolvable to stop zombie re-walks

### DIFF
--- a/crates/cartog-db/src/store/lsp.rs
+++ b/crates/cartog-db/src/store/lsp.rs
@@ -189,14 +189,21 @@ impl Database {
         Ok(n as u32)
     }
 
-    /// Mark a single edge as `resolution_state = 2` (LSP definitively gave up).
+    /// Mark a single edge as `resolution_state = 2` (LSP definitively gave up,
+    /// or cartog could not form a query for it at all).
     ///
-    /// Callers MUST only invoke this after a definitive negative answer from
-    /// the language server. Never call from a transient-error branch (server
-    /// crash, didOpen failure, half-loaded warmup) — the marker is sticky
-    /// across runs until [`Self::reset_unresolvable_for_names`] reopens it
-    /// (on a matching new symbol) or [`Self::reset_all_unresolvable`] runs
-    /// (`--force`).
+    /// Callers MUST only invoke this on a definitive result, one of:
+    /// - a definitive negative answer from the language server (`Ok(None)`), or
+    /// - a deterministic cartog-side fact that the edge is unqueryable — its
+    ///   target column can't be located on its recorded line, so no LSP
+    ///   `definition` request can be sent (see `pending_unlocatable`).
+    ///
+    /// Never call from a transient-error branch (server crash, didOpen failure,
+    /// half-loaded warmup) — the marker is sticky across runs until
+    /// [`Self::reset_unresolvable_for_names`] reopens it (on a matching new
+    /// symbol) or [`Self::reset_all_unresolvable`] runs (`--force`). An
+    /// unlocatable edge's target name is typically a compound expression, so the
+    /// name-keyed reopen won't match it; `--force` is its only reopen path.
     ///
     /// The `WHERE resolution_state = 0` guard preserves the invariant that
     /// state {2, 3} rows have `target_id IS NULL` — without it an accidental

--- a/crates/cartog-lsp/README.md
+++ b/crates/cartog-lsp/README.md
@@ -16,15 +16,16 @@ Resolves edges that the heuristic resolver in `cartog-db` left unresolved, by qu
 4. For each file with unresolved edges:
    - Send `textDocument/didOpen` to the server
    - For each edge, find the target name's **column** in the source line
-   - Send `textDocument/definition` request at that position
+   - **Column not found** (the `target_name` doesn't appear as a locatable word on its recorded line — a whole-expression or multi-line target the extractor emitted, so no column can be computed) → cartog can't even form a query, so buffer as `resolution_state = 2` (unlocatable-by-LSP) and never query it — otherwise it re-walks fruitlessly on every reindex
+   - Otherwise send a `textDocument/definition` request at that position
    - The response collapses into `DefinitionOutcome::InRoot(loc)` (target lives inside the indexed root), `DefinitionOutcome::External` (target lives outside: stdlib, deps, node_modules), or `None` (server gave no answer)
    - **InRoot** + symbol found at file+line → update `target_id` (sets `resolution_state = 1`)
    - **InRoot** + no symbol → buffer as `resolution_state = 2` (cartog extraction gap — not external)
    - **External** → buffer as `resolution_state = 3`
    - **`Ok(None)`** → buffer as `resolution_state = 2` (truly unresolvable)
-   - Unresolvable marks (`state = 2`) are committed *only if* the language resolved at least one in-root edge this run (per-language success gate — protects against half-loaded servers that fabricate `Ok(None)`)
+   - Unresolvable marks (`state = 2`) from `Ok(None)` are committed *only if* the language resolved at least one in-root edge this run (per-language success gate — protects against half-loaded servers that fabricate `Ok(None)`); unlocatable marks are a deterministic cartog-side fact, so they commit whenever the server stayed alive (no success gate, like external)
    - External marks (`state = 3`) come from positive LSP answers and are committed whenever the server stayed alive (no gate)
-   - Transient errors (`Err(_)`) never mark — markers are sticky across runs
+   - Transient errors (`Err(_)`) and a dead server (`server_died`) never mark — markers are sticky across runs
    - Send `textDocument/didClose`
 
 ### Column finding

--- a/crates/cartog-lsp/src/client.rs
+++ b/crates/cartog-lsp/src/client.rs
@@ -845,4 +845,60 @@ mod tests {
             "second write should be near-instant, took {elapsed:?}"
         );
     }
+
+    /// Spawn a fake server that exits immediately (its stdin read-end closes).
+    /// A write against it hits a broken pipe, unlike `silent_fake_server` which
+    /// stays alive and wedges the write until the ack timeout.
+    #[cfg(unix)]
+    fn dead_fake_server() -> LspClient {
+        use std::process::{Command, Stdio};
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn dead fake server");
+        LspClient::new(child).expect("client over dead fake server")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_to_a_dead_server_fails_fast_via_broken_pipe_not_write_timeout() {
+        // The server_died seam: once the child is reaped its stdin read-end is
+        // closed, so a didClose write returns BrokenPipe via the Ok(Err(_)) ack
+        // arm — promptly, never after the full write_timeout. A regression here
+        // (e.g. classifying the broken pipe as a wedge) would reintroduce a 10s
+        // stall on the dead-server path.
+        let mut client = dead_fake_server();
+        // A long write_timeout: if the write blocked on it, the elapsed check
+        // below would fail. A broken pipe must not wait on it at all.
+        client.set_write_timeout(Duration::from_secs(30));
+
+        // Ensure the child has exited (and is reaped) before we write, so the
+        // write deterministically hits a closed pipe rather than a live buffer.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while client.is_alive() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!client.is_alive(), "fake server should have exited");
+
+        let started = Instant::now();
+        let err = client
+            .send_notification("textDocument/didClose", serde_json::json!({}))
+            .expect_err("a write to a dead server must fail");
+        let elapsed = started.elapsed();
+
+        // Classification, not exact timing (cf. the wall-clock deadline flake):
+        // it is NOT a write-timeout wedge, and it returned well under the 30s
+        // write_timeout — proving the BrokenPipe short-circuit, not a block.
+        assert!(
+            !is_write_timeout(&err),
+            "dead-server write is a broken pipe, not a write-ack timeout: {err}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "a broken pipe must return promptly, not wait out write_timeout; took {elapsed:?}"
+        );
+    }
 }

--- a/crates/cartog-lsp/src/resolve.rs
+++ b/crates/cartog-lsp/src/resolve.rs
@@ -25,6 +25,11 @@ pub(crate) struct LangOutcomes {
     pub in_root: Vec<(i64, DefinitionLocation)>,
     /// Definitive "no definition"; marked unresolvable only if ≥1 edge resolved.
     pub pending_unresolvable: Vec<i64>,
+    /// Edge column not found on its line — cartog can't form an LSP query for it,
+    /// so it's unresolvable-by-LSP. Distinct from `pending_unresolvable` (server
+    /// said "no def"): this is a deterministic cartog-side fact, marked whenever
+    /// the server stayed alive (no resolved-gate).
+    pub pending_unlocatable: Vec<i64>,
     /// Target outside the indexed root (stdlib/deps).
     pub pending_external: Vec<i64>,
     /// Process died mid-drain — answers may be corrupt, so `apply` marks nothing
@@ -89,6 +94,24 @@ pub(crate) fn apply_lang_outcomes(
                  not marking (server may be half-loaded or unhealthy)"
             );
         }
+    }
+
+    // Unlocatable: a deterministic cartog-side fact (column not found on the
+    // line), independent of server health, so no resolved-gate like external —
+    // commit whenever the process stayed alive.
+    if !outcomes.server_died {
+        let mut n = 0u32;
+        for edge_id in &outcomes.pending_unlocatable {
+            if let Err(e) = db.mark_edge_unresolvable(*edge_id) {
+                tracing::debug!("failed to mark unlocatable edge {edge_id} unresolvable: {e:#}");
+                continue;
+            }
+            n += 1;
+        }
+        if n > 0 {
+            tracing::debug!("LSP: {language} marked {n} unlocatable edges unresolvable");
+        }
+        marked_unresolvable += n;
     }
 
     // External: a half-loaded server can't fabricate a concrete out-of-root URI,
@@ -274,13 +297,18 @@ pub(crate) fn drain_language(
 
         // Pair each edge whose target column we can locate with its LSP position
         // in ONE vec so the edge↔position↔outcome correspondence can't drift.
-        let batch: Vec<(&UnresolvedEdge, (u32, u32))> = file_edges
-            .iter()
-            .filter_map(|&edge| {
-                find_column_in_line(&lines, edge.line, &edge.target_name)
-                    .map(|col| (edge, (edge.line.saturating_sub(1), col)))
-            })
-            .collect();
+        // An edge whose target_name doesn't appear as a locatable word on its
+        // recorded line (a whole-expression or multi-line target) has no column,
+        // so it can never be queried: bucket it as unresolvable-by-LSP instead of
+        // silently dropping it, or reopen_heuristic_exhausted re-walks it
+        // fruitlessly on every pass.
+        let mut batch: Vec<(&UnresolvedEdge, (u32, u32))> = Vec::with_capacity(file_edges.len());
+        for &edge in &file_edges {
+            match find_column_in_line(&lines, edge.line, &edge.target_name) {
+                Some(col) => batch.push((edge, (edge.line.saturating_sub(1), col))),
+                None => out.pending_unlocatable.push(edge.edge_id),
+            }
+        }
         let positions: Vec<(u32, u32)> = batch.iter().map(|&(_, pos)| pos).collect();
 
         let outcomes = match manager.definitions_batch(language, file_path, &positions, cancel) {
@@ -625,6 +653,55 @@ mod tests {
     }
 
     #[test]
+    fn unlocatable_edges_are_marked_unresolvable() {
+        // An edge whose column couldn't be found is unresolvable-by-LSP; its
+        // count folds into marked_unresolvable alongside a real success.
+        let (db, ids) = db_with_edges(2);
+        let outcomes = LangOutcomes {
+            in_root: vec![in_root_at(ids[0], 10)],
+            pending_unlocatable: vec![ids[1]],
+            ..Default::default()
+        };
+        let (resolved, marked_u, marked_x) = apply_lang_outcomes(&db, "python", &outcomes).unwrap();
+        assert_eq!((resolved, marked_u, marked_x), (1, 1, 0));
+        assert_eq!(db.edge_resolution_state(ids[0]).unwrap(), 1, "resolved");
+        assert_eq!(
+            db.edge_resolution_state(ids[1]).unwrap(),
+            2,
+            "unlocatable → state=2"
+        );
+    }
+
+    #[test]
+    fn unlocatable_marked_even_with_zero_resolved() {
+        // Unlike pending_unresolvable, unlocatable has no resolved-gate: it's a
+        // deterministic cartog-side fact, marked whenever the server stayed alive.
+        // server_died still suppresses it (untrusted pass).
+        let (db, ids) = db_with_edges(1);
+        let outcomes = LangOutcomes {
+            pending_unlocatable: vec![ids[0]],
+            ..Default::default()
+        };
+        let (resolved, marked_u, _) = apply_lang_outcomes(&db, "python", &outcomes).unwrap();
+        assert_eq!((resolved, marked_u), (0, 1), "no gate on resolved");
+        assert_eq!(db.edge_resolution_state(ids[0]).unwrap(), 2);
+
+        let (db2, ids2) = db_with_edges(1);
+        let dead = LangOutcomes {
+            pending_unlocatable: vec![ids2[0]],
+            server_died: true,
+            ..Default::default()
+        };
+        let (_, marked_dead, _) = apply_lang_outcomes(&db2, "python", &dead).unwrap();
+        assert_eq!(marked_dead, 0, "server death suppresses unlocatable marks");
+        assert_eq!(
+            db2.edge_resolution_state(ids2[0]).unwrap(),
+            0,
+            "stays state=0 on death"
+        );
+    }
+
+    #[test]
     fn in_root_with_no_symbol_at_line_is_unresolvable_not_external() {
         // A located line with no covering symbol falls to unresolvable (gated on
         // the sibling success), never external.
@@ -954,6 +1031,59 @@ mod tests {
         assert!(
             !mgr.has_client_for_test("python"),
             "a wedged client must be dropped, not left for start() to reuse"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unlocatable_edges_are_bucketed_and_not_queried() {
+        use crate::manager::test_support::{null_result_frames, scripted_fake_server};
+
+        let _guard = parallel_lock(); // drain_language reads the global panic hook
+
+        // One file, two edges: `findable` sits on its line; the second edge's
+        // target `Pool::new` never appears on its line (line 2 is a different
+        // expression), so no column can be computed — it lands in
+        // pending_unlocatable and is never queried. Only the findable edge
+        // reaches the server.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("f.py"), "findable()\nfoo.bar().baz()\n").unwrap();
+        let edges = vec![
+            UnresolvedEdge {
+                edge_id: 1,
+                target_name: "findable".to_string(),
+                file_path: "f.py".to_string(),
+                line: 1,
+            },
+            UnresolvedEdge {
+                edge_id: 2,
+                target_name: "Pool::new".to_string(),
+                file_path: "f.py".to_string(),
+                line: 2,
+            },
+        ];
+
+        // The server answers exactly one request (id 1) — the one findable edge.
+        let mut mgr = LspManager::new(tmp.path());
+        mgr.insert_client_for_test("python", scripted_fake_server(&null_result_frames(&[1])));
+
+        let sink = ProgressSink::new(2, None);
+        let res = drain_language(tmp.path(), &mut mgr, "python", &edges, &sink, None).unwrap();
+
+        assert_eq!(
+            res.outcomes.pending_unlocatable,
+            vec![2],
+            "the unfindable edge is bucketed as unlocatable"
+        );
+        assert_eq!(
+            res.outcomes.pending_unresolvable,
+            vec![1],
+            "only the findable edge was queried (server said no def)"
+        );
+        assert_eq!(
+            sink.processed(),
+            1,
+            "only the findable edge is queried — the unlocatable one never is"
         );
     }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -135,6 +135,17 @@ the same way: each write has a 10 s deadline, and cartog logs `… LSP server
 stopped reading stdin …` and falls back to heuristics for that language instead
 of hanging.
 
+### Some edges never resolve no matter how many times I reindex
+
+If an edge's target name can't be located as a word on its recorded source line
+— because the extractor emitted a whole expression or a multi-line target that
+doesn't appear verbatim on that one line — cartog can't compute a column, so it
+can't form an LSP definition query for it. Those edges are now sealed as
+`unresolvable` (state 2) — surfaced as `provenance: lsp_unresolvable` in `--json`
+— instead of being re-attempted on every reindex. To reopen them, run
+`cartog index --force` (a name-keyed reopen won't fire: the stored target name is
+a compound expression that never matches a plain added symbol name).
+
 ### My `[lsp.<lang>]` command override isn't being used
 
 - The override only fires during the LSP edge-resolution pass — run


### PR DESCRIPTION
## Problem

During LSP edge resolution, `drain_language` locates each edge's target column on its source line via `find_column_in_line`. Edges whose `target_name` can't be located as a word on its recorded line — a whole-expression or multi-line target (e.g. the Rust extractor emits `Pool::new`, method-chain receivers) — were **silently dropped** by the query-batch `filter_map`. A dropped edge is never queried, never marked, and stays `resolution_state = 0` forever.

Because `reopen_heuristic_exhausted` un-seals state 4→0 before every LSP-enabled reindex, these edges are re-fetched and re-attempted on **every** pass with zero progress. On the family-check DB this was ~10,928 permanent state-0 zombies (only ~72 edges were locatable).

## Fix (Part 1)

An edge cartog can't even form a query for is definitively unresolvable-by-LSP. Capture the dropped edge_ids in a new `LangOutcomes.pending_unlocatable` bucket and mark them `unresolvable` (state 2) via the existing `mark_edge_unresolvable`, so they stop re-walking.

- **Gating**: `!server_died` only (no `resolved > 0` gate, unlike `pending_unresolvable`) — unlocatable is a deterministic cartog-side fact independent of server health, same trust model as the external bucket.
- Sticky-but-self-correcting: reset by `--force` (`reset_all_unresolvable`). The name-keyed reopen (`reset_unresolvable_for_names`) can't match a compound target name, so `--force` is the only reopen path (documented).
- Resolution-side, **all-language** fix — no extractor change.

The Rust-extractor root cause (emit bare identifiers instead of `Pool::new`) is a separate, larger PR (breaks extractor tests + `webapp_rs.json` ground-truth, needs bench re-verify) — **explicitly deferred**.

## Part 2 — dead-server `close_file` invariant (test-only)

Investigated and found **already safe**: on the `server_died` path the child is reaped, so its stdin read-end is closed and `close_file`'s write returns `BrokenPipe` promptly via the `Ok(Err(_))` ack arm — no `write_timeout` block. Added a `#[cfg(unix)]` regression test so a future edit can't reintroduce a 10s stall on this seam. No production change.

## Also

Widened `mark_edge_unresolvable`'s precondition docstring to sanction the cartog-side unlocatable determination alongside the server `Ok(None)` case.

## Tests

- `unlocatable_edges_are_marked_unresolvable` — folds into `marked_unresolvable` alongside a real success.
- `unlocatable_marked_even_with_zero_resolved` — proves the health-gate difference vs `pending_unresolvable`; `server_died=true` suppresses.
- `unlocatable_edges_are_bucketed_and_not_queried` (`#[cfg(unix)]`, scripted fake server) — the unfindable edge lands in `pending_unlocatable` and is never queried; only the findable edge reaches the server.
- `write_to_a_dead_server_fails_fast_via_broken_pipe_not_write_timeout` (`#[cfg(unix)]`) — dead-server write returns `Err` well under a 30s `write_timeout`, not classified as a wedge.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (+ `--no-default-features`), `cargo test -p cartog-lsp -p cartog-db` (83 + 199), `cargo test --workspace` (+ `--no-default-features`), `cargo doc --no-deps` (lsp + db, warning-clean) — all green.

## Docs

Internal resilience change (no new command/flag/config/MCP-tool/language/count), so site + reference docs untouched per doc-sync rule. Updated the cartog-lsp `README.md` outcome list (adds the unlocatable branch) and one `docs/troubleshooting.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edges that can’t be precisely located on a source line are now handled more consistently and won’t be queried unnecessarily.
  * LSP requests now fail fast when the server process is already dead, instead of being mistaken for a timeout.
  * Unresolvable resolution states are now recorded more reliably, while transient failures and dead-server cases are left unmarked.

* **Documentation**
  * Improved troubleshooting guidance for resolution issues and reopen behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->