### PR TITLE
fix(mcp): drop unused `rmcp::model::*` glob imports

### DIFF
--- a/crates/cartog-mcp/src/tools/graph.rs
+++ b/crates/cartog-mcp/src/tools/graph.rs
@@ -2,9 +2,7 @@
 
 use std::sync::Arc;
 
-use rmcp::{
-    handler::server::wrapper::Parameters, model::*, tool, tool_router, ErrorData as McpError,
-};
+use rmcp::{handler::server::wrapper::Parameters, tool, tool_router, ErrorData as McpError};
 
 use crate::types::*;
 use crate::*;

--- a/crates/cartog-mcp/src/tools/index.rs
+++ b/crates/cartog-mcp/src/tools/index.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use rmcp::{
-    handler::server::wrapper::Parameters, model::*, service::RequestContext, tool, tool_router,
+    handler::server::wrapper::Parameters, service::RequestContext, tool, tool_router,
     ErrorData as McpError, RoleServer,
 };
 

--- a/crates/cartog-mcp/src/tools/manage.rs
+++ b/crates/cartog-mcp/src/tools/manage.rs
@@ -1,6 +1,6 @@
 //! MCP management tool: cartog_update.
 
-use rmcp::{model::*, tool, tool_router, ErrorData as McpError};
+use rmcp::{tool, tool_router, ErrorData as McpError};
 
 use crate::types::*;
 use crate::*;

--- a/crates/cartog-mcp/src/tools/rag.rs
+++ b/crates/cartog-mcp/src/tools/rag.rs
@@ -2,9 +2,7 @@
 
 use std::sync::Arc;
 
-use rmcp::{
-    handler::server::wrapper::Parameters, model::*, tool, tool_router, ErrorData as McpError,
-};
+use rmcp::{handler::server::wrapper::Parameters, tool, tool_router, ErrorData as McpError};
 
 use crate::types::*;
 use crate::*;

--- a/crates/cartog-mcp/src/tools/search.rs
+++ b/crates/cartog-mcp/src/tools/search.rs
@@ -2,9 +2,7 @@
 
 use std::sync::Arc;
 
-use rmcp::{
-    handler::server::wrapper::Parameters, model::*, tool, tool_router, ErrorData as McpError,
-};
+use rmcp::{handler::server::wrapper::Parameters, tool, tool_router, ErrorData as McpError};
 
 use crate::types::*;
 use crate::*;


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets -- -D warnings` fails on rustc **1.98** with five `unused import: model::*` errors in `crates/cartog-mcp/src/tools/`.

CI currently runs **1.97.1**, where the lint does not fire — so CI is green and this is **latent**: the Clippy job breaks the moment `dtolnay/rust-toolchain@stable` rolls forward to 1.98. It already blocks `make check-rust` for anyone on a current toolchain.

The tool modules reach model types through `crate::types::*` / `crate::*`, so nothing referenced the glob.

## Changes

- Remove `model::*` from the `rmcp` import in `tools/{graph,index,manage,rag,search}.rs`
- `cargo fmt` collapses the now-shorter `use` onto one line in three of the five

## Verification

| Check | Result |
|---|---|
| `cargo clippy --all-targets -- -D warnings` | pass on 1.98 (was 5 errors) |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | pass |
| `cargo test --workspace` | 33 suites pass, 0 failures |
| `cargo fmt --check` | pass |
| `cargo build --all-targets` | pass |

Verified against clean `main` that these five errors are pre-existing and not introduced by any feature branch.

## Checklist

- [x] `make check` passes locally
- [x] Commit messages follow conventional commits
- [ ] Tests added/updated for new behavior — n/a, dead-import removal
- [x] Documentation updated if needed — n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal imports across graph, index, management, retrieval, and search tools.
  - No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->