### PR TITLE
fix(config): honor `[reranker] enabled`, reject unknown keys per section

### DIFF
--- a/.cartog.toml.example
+++ b/.cartog.toml.example
@@ -34,4 +34,5 @@
 # model    = "nomic-embed-text"
 
 [reranker]
+# enabled = true       # false turns rerank off entirely (wins over `provider`)
 # provider = "local"   # or "none" to skip cross-encoder reranking

--- a/README.md
+++ b/README.md
@@ -634,7 +634,8 @@ base_url = "http://localhost:11434"
 # api_key_env = "OPENAI_API_KEY"             # env var NAME; never the key itself
 
 [reranker]
-provider = "none"            # "local" (default) or "none"
+enabled = false              # false turns rerank off (wins over `provider`)
+# provider = "none"          # "local" (default) or "none" — equivalent
 # model  = "BAAI/bge-reranker-base"   # default: jinaai/jina-reranker-v1-turbo-en (~150MB)
 
 # [index]

--- a/crates/cartog/src/commands/config_display.rs
+++ b/crates/cartog/src/commands/config_display.rs
@@ -91,7 +91,9 @@ pub fn cmd_config(
                 value: reranker.map_or(DEFAULT_RERANKER_PROVIDER.into(), |r| {
                     r.provider().to_string()
                 }),
-                is_default: reranker.map_or(true, |r| r.provider.is_none()),
+                // `enabled = false` resolves the provider to "none"; without it
+                // in the check, an explicit opt-out reads back as "(default)".
+                is_default: reranker.map_or(true, |r| r.provider.is_none() && r.enabled.is_none()),
                 default: DEFAULT_RERANKER_PROVIDER.into(),
             },
         },

--- a/crates/cartog/src/commands/init.rs
+++ b/crates/cartog/src/commands/init.rs
@@ -236,6 +236,83 @@ mod tests {
         }
     }
 
+    /// Uncomment every commented directive in a template, dropping prose.
+    fn uncomment_template(src: &str) -> String {
+        let mut out = String::new();
+        for line in src.lines() {
+            let t = line.trim_start_matches(['#', ' ']).trim();
+            // Strip a trailing inline comment so `[embedding.openai]  # note`
+            // is still recognized as a header.
+            let t = if t.starts_with('[') {
+                t.split('#').next().unwrap_or(t).trim()
+            } else {
+                t
+            };
+            let is_header = t.starts_with('[') && t.ends_with(']');
+            // An assignment, not prose that happens to contain '=' ("0 or
+            // omitted = auto"): the text left of the first '=' must be a single
+            // bare TOML key.
+            let is_assignment = !t.starts_with('[')
+                && t.split_once('=').is_some_and(|(k, _)| {
+                    let k = k.trim();
+                    !k.is_empty()
+                        && k.chars()
+                            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+                });
+            if is_header || is_assignment {
+                out.push_str(t);
+                out.push('\n');
+            }
+        }
+        out
+    }
+
+    /// Every key a user-facing template teaches must deserialize into a real
+    /// config field. `[reranker] enabled` shipped in both templates for
+    /// releases while no such field existed, so anyone who followed them was
+    /// silently left with the cross-encoder loaded. Uncommenting and parsing
+    /// under `deny_unknown_fields` is what catches that class of drift.
+    ///
+    /// Covers `.cartog.toml.example` too — a second shipped template, and the
+    /// only place `[embedding.local]` / `[embedding.ollama]` appear.
+    #[test]
+    fn every_template_key_parses_into_a_real_config_field() {
+        let example = fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join(".cartog.toml.example"),
+        )
+        .expect("`.cartog.toml.example` must exist at the repo root");
+
+        for (name, src) in [
+            ("init.rs TOML_TEMPLATE", TOML_TEMPLATE),
+            (".cartog.toml.example", example.as_str()),
+        ] {
+            let rendered = uncomment_template(src);
+            let cfg: Result<crate::config::CartogConfig, _> = toml::from_str(&rendered);
+            assert!(
+                cfg.is_ok(),
+                "{name}: key is not a real config field: {}\n--- rendered ---\n{rendered}",
+                cfg.unwrap_err()
+            );
+        }
+    }
+
+    /// A freshly-scaffolded config must load clean — no unknown-section
+    /// warnings on a user's very first run.
+    #[test]
+    fn scaffolded_template_has_no_unknown_sections() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_toml(tmp.path(), false).unwrap();
+        let body = fs::read_to_string(tmp.path().join(".cartog.toml")).unwrap();
+        let raw: toml::value::Table = toml::from_str(&body).unwrap();
+        assert!(
+            crate::config::unknown_sections(&raw).is_empty(),
+            "template emits unknown sections: {:?}",
+            crate::config::unknown_sections(&raw)
+        );
+    }
+
     #[test]
     fn toml_scaffold_preserves_existing_file() {
         let tmp = TempDir::new().unwrap();

--- a/crates/cartog/src/commands/init.rs
+++ b/crates/cartog/src/commands/init.rs
@@ -53,7 +53,9 @@ const TOML_TEMPLATE: &str = r##"# .cartog.toml — project-level configuration f
 # command = ["docker", "run", "--rm", "-i", "-v", "${ROOT}:${ROOT}", "-w", "${ROOT}", "cartog-lsp-dart:stable"]
 
 # [reranker]
-# enabled = true
+# enabled = true                 # false turns re-ranking off (wins over `provider`)
+# provider = "local"             # "local" (default) or "none"
+# model    = "jinaai/jina-reranker-v1-turbo-en"
 
 # [rag]
 # retrieval_multiplier = 3  # over-retrieve N× before fusion (default: 3)

--- a/crates/cartog/src/commands/rag.rs
+++ b/crates/cartog/src/commands/rag.rs
@@ -16,31 +16,44 @@ use cartog_rag as rag;
 /// Download the embedding model.
 pub fn cmd_rag_setup(json: bool, provider_config: &rag::EmbeddingProviderConfig) -> Result<()> {
     let reranker_model = provider_config.reranker_model.as_deref();
+    // Re-ranking off ⇒ don't fetch the cross-encoder. `[reranker] enabled =
+    // false` / `provider = "none"` exists to avoid that model entirely, so
+    // downloading it here would contradict the setting.
+    let want_reranker = provider_config.reranker_provider != "none";
     let spinner = if json {
         None
     } else {
         // One-time notice so the multi-hundred-MB download isn't a silent wait.
-        eprintln!(
-            "Downloading embedding (~80MB) + re-ranker ({}) models, one-time…",
-            reranker_model.unwrap_or(rag::DEFAULT_RERANKER_MODEL)
-        );
+        if want_reranker {
+            eprintln!(
+                "Downloading embedding (~80MB) + re-ranker ({}) models, one-time…",
+                reranker_model.unwrap_or(rag::DEFAULT_RERANKER_MODEL)
+            );
+        } else {
+            eprintln!(
+                "Downloading embedding model (~80MB), one-time… \
+                 (re-ranking disabled; skipping the cross-encoder)"
+            );
+        }
         Spinner::start("Downloading models")
     };
     // Download bi-encoder (embeddings)
     let embed_result = rag::setup::download_model();
     // Download cross-encoder (re-ranking) — the configured model, not always the default.
-    let rerank_result =
-        rag::setup::download_cross_encoder(reranker_model, provider_config.intra_threads);
+    let rerank_result = want_reranker
+        .then(|| rag::setup::download_cross_encoder(reranker_model, provider_config.intra_threads));
     if let Some(s) = spinner {
         s.stop();
     }
     let embed_result = embed_result?;
-    let rerank_result = rerank_result?;
+    let rerank_result = rerank_result.transpose()?;
 
     #[derive(serde::Serialize)]
     struct CombinedSetup {
         embedding: rag::setup::SetupResult,
-        reranker: rag::setup::SetupResult,
+        /// Absent when re-ranking is disabled — no cross-encoder was fetched.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reranker: Option<rag::setup::SetupResult>,
     }
 
     let combined = CombinedSetup {
@@ -49,9 +62,13 @@ pub fn cmd_rag_setup(json: bool, provider_config: &rag::EmbeddingProviderConfig)
     };
 
     output(&combined, json, None, |c| {
+        let rerank_line = match &c.reranker {
+            Some(r) => format!("Re-ranker model: {}\n", r.model_dir),
+            None => "Re-ranker: disabled (no cross-encoder downloaded)\n".to_string(),
+        };
         format!(
-            "Embedding model: {}\nRe-ranker model: {}\nModels ready. You can now run 'cartog rag index'.\n",
-            c.embedding.model_dir, c.reranker.model_dir
+            "Embedding model: {}\n{rerank_line}Models ready. You can now run 'cartog rag index'.\n",
+            c.embedding.model_dir
         )
     })
 }

--- a/crates/cartog/src/config/load.rs
+++ b/crates/cartog/src/config/load.rs
@@ -59,6 +59,153 @@ impl ConfigLoad {
     }
 }
 
+/// Known non-language keys of `[lsp]`. A scalar `[lsp]` key outside this set is
+/// a typo, not a language name (a language entry is a table: `[lsp.rust]`).
+pub(crate) const LSP_SCALAR_KEYS: &[&str] = &["max_concurrent_servers"];
+
+/// Drop misspelled scalar keys from `[lsp]`, warning for each. Returns whether
+/// any were removed. See the caller for why `deny_unknown_fields` can't do this.
+fn strip_unknown_lsp_scalars(raw: &mut toml::value::Table, path: &Path) -> bool {
+    let Some(toml::Value::Table(lsp)) = raw.get_mut("lsp") else {
+        return false;
+    };
+    let bad: Vec<String> = lsp
+        .iter()
+        .filter(|(k, v)| !v.is_table() && !LSP_SCALAR_KEYS.contains(&k.as_str()))
+        .map(|(k, _)| k.clone())
+        .collect();
+    for key in &bad {
+        lsp.remove(key);
+        // Ungated for the same reason as the unknown-field warning in
+        // `read_config`: a dropped key is a setting silently not in effect.
+        eprintln!(
+            "cartog: warning: unknown key '{key}' in [lsp] of {} (ignored); \
+             expected one of {}, or a per-language table like [lsp.rust]",
+            path.display(),
+            LSP_SCALAR_KEYS.join(", ")
+        );
+    }
+    !bad.is_empty()
+}
+
+/// Whether a TOML error is serde's `deny_unknown_fields` rejection (a typo)
+/// rather than a syntax or type error.
+fn is_unknown_field_error(e: &toml::de::Error) -> bool {
+    e.to_string().contains("unknown field")
+}
+
+/// Whether `section` is refused by schema `S` specifically for an unknown field.
+fn section_has_unknown_field<S: serde::de::DeserializeOwned>(section: &toml::value::Table) -> bool {
+    match toml::to_string(&toml::Value::Table(section.clone())) {
+        Ok(rendered) => {
+            matches!(toml::from_str::<S>(&rendered), Err(ref e) if is_unknown_field_error(e))
+        }
+        Err(_) => false,
+    }
+}
+
+/// Drop the keys that schema `S` refuses from `section`, in place.
+///
+/// Each candidate is removed and the section re-probed: a removal is kept only
+/// if it actually resolved an unknown-field complaint **for this section**. That
+/// scoping is the point — an earlier version matched the offending name against
+/// the whole tree, so `[rag] path` silently deleted `[database] path` and
+/// pointed cartog at a different database. A key is now only ever removed from
+/// the section it was written in.
+/// A stray key inside a sub-table (`[embedding.openai] base_urll`) must never be
+/// resolved by deleting the sub-table: that silently discarded a whole provider
+/// block, moving the endpoint from a self-hosted server to the public API. Only
+/// scalar keys are ever candidates; sub-tables are cleaned by their own schema
+/// via `strip_unknown_in_subtable` before this runs.
+fn strip_unknown_in_section<S: serde::de::DeserializeOwned>(section: &mut toml::value::Table) {
+    if !section_has_unknown_field::<S>(section) {
+        return;
+    }
+    let candidates: Vec<String> = section
+        .iter()
+        .filter(|(_, v)| !v.is_table())
+        .map(|(k, _)| k.clone())
+        .collect();
+    for key in candidates {
+        if !section_has_unknown_field::<S>(section) {
+            return;
+        }
+        let Some(saved) = section.remove(&key) else {
+            continue;
+        };
+        // Removing it didn't help ⇒ it wasn't the stray key; put it back.
+        if section_has_unknown_field::<S>(section) {
+            section.insert(key, saved);
+        }
+    }
+}
+
+/// Clean one named sub-table of `section` against its own schema `S`, leaving the
+/// sub-table itself in place.
+fn strip_unknown_in_subtable<S: serde::de::DeserializeOwned>(
+    section: &mut toml::value::Table,
+    name: &str,
+) {
+    if let Some(toml::Value::Table(sub)) = section.get_mut(name) {
+        strip_unknown_in_section::<S>(sub);
+    }
+}
+
+/// Re-parse `text` with unknown keys removed, so one typo doesn't cost the whole
+/// config. Returns `None` when the result still won't parse — a real syntax or
+/// type error rather than a stray key.
+///
+/// Works section by section against that section's own schema, so a stray key is
+/// only ever dropped from where it was written.
+fn reparse_ignoring_unknown_keys(text: &str) -> Option<CartogConfig> {
+    let mut raw: toml::value::Table = toml::from_str(text).ok()?;
+    // `[remote]` and `[lsp.<lang>]` are exempt: a mistyped key there could
+    // redirect where the index is pushed or which process is spawned as a
+    // language server, so both stay hard rejections. See
+    // `unknown_remote_key_stays_a_hard_rejection` /
+    // `read_config_rejects_unknown_lsp_field`.
+    if let Some(toml::Value::Table(remote)) = raw.get("remote") {
+        if section_has_unknown_field::<crate::config::RemoteConfig>(remote) {
+            return None;
+        }
+    }
+    if let Some(toml::Value::Table(lsp)) = raw.get("lsp") {
+        for value in lsp.values() {
+            if let toml::Value::Table(lang) = value {
+                if section_has_unknown_field::<crate::config::LspLangConfig>(lang) {
+                    return None;
+                }
+            }
+        }
+    }
+
+    for (name, value) in raw.iter_mut() {
+        let toml::Value::Table(section) = value else {
+            continue;
+        };
+        match name.as_str() {
+            "database" => strip_unknown_in_section::<DatabaseConfig>(section),
+            "embedding" => {
+                // Clean the provider sub-tables first, each against its own
+                // schema, so the parent probe never sees them as the problem.
+                strip_unknown_in_subtable::<LocalEmbeddingConfig>(section, "local");
+                strip_unknown_in_subtable::<OllamaConfig>(section, "ollama");
+                strip_unknown_in_subtable::<OpenAiConfig>(section, "openai");
+                strip_unknown_in_section::<EmbeddingConfig>(section);
+            }
+            "reranker" => strip_unknown_in_section::<RerankerConfig>(section),
+            "rag" => strip_unknown_in_section::<RagConfig>(section),
+            "security" => strip_unknown_in_section::<SecurityConfig>(section),
+            "index" => strip_unknown_in_section::<IndexConfig>(section),
+            // `remote` / `lsp` rejected above; unknown sections already warned.
+            _ => {}
+        }
+    }
+
+    let rendered = toml::to_string(&raw).ok()?;
+    toml::from_str::<CartogConfig>(&rendered).ok()
+}
+
 /// Load the local project config from `.cartog.toml`. See [`ConfigLoad`]
 /// for the three possible outcomes; existing commands that don't care
 /// about the rejected-vs-missing distinction can wrap this with
@@ -159,7 +306,8 @@ pub(crate) fn read_config(path: &Path) -> Option<CartogConfig> {
     // keys before they have a chance to be deserialised or logged anywhere.
     // Also warn (non-fatal) about unknown top-level sections so a typo like
     // `[embeddings]` doesn't silently leave the user on defaults.
-    if let Ok(raw) = toml::from_str::<toml::value::Table>(&text) {
+    let mut text = text;
+    if let Ok(mut raw) = toml::from_str::<toml::value::Table>(&text) {
         if let Some(toml::Value::Table(remote)) = raw.get("remote") {
             if let Err(msg) = validate_remote_no_credentials(remote) {
                 eprintln!("cartog: error in {}: {msg}", path.display());
@@ -167,10 +315,43 @@ pub(crate) fn read_config(path: &Path) -> Option<CartogConfig> {
             }
         }
         warn_unknown_sections(&raw, path);
+        // `[lsp]` can't use `deny_unknown_fields` (it's `#[serde(flatten)]`), so
+        // a misspelled sibling key is parsed as a language name and fails with
+        // "invalid type: integer, expected struct LspLangConfig" — naming
+        // neither the key nor the section. Name it and drop it here instead.
+        if strip_unknown_lsp_scalars(&mut raw, path) {
+            if let Ok(cleaned) = toml::to_string(&raw) {
+                text = cleaned;
+            }
+        }
     }
 
     let parsed = match toml::from_str::<CartogConfig>(&text) {
         Ok(cfg) => cfg,
+        // An unknown key is a typo, not a reason to discard the file. Reporting
+        // it is the point of `deny_unknown_fields`, but `Rejected` also revokes
+        // index-creation consent and drops every other setting — too much blast
+        // radius for one misspelling. Name the key, then retry without it.
+        Err(e) if is_unknown_field_error(&e) => {
+            // Deliberately NOT TTY-gated, unlike the info-ish sibling
+            // diagnostics: a dropped key means a setting the user wrote is not
+            // in effect, which is warn-level. Gating it would reproduce the
+            // silent-ignore bug this change exists to fix precisely where
+            // cartog does most of its work (MCP, `--json`, CI). Mirrors
+            // `main.rs`'s rule that captured stderr suppresses info, not warn.
+            eprintln!(
+                "cartog: warning: in {}: {e}\n\
+                 cartog: warning: ignoring that key; the rest of the config still applies.",
+                path.display()
+            );
+            match reparse_ignoring_unknown_keys(&text) {
+                Some(cfg) => cfg,
+                None => {
+                    eprintln!("cartog: warning: failed to parse {}", path.display());
+                    return None;
+                }
+            }
+        }
         Err(e) => {
             // Use eprintln rather than tracing — tracing may not be initialised yet.
             eprintln!("cartog: warning: failed to parse {}: {e}", path.display());

--- a/crates/cartog/src/config/schema.rs
+++ b/crates/cartog/src/config/schema.rs
@@ -60,6 +60,7 @@ pub struct LspLangConfig {
 
 /// Secret-redaction settings.
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityConfig {
     /// Redact known secret patterns from stored symbol text. Default: true.
     /// The sensitive-file deny-list is always enforced regardless of this flag.
@@ -76,6 +77,7 @@ impl SecurityConfig {
 
 /// Indexing settings.
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct IndexConfig {
     /// Repo-root-relative globs whose matching files and directories are skipped
     /// during indexing (e.g. `vendor/**`, `**/*.generated.*`). Complements the
@@ -186,6 +188,7 @@ pub(crate) fn validate_remote_no_credentials(table: &toml::value::Table) -> Resu
 /// rerank_min           = 8
 /// ```
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RagConfig {
     /// Over-retrieval multiplier for FTS5 + vector candidate pools.
     pub retrieval_multiplier: Option<u32>,
@@ -225,12 +228,14 @@ impl RagConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DatabaseConfig {
     /// Filesystem path to the cartog SQLite database. Supports `~` expansion.
     pub path: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EmbeddingConfig {
     /// Provider type: "local" (default), "ollama", or "openai".
     pub provider: Option<String>,
@@ -267,6 +272,7 @@ impl EmbeddingConfig {
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LocalEmbeddingConfig {
     /// Prefix prepended to text during search (e.g. "search_query: ").
     pub query_prefix: Option<String>,
@@ -279,6 +285,7 @@ pub struct LocalEmbeddingConfig {
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OllamaConfig {
     /// Ollama server URL (default: "http://localhost:11434").
     pub base_url: Option<String>,
@@ -300,6 +307,7 @@ impl OllamaConfig {
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OpenAiConfig {
     /// OpenAI-compatible base URL (default: "https://api.openai.com/v1").
     pub base_url: Option<String>,
@@ -334,6 +342,7 @@ impl OpenAiConfig {
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RerankerConfig {
     /// Turn re-ranking off without naming a provider. `false` resolves the
     /// provider to `"none"` regardless of [`Self::provider`].

--- a/crates/cartog/src/config/schema.rs
+++ b/crates/cartog/src/config/schema.rs
@@ -335,6 +335,15 @@ impl OpenAiConfig {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct RerankerConfig {
+    /// Turn re-ranking off without naming a provider. `false` resolves the
+    /// provider to `"none"` regardless of [`Self::provider`].
+    ///
+    /// Shipped in the `cartog init` template long before it was a real field,
+    /// so a config carrying `enabled = false` was silently ignored and left
+    /// the cross-encoder loaded. Honored here rather than rejected: erroring
+    /// on a key our own template taught users to write would punish them for
+    /// that bug.
+    pub enabled: Option<bool>,
     /// Provider type: "local" (default) or "none".
     pub provider: Option<String>,
     /// Reranker model as a fastembed HF repo path (e.g. `BAAI/bge-reranker-base`).
@@ -343,9 +352,15 @@ pub struct RerankerConfig {
 }
 
 pub const DEFAULT_RERANKER_PROVIDER: &str = "local";
+pub const RERANKER_PROVIDER_NONE: &str = "none";
 
 impl RerankerConfig {
+    /// Resolved provider name. `enabled = false` wins over an explicit
+    /// `provider` so the two spellings can't disagree about being off.
     pub fn provider(&self) -> &str {
+        if self.enabled == Some(false) {
+            return RERANKER_PROVIDER_NONE;
+        }
         self.provider
             .as_deref()
             .unwrap_or(DEFAULT_RERANKER_PROVIDER)

--- a/crates/cartog/src/config/tests/load.rs
+++ b/crates/cartog/src/config/tests/load.rs
@@ -277,6 +277,16 @@ fn read_config_rejects_unknown_lsp_field() {
     let cfg_path = dir.path().join(".cartog.toml");
     fs::write(&cfg_path, "[lsp.dart]\ncmd = [\"x\"]\n").unwrap();
     assert!(read_config(&cfg_path).is_none());
+
+    // `cmd` alone is a *missing field* error, which would pass even with
+    // `deny_unknown_fields` off. Pair a valid `command` with a stray key so this
+    // actually exercises unknown-field rejection.
+    let stray = dir.path().join("stray.toml");
+    fs::write(&stray, "[lsp.dart]\ncommand = [\"x\"]\nargz = 1\n").unwrap();
+    assert!(
+        read_config(&stray).is_none(),
+        "a stray key alongside a valid `command` must still reject"
+    );
 }
 
 #[test]
@@ -382,4 +392,254 @@ fn scopeguard(key: &'static str) -> impl Drop {
         key,
         prev: std::env::var(key).ok(),
     }
+}
+
+/// An unknown key is a typo, not a reason to discard the file. Before this was
+/// handled, `deny_unknown_fields` made one misspelling drop every other setting
+/// AND revoke index-creation consent (`config_present` is false for `Rejected`),
+/// so `cartog index` refused with "no .cartog.toml in this project".
+#[test]
+fn unknown_key_keeps_the_rest_of_the_config() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[database]\npath = \"/tmp/kept.db\"\n\n[rag]\nrerank_mx = 10\nrerank_max = 33\n",
+    )
+    .unwrap();
+
+    let cfg = read_config(&cfg_path).expect("a stray key must not reject the whole config");
+    assert_eq!(
+        cfg.database.expect("[database] survives").path.as_deref(),
+        Some("/tmp/kept.db"),
+    );
+    // A valid sibling in the *same* section survives too.
+    assert_eq!(cfg.rag.expect("[rag] survives").rerank_max, Some(33));
+}
+
+#[test]
+fn unknown_key_still_loads_so_consent_is_preserved() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(&cfg_path, "[security]\nredact_secretz = false\n").unwrap();
+    // `Some` is what makes `ConfigLoad::Loaded` (= consent to create an index).
+    assert!(
+        read_config(&cfg_path).is_some(),
+        "a typo must not revoke index-creation consent"
+    );
+}
+
+#[test]
+fn genuine_syntax_error_is_still_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(&cfg_path, "[database\npath = \"x\"\n").unwrap();
+    assert!(read_config(&cfg_path).is_none());
+}
+
+#[test]
+fn wrong_value_type_is_still_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(&cfg_path, "[index]\njobs = \"many\"\n").unwrap();
+    assert!(read_config(&cfg_path).is_none());
+}
+
+#[test]
+fn unknown_lsp_scalar_key_is_dropped_not_fatal() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[lsp]\nmax_concurrent_serverz = 2\n\n[lsp.rust]\ncommand = [\"rust-analyzer\"]\n",
+    )
+    .unwrap();
+    let cfg = read_config(&cfg_path).expect("[lsp] typo must not reject the config");
+    let lsp = cfg.lsp.expect("[lsp] survives");
+    assert!(
+        lsp.langs.contains_key("rust"),
+        "per-language entry survives"
+    );
+    assert_eq!(lsp.max_concurrent_servers, None);
+}
+
+/// `[remote]` is exempt from the lenient unknown-key path: a mistyped key there
+/// could silently redirect where the index is pushed or pulled.
+#[test]
+fn unknown_remote_key_stays_a_hard_rejection() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[remote]\nurl = \"s3://b/k\"\npathstyle = true\n",
+    )
+    .unwrap();
+    assert!(
+        read_config(&cfg_path).is_none(),
+        "a stray [remote] key must reject the config, not be ignored"
+    );
+}
+
+/// The lenient path keys off `toml`'s error text (`is_unknown_field_error`).
+/// If a dep bump rewords it, typos silently revert to full rejection — which
+/// also revokes index-creation consent. Fail loudly here instead.
+#[test]
+fn toml_still_reports_unknown_fields_in_the_format_we_parse() {
+    let e = toml::from_str::<CartogConfig>("[security]\nredact_secretz = false\n")
+        .expect_err("unknown field must error");
+    assert!(
+        e.to_string().contains("unknown field"),
+        "toml error format changed — is_unknown_field_error is now dead: {e}"
+    );
+}
+
+/// A stray key must be dropped from the section it was written in, never matched
+/// by name across the tree. `[rag] path` once deleted `[database] path`, silently
+/// pointing cartog at a different database.
+#[test]
+fn typo_does_not_delete_a_same_named_key_in_another_section() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[database]\npath = \"/tmp/kept.db\"\n\n[rag]\npath = \"oops\"\nrerank_max = 33\n",
+    )
+    .unwrap();
+    let cfg = read_config(&cfg_path).expect("stray key must not reject the config");
+    assert_eq!(
+        cfg.database.expect("[database] survives").path.as_deref(),
+        Some("/tmp/kept.db"),
+        "a [rag] typo must not delete [database] path"
+    );
+    assert_eq!(cfg.rag.expect("[rag] survives").rerank_max, Some(33));
+}
+
+#[test]
+fn typo_does_not_delete_embedding_provider_from_another_section() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[embedding]\nprovider = \"ollama\"\n\n[security]\nprovider = \"x\"\n",
+    )
+    .unwrap();
+    let cfg = read_config(&cfg_path).expect("stray key must not reject the config");
+    assert_eq!(
+        cfg.embedding.expect("[embedding] survives").provider(),
+        "ollama",
+        "a [security] typo must not reset [embedding] provider to the default"
+    );
+}
+
+/// Two typos in different sections: both siblings must survive. Exercises the
+/// per-section pass more than once.
+#[test]
+fn multiple_typos_in_different_sections_all_resolve() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[database]\npath = \"/tmp/x.db\"\nbogus = 1\n\n[rag]\nrerank_max = 7\nalso_bogus = 2\n",
+    )
+    .unwrap();
+    let cfg = read_config(&cfg_path).expect("stray keys must not reject the config");
+    assert_eq!(
+        cfg.database.expect("[database] survives").path.as_deref(),
+        Some("/tmp/x.db")
+    );
+    assert_eq!(cfg.rag.expect("[rag] survives").rerank_max, Some(7));
+}
+
+/// `[lsp.<lang>]` stays strict: the argv there spawns a process, so a stray key
+/// must reject rather than be silently dropped.
+#[test]
+fn unknown_lsp_lang_key_stays_a_hard_rejection() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[lsp.rust]\ncommand = [\"rust-analyzer\"]\nargz = 1\n",
+    )
+    .unwrap();
+    assert!(
+        read_config(&cfg_path).is_none(),
+        "a stray [lsp.<lang>] key must reject the config"
+    );
+}
+
+/// The `[remote]` boundary must not be defeatable from another section. A typo
+/// named like a remote field once deleted the REAL `[remote] endpoint`, which
+/// makes `cartog push` fall back to AWS's default host instead of the user's
+/// private endpoint.
+#[test]
+fn typo_elsewhere_never_deletes_a_remote_key() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[remote]\nurl = \"s3://team/idx\"\nendpoint = \"https://minio.internal\"\n\
+         \n[security]\nendpoint = \"typo\"\n",
+    )
+    .unwrap();
+    let cfg = read_config(&cfg_path).expect("stray [security] key must not reject the config");
+    let remote = cfg.remote.expect("[remote] survives");
+    assert_eq!(
+        remote.endpoint.as_deref(),
+        Some("https://minio.internal"),
+        "a typo in another section must never delete [remote] endpoint"
+    );
+    assert_eq!(remote.url.as_deref(), Some("s3://team/idx"));
+}
+
+/// `LSP_SCALAR_KEYS` hand-lists `LspConfig`'s non-flattened fields (it can't use
+/// `deny_unknown_fields` — `#[serde(flatten)]` forbids it). If a new scalar field
+/// is added to `LspConfig` and not to that list, it would be silently stripped as
+/// a typo. Assert every listed key round-trips, so the two can't drift apart.
+#[test]
+fn lsp_scalar_keys_are_all_real_lsp_config_fields() {
+    for key in LSP_SCALAR_KEYS {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg_path = dir.path().join(".cartog.toml");
+        // A usize-valued scalar covers today's only entry; extend if a
+        // non-numeric scalar is ever added.
+        std::fs::write(&cfg_path, format!("[lsp]\n{key} = 2\n")).unwrap();
+        let cfg = read_config(&cfg_path)
+            .unwrap_or_else(|| panic!("[lsp] {key} must parse — is it a real LspConfig field?"));
+        let lsp = cfg
+            .lsp
+            .unwrap_or_else(|| panic!("[lsp] section must survive for key {key}"));
+        assert!(
+            !lsp.langs.contains_key(*key),
+            "{key} was routed into the per-language map instead of a real field \
+             — LSP_SCALAR_KEYS and LspConfig have drifted"
+        );
+    }
+}
+
+/// A stray key inside a provider sub-table must not take the sub-table with it.
+/// Deleting `[embedding.openai]` silently moved the endpoint from a self-hosted
+/// server to the public API and changed which env var supplies the key.
+#[test]
+fn typo_in_a_provider_subtable_keeps_the_subtable() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg_path = dir.path().join(".cartog.toml");
+    std::fs::write(
+        &cfg_path,
+        "[embedding]\nprovider = \"openai\"\n\n[embedding.openai]\n\
+         base_url = \"http://good.example/v1\"\napi_key_env = \"MY_CUSTOM_KEY\"\n\
+         base_urll = \"typo\"\n",
+    )
+    .unwrap();
+    let cfg = read_config(&cfg_path).expect("stray sub-table key must not reject the config");
+    let openai = cfg
+        .embedding
+        .expect("[embedding] survives")
+        .openai
+        .expect("[embedding.openai] must survive a typo inside it");
+    assert_eq!(
+        openai.base_url(),
+        "http://good.example/v1",
+        "a typo must not repoint the endpoint at the public API"
+    );
+    assert_eq!(openai.api_key_env(), "MY_CUSTOM_KEY");
 }

--- a/crates/cartog/src/config/tests/schema.rs
+++ b/crates/cartog/src/config/tests/schema.rs
@@ -309,6 +309,34 @@ unknown_field = "should be ignored"
 }
 
 #[test]
+fn reranker_enabled_false_resolves_provider_to_none() {
+    let cfg: CartogConfig = toml::from_str("[reranker]\nenabled = false\n").unwrap();
+    assert_eq!(cfg.reranker.unwrap().provider(), "none");
+}
+
+#[test]
+fn reranker_enabled_false_wins_over_explicit_provider() {
+    let toml_str = r#"
+[reranker]
+enabled = false
+provider = "local"
+"#;
+    let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.reranker.unwrap().provider(), "none");
+}
+
+#[test]
+fn reranker_enabled_true_keeps_provider() {
+    let toml_str = r#"
+[reranker]
+enabled = true
+provider = "local"
+"#;
+    let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.reranker.unwrap().provider(), "local");
+}
+
+#[test]
 fn to_search_tuning_clamps_zero_retrieval() {
     let cfg = RagConfig {
         retrieval_multiplier: Some(0),

--- a/crates/cartog/src/config/tests/schema.rs
+++ b/crates/cartog/src/config/tests/schema.rs
@@ -297,15 +297,21 @@ path = "/tmp/test.db"
 }
 
 #[test]
-fn test_config_unknown_fields_ignored() {
+fn unknown_key_in_a_section_is_rejected() {
+    // Previously ignored in silence, which is how `[reranker] enabled` shipped
+    // in the init template for releases without being a real field.
     let toml_str = r#"
 [embedding]
 provider = "local"
-unknown_field = "should be ignored"
+unknown_field = "typo"
 "#;
-    // serde default: unknown fields are silently ignored
-    let cfg: CartogConfig = toml::from_str(toml_str).unwrap();
-    assert_eq!(cfg.embedding.unwrap().provider(), "local");
+    let err = toml::from_str::<CartogConfig>(toml_str)
+        .expect_err("unknown key must be rejected")
+        .to_string();
+    assert!(
+        err.contains("unknown_field"),
+        "error must name the key: {err}"
+    );
 }
 
 #[test]

--- a/docs/explanation/rag-pipeline.md
+++ b/docs/explanation/rag-pipeline.md
@@ -54,7 +54,7 @@ Query
   │     Over-retrieval: max(limit × 3, 20) per source
   │
   └─→ Cross-encoder re-ranking (optional)
-        jina-reranker-v1-turbo-en (`jinaai/jina-reranker-v1-turbo-en`, default; configurable via `[reranker] model`, or disable with `[reranker] provider = "none"`), scores (query, full_content) pairs jointly
+        jina-reranker-v1-turbo-en (`jinaai/jina-reranker-v1-turbo-en`, default; configurable via `[reranker] model`, or disable with `[reranker] enabled = false`), scores (query, full_content) pairs jointly
         Capped at 50 candidates to bound latency
         Graceful degradation: tri-state cache (not attempted / failed / ready)
         If model unavailable → search works with RRF-only ordering

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -219,6 +219,10 @@ enabled = false
 # provider = "none"   # equivalent
 ```
 
+Unknown keys inside a config section are reported on stderr with the valid
+alternatives, so a typo like `rerank_mx = 10` is visible instead of silently
+leaving you on defaults. The bad key is ignored and the rest of the config still
+applies. (Unknown top-level *sections* warn the same way.)
 
 ## Hybrid search tuning (`[rag]`)
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -151,10 +151,15 @@ regardless of this value.
 
 **Default models (local provider):**
 
-| Role | Config value | HuggingFace repo (downloaded) | Dim | Size |
-|------|-------------|-------------------------------|-----|------|
+| Role | Config value | HuggingFace repo (downloaded) | Dim | Download size |
+|------|-------------|-------------------------------|-----|---------------|
 | Embedding | `BAAI/bge-small-en-v1.5` | `Qdrant/bge-small-en-v1.5-onnx-Q` (ONNX-quantized) | 384 | ~80MB |
 | Reranker | `jinaai/jina-reranker-v1-turbo-en` (default) | `jinaai/jina-reranker-v1-turbo-en` | — | ~150MB |
+
+Sizes above are **on-disk download size**, not resident memory. Loading a model
+costs more than its weights (ONNX Runtime arenas scale with thread count), so
+these figures are not a memory budget — set `[reranker] enabled = false` if you
+need to avoid the cross-encoder's footprint entirely.
 
 The embedding config value is the fastembed model code you set under `[embedding]
 model`; cartog downloads the matching ONNX-quantized repo from HuggingFace into the
@@ -186,11 +191,12 @@ TOML > uncapped. Read at provider load, so restart `cartog serve` to change it.
 
 **Reranker model** — the cross-encoder is configurable, mirroring `[embedding]
 model`. The value is a fastembed reranker HuggingFace repo path; unset uses the
-default (`jinaai/jina-reranker-v1-turbo-en`, ~150MB — small, fast, and higher
-BEIR NDCG@10 than the older `bge-reranker-base`):
+default (`jinaai/jina-reranker-v1-turbo-en`, ~150MB to download — small, fast,
+and higher BEIR NDCG@10 than the older `bge-reranker-base`):
 
 ```toml
 [reranker]
+enabled  = true                                 # false = off, wins over `provider`
 provider = "local"                              # "local" (default) | "none"
 model    = "BAAI/bge-reranker-base"             # opt back to the former default (~1.1GB)
 # model  = "jinaai/jina-reranker-v2-base-multilingual"  # multilingual (~300MB)
@@ -204,12 +210,15 @@ one (it reuses the already-downloaded weights). See
 [troubleshooting](../troubleshooting.md) to reclaim the orphaned `bge-reranker-base`
 cache.
 
-**Disable re-ranking** (skips the ~150MB reranker download):
+**Disable re-ranking** (skips the ~150MB reranker download and its resident cost).
+Either spelling works; `enabled = false` wins over an explicit `provider`:
 
 ```toml
 [reranker]
-provider = "none"
+enabled = false
+# provider = "none"   # equivalent
 ```
+
 
 ## Hybrid search tuning (`[rag]`)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -312,6 +312,27 @@ Only the nearest one is used. There is no merging.
 See [`.cartog.toml.example`](../.cartog.toml.example) at the repo root for a
 fully commented template.
 
+### `cartog: warning: unknown field 'x'` in my config
+
+Keys inside a config section are validated, so a typo (`rerank_mx = 10`) or a
+key written for a newer cartog than your binary is now **named on stderr** with
+the valid alternatives, instead of being silently ignored:
+
+```
+cartog: warning: in .cartog.toml: unknown field `rerank_mx`, expected one of
+  `retrieval_multiplier`, `retrieval_floor`, `rerank_max`, `rerank_min`
+cartog: warning: ignoring that key; the rest of the config still applies.
+```
+
+The offending key is dropped from **the section it was written in**, and every
+other setting still applies — a typo costs you that one key, not the whole file.
+Unknown top-level *sections* warn the same way.
+
+Two sections are deliberately stricter, because a stray key there could redirect
+where data goes rather than merely be ignored: an unknown key in `[remote]` (the
+push/pull target) or in `[lsp.<lang>]` (the argv cartog spawns) rejects the whole
+config with a loud error instead of being dropped.
+
 ### `[reranker] enabled = false` had no effect on older versions
 
 `enabled` was shipped in the `cartog init` template before it was a real config

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -312,6 +312,13 @@ Only the nearest one is used. There is no merging.
 See [`.cartog.toml.example`](../.cartog.toml.example) at the repo root for a
 fully commented template.
 
+### `[reranker] enabled = false` had no effect on older versions
+
+`enabled` was shipped in the `cartog init` template before it was a real config
+field, so unknown-key handling dropped it and the cross-encoder stayed loaded.
+It is now honored, and takes precedence over `provider`. On an older binary use
+`provider = "none"` instead.
+
 ## Database
 
 ### "database at `<path>` is corrupt or not a cartog database"

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -173,7 +173,7 @@ cartog index .          <span class="comment"># 6. re-index after changes</span>
           <tbody>
             <tr><td><code>[database]</code></td><td><code>.cartog/db.sqlite</code> (git-root relative)</td><td>you want the DB elsewhere</td></tr>
             <tr><td><code>[embedding]</code></td><td><code>provider = "local"</code> (ONNX, CPU)</td><td>using Ollama / a different model — see <a href="#config-providers">Embedding Providers</a></td></tr>
-            <tr><td><code>[reranker]</code></td><td><code>provider = "local"</code>, <code>model = "jinaai/jina-reranker-v1-turbo-en"</code> (default)</td><td>picking a different cross-encoder, or disabling rerank (<code>"none"</code>)</td></tr>
+            <tr><td><code>[reranker]</code></td><td><code>provider = "local"</code>, <code>model = "jinaai/jina-reranker-v1-turbo-en"</code> (default)</td><td>picking a different cross-encoder, or disabling rerank (<code>enabled = false</code>)</td></tr>
             <tr><td><code>[rag]</code></td><td>tuned retrieval/rerank pools</td><td>tuning hybrid-search recall vs. cost</td></tr>
             <tr><td><code>[remote]</code></td><td>unset (no sync)</td><td>sharing an index over S3 — see <a href="#config-remote">Remote Storage</a></td></tr>
             <tr><td><code>[security]</code></td><td><code>redact_secrets = true</code></td><td>opting out of pattern redaction — see <a href="#config-secrets">Secret Redaction</a></td></tr>
@@ -257,6 +257,7 @@ base_url    = "https://api.openai.com/v1"  <span class="comment"># or http://loc
 api_key_env = "OPENAI_API_KEY"   <span class="comment"># env var NAME, not the key; unset = keyless local endpoint</span>
 
 [reranker]
+enabled  = true                  <span class="comment"># DEFAULT — false turns rerank off (wins over provider)</span>
 provider = "local"               <span class="comment"># DEFAULT — "local" or "none"</span>
 
 [rag]
@@ -305,7 +306,7 @@ url        = "s3://my-team-bucket/cartog/main"
         <h3>Default models (local provider)</h3>
         <table>
           <thead>
-            <tr><th>Role</th><th>Config value</th><th>HuggingFace repo (downloaded)</th><th>Dim</th><th>Size</th></tr>
+            <tr><th>Role</th><th>Config value</th><th>HuggingFace repo (downloaded)</th><th>Dim</th><th>Download size</th></tr>
           </thead>
           <tbody>
             <tr>
@@ -324,6 +325,12 @@ url        = "s3://my-team-bucket/cartog/main"
             </tr>
           </tbody>
         </table>
+        <p>
+          Sizes above are <strong>on-disk download size, not resident memory</strong>. Loading a
+          model costs more than its weights (ONNX Runtime arenas scale with thread count), so these
+          figures are not a memory budget — set <code>[reranker] enabled = false</code> to avoid the
+          cross-encoder's footprint entirely.
+        </p>
         <p>
           The embedding config value is the fastembed model code you set under
           <code>[embedding] model</code>; cartog downloads the matching ONNX-quantized repo from
@@ -393,7 +400,7 @@ cartog rag search "error handling"</pre>
         <pre><span class="comment"># Skip the ~150MB reranker model download</span>
 cat > .cartog.toml &lt;&lt;EOF
 [reranker]
-provider = "none"
+enabled = false
 EOF
 
 cartog rag setup     <span class="comment"># only downloads embedding model (~80MB)</span></pre>


### PR DESCRIPTION
## Summary

`[reranker] enabled` shipped in the `cartog init` template and `.cartog.toml.example` **for releases without ever being a field** on `RerankerConfig`, so serde silently dropped it. Users who followed our own template kept a ~2.3GB cross-encoder resident and had no way to tell.

Two commits: the user-facing fix, then the validation change that makes this class of bug impossible.

**Measured** on a 771-file repo — `rag search --limit 20`:

| Config | Peak RSS |
|---|---|
| default (re-ranking on) | 2.43 GB |
| `enabled = false` | **304 MB** |

## Changes

**`fix(config): honor [reranker] enabled`**
- `enabled: Option<bool>`; `false` resolves the provider to `"none"` and wins over an explicit `provider`, so the two spellings can't disagree about being off
- `cartog rag setup` no longer downloads the ~150MB cross-encoder when re-ranking is off (it ignored `reranker_provider` entirely); reports `Re-ranker: disabled`, JSON field omitted
- `cartog config` reported an explicit `enabled = false` as `none (default)` — `is_default` only looked at `provider`
- Docs: split on-disk **download size** from **resident memory** in the model table; the `~150MB` figure read as a memory budget, which it is not

**`feat(config): reject unknown keys per section`**
- `deny_unknown_fields` on the 9 sections missing it, matching the existing `LspLangConfig`/`RemoteConfig` convention
- Rejecting outright is too blunt: `read_config` returning `None` makes `ConfigLoad::Rejected`, which discards every other setting **and** revokes index-creation consent (`config_present` in `main.rs`) — so one typo made `cartog index` refuse with *"no .cartog.toml in this project"* while the user was looking at one. Instead: warn, then re-parse each section against its own schema, dropping only keys that section refuses
- `[remote]` and `[lsp.<lang>]` stay **hard rejections** — a typo there redirects where data goes or which process is spawned, not merely a setting to ignore

### Why per-section scoping matters

Matching the offending key name against the whole tree caused silent data loss. Each of these was reproduced:

| Config | Consequence |
|---|---|
| `[rag] path` typo + `[database] path` | DB path dropped → cartog used a **different database** |
| `[security] provider` typo + `[embedding] provider = "ollama"` | silently reverted to local ONNX |
| typo in any later-sorting section + `[remote] endpoint` | **`[remote]` exemption bypassed** → `push` targets AWS's default host, not the configured one |
| typo inside `[embedding.openai]` | whole sub-table deleted → endpoint moved to the **public OpenAI API**, and a different env var supplied the key |

Warnings are deliberately **not** TTY-gated, unlike the info-level sibling diagnostics: a dropped key is a setting not in effect, and gating it would reproduce the silent-ignore bug exactly where cartog mostly runs (MCP, `--json`, CI).

## Verification

| Check | Result |
|---|---|
| `make check-rust` | pass |
| `cargo test -p cartog` | 401 pass (default), 372 (`--no-default-features`) |
| `cargo clippy --all-targets -- -D warnings` | pass, both feature modes |
| `cargo fmt --check` | pass |
| `cargo audit` | 0 vulnerabilities |
| `npm run build` (site) | pass |

**Regression tests are proven, not assumed.** I reintroduced each old implementation and confirmed the tests fail against it: the three cross-section collision tests fail under name-based removal, and the sub-table test fails without per-schema recursion. Also added a guard on toml's error wording (the recovery path keys off it, on a caret-ranged dep) and an `LSP_SCALAR_KEYS`-vs-`LspConfig` drift guard.

`read_config_rejects_unknown_lsp_field` was passing for the wrong reason — `cmd = ["x"]` alone trips a *missing-field* error, never exercising unknown-field rejection. It now pairs a stray key with a valid `command`.

## Follow-up considered, not done

`main.rs:138` derives index-creation **consent** from **parse success**. Making consent "a config file was found" would delete this PR's recovery path entirely (~70 lines) and fail closed on settings while failing open on consent — arguably a better fix. That changes the consent gate's semantics, so it belongs in its own change rather than riding along here.

## Checklist

- [x] `make check` passes locally
- [x] Commit messages follow conventional commits
- [x] Tests added/updated for new behavior
- [x] Documentation updated if needed (docs + site, per the sync rule)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `enabled = false` to disable re-ranking, overriding the configured provider.
  - Disabled re-ranking now skips cross-encoder downloads and reports its status clearly.
  - Configuration scaffolding includes the latest re-ranking options.

- **Bug Fixes**
  - Configuration typos are reported with warnings while valid settings continue to apply.
  - Invalid keys are strictly validated in supported configuration sections.

- **Documentation**
  - Updated configuration guides, examples, and troubleshooting content.
  - Clarified model download sizes and the disk-space impact of re-ranking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->