### PR TITLE
chore(plugin): enrich Claude plugin manifest metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,10 +3,24 @@
   "description": "Code graph navigation and semantic search for LLM coding agents",
   "version": "0.30.3",
   "license": "MIT",
-  "keywords": ["code-graph", "tree-sitter", "semantic-search", "code-navigation", "refactoring"],
+  "category": "developer-tools",
+  "keywords": [
+    "code-graph",
+    "tree-sitter",
+    "semantic-search",
+    "code-navigation",
+    "refactoring",
+    "code-indexer",
+    "mcp",
+    "rag",
+    "llm-agents",
+    "impact-analysis"
+  ],
   "author": {
     "name": "Julien Rollin"
   },
+  "homepage": "https://www.cartog.dev",
+  "repository": "https://github.com/jrollin/cartog",
   "skills": "./skills/",
   "mcpServers": {
     "cartog": {


### PR DESCRIPTION
## Summary

Enrich `.claude-plugin/plugin.json` with provenance and discovery metadata,
matching the convention used across the repo (README, docs, site, VS Code
extension all reference `www.cartog.dev`) and by comparable marketplace plugins.

## Changes

- **Provenance**: add `homepage` (`https://www.cartog.dev`) and `repository`
  (`https://github.com/jrollin/cartog`).
- **Discovery**: add `category: developer-tools`; expand `keywords` 5 → 10
  (`code-indexer`, `mcp`, `rag`, `llm-agents`, `impact-analysis`).

Metadata-only, no behavior change. Validated with `claude plugin validate .` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved plugin metadata with clearer categorization and expanded discoverability keywords.
  * Added homepage and repository information to the author details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->