### PR TITLE
docs: finish the `[reranker] enabled` sync and clear a doc-link warning

### DIFF
--- a/crates/cartog-watch/src/lib.rs
+++ b/crates/cartog-watch/src/lib.rs
@@ -87,7 +87,7 @@ pub struct WatchConfig {
     /// True when a `.cartog.toml` exists but could not be parsed, so its
     /// `[database] path` is unknown.
     ///
-    /// The live re-check in [`watcher_consents`] keys on the file *existing*
+    /// The live re-check in `watcher_consents` keys on the file *existing*
     /// (the mid-session `cartog init` signal), which would otherwise let a
     /// broken config grant consent and pre-build an index at the default
     /// location the user may have configured away from. The binary already

--- a/docs/how-to/switch-embedding-provider.md
+++ b/docs/how-to/switch-embedding-provider.md
@@ -122,7 +122,8 @@ one (it reuses the already-downloaded weights). See
 [troubleshooting](../troubleshooting.md) to reclaim the orphaned `bge-reranker-base`
 cache.
 
-**Disable re-ranking** (skips the ~150MB reranker download). Either spelling
+**Disable re-ranking** (skips the ~150MB reranker download and its resident
+cost). Either spelling
 works; `enabled = false` wins over an explicit `provider`:
 
 ```toml

--- a/docs/how-to/switch-embedding-provider.md
+++ b/docs/how-to/switch-embedding-provider.md
@@ -122,9 +122,11 @@ one (it reuses the already-downloaded weights). See
 [troubleshooting](../troubleshooting.md) to reclaim the orphaned `bge-reranker-base`
 cache.
 
-**Disable re-ranking** (skips the ~150MB reranker download):
+**Disable re-ranking** (skips the ~150MB reranker download). Either spelling
+works; `enabled = false` wins over an explicit `provider`:
 
 ```toml
 [reranker]
-provider = "none"
+enabled = false
+# provider = "none"   # equivalent
 ```

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -537,7 +537,7 @@ jobs = 4</pre>
         <p><strong>Note:</strong> When using Ollama, skip this — models are managed by the Ollama server.</p>
         <pre><span class="comment"># To also skip the reranker download:</span>
 [reranker]
-provider = "none"</pre>
+enabled = false</pre>
 
         <h2 id="rag-index"><code>cartog rag index</code></h2>
         <p>Build the embedding index for semantic search. Indexes both code symbols and Markdown documents (<code>.md</code> files). Requires <code>cartog index</code> first. For the local provider, also requires <code>cartog rag setup</code>.</p>

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -126,7 +126,7 @@ All examples below use CLI syntax. MCP tool names and parameters:
 
 Before first use, ensure cartog is installed and indexed.
 
-If the project uses a remote embedding provider (`.cartog.toml` has `[embedding] provider = "ollama"` or `provider = "openai"`), that provider supplies the **embedding** model — but `cartog rag setup` still downloads the cross-encoder **reranker** (~150MB default, provider-agnostic; there is no remote reranker). Skip `rag setup` only if you also disable the reranker (`[reranker] provider = "none"`); otherwise run it once. The `openai` provider reads its API key from an env var (`api_key_env`, default `OPENAI_API_KEY`), never from `.cartog.toml`.
+If the project uses a remote embedding provider (`.cartog.toml` has `[embedding] provider = "ollama"` or `provider = "openai"`), that provider supplies the **embedding** model — but `cartog rag setup` still downloads the cross-encoder **reranker** (~150MB default, provider-agnostic; there is no remote reranker). Skip `rag setup` only if you also disable the reranker (`[reranker] enabled = false`); otherwise run it once. The `openai` provider reads its API key from an env var (`api_key_env`, default `OPENAI_API_KEY`), never from `.cartog.toml`.
 
 The plugin's SessionStart hook handles install + indexing automatically:
 


### PR DESCRIPTION
## Summary

Audited every markdown/astro surface against merged `main`. Three still taught only `provider = "none"` — missed by the earlier passes because those searched for the `[reranker]` section header rather than the value.

## Changes

| Surface | What was stale |
|---|---|
| `docs/how-to/switch-embedding-provider.md` | its "Disable re-ranking" block |
| `site/src/pages/usage.astro` | the `rag setup` skip-the-download snippet (the summary-table row and `[reranker]` example block were already correct) |
| `skills/cartog/SKILL.md` | what the agent itself reads |

`provider = "none"` remains valid; these now show `enabled = false`, the spelling the `init` template teaches and the one users are most likely to reach for.

**Verified the claim these blocks make is actually true:** `cartog rag setup` with `enabled = false` prints `skipping the cross-encoder` and does not fetch it.

Also drops an intra-doc link from `WatchConfig::config_unparseable` to the private `watcher_consents` — the convention is plain `` `code` `` for internal targets. `cargo doc --no-deps --workspace` is back to **0 warnings**.

## Counts re-verified against the code

Not assumed — measured:

| Claim | Verified |
|---|---|
| 27 CLI commands | 27 top-level in `--help` |
| 16 MCP tools | 16 `#[tool]` handlers |
| 17 code languages + Markdown = 18 | 17 non-Markdown `get_extractor` arms (`tsx` is a TypeScript variant) |

No stale `allow_index_creation(db_path, config_present)` signature and no remaining "a rejected config is **not** consent" claim anywhere.

## Verification

| Check | Result |
|---|---|
| `cargo doc --no-deps --workspace` | 0 warnings (was 1) |
| `cargo test --doc --workspace` | pass |
| `cargo test -p cartog-watch` | 72 pass |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | pass |
| `npm run build` (site) | pass |
| `claude plugin validate .` | passed |
| `make check-skill` | 40 passed, 0 failed |

`make eval-skill` not run: the SKILL.md change is a one-line config-key spelling in prose, not search routing.

## Checklist

- [x] `make check` passes locally
- [x] Commit messages follow conventional commits
- [ ] Tests added/updated for new behavior — n/a, docs + one doc-comment link
- [x] Documentation updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `enabled = false` as the recommended way to disable re-ranking.
  * Clarified that disabling re-ranking takes precedence over an explicitly configured provider.
  * Updated setup examples and guidance to use the new configuration option.
  * Improved inline configuration terminology in technical documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->