### PR TITLE
feat(doctor): add version, paths, and lsp checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Your code never leaves your machine — unless you explicitly opt in to
 | **MCP "Connection closed" on a 2nd editor window** | Expected: single-writer election makes the 2nd instance read-only (14 of 16 tools). Ensure `cartog --version` ≥ 0.17 and `CARTOG_SINGLE_WRITER` is unset. |
 | **`.cartog.toml` ignored** | Cartog walks up to the git root; with no `.git`, put it in the cwd or pass `--db`. `cartog config` prints the resolved paths. |
 | **Missing symbols / recall lower than expected** | Wait for the watcher (or run `cartog index`), check the file's language is supported and not `.gitignore`d. Install a language server on PATH to lift edge resolution from ~25% to up to ~81%. |
-| **Anything else** | `cartog doctor` checks git, config, DB, and models. |
+| **Anything else** | `cartog doctor` checks git, config, key paths, DB, LSP servers, models, and the release version. |
 
 Full list with detailed fixes: **[docs/troubleshooting.md](docs/troubleshooting.md)**.
 

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Your code never leaves your machine — unless you explicitly opt in to
 | **MCP "Connection closed" on a 2nd editor window** | Expected: single-writer election makes the 2nd instance read-only (14 of 16 tools). Ensure `cartog --version` ≥ 0.17 and `CARTOG_SINGLE_WRITER` is unset. |
 | **`.cartog.toml` ignored** | Cartog walks up to the git root; with no `.git`, put it in the cwd or pass `--db`. `cartog config` prints the resolved paths. |
 | **Missing symbols / recall lower than expected** | Wait for the watcher (or run `cartog index`), check the file's language is supported and not `.gitignore`d. Install a language server on PATH to lift edge resolution from ~25% to up to ~81%. |
-| **Anything else** | `cartog doctor` checks git, config, key paths, DB, LSP servers, models, and the release version. |
+| **Anything else** | `cartog doctor` checks git, config, key paths, DB, LSP servers, models, the remote, and the release version. |
 
 Full list with detailed fixes: **[docs/troubleshooting.md](docs/troubleshooting.md)**.
 

--- a/crates/cartog/src/auto_check.rs
+++ b/crates/cartog/src/auto_check.rs
@@ -12,6 +12,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
+use crate::semver::{compare_stable_versions, parse_release_tag};
 use crate::state::State;
 use crate::time_fmt::{parse_rfc3339_secs, rfc3339_now};
 
@@ -261,41 +262,6 @@ fn fetch_latest_tag(url: &str) -> Result<String, CheckOnceError> {
         .map_err(|e| CheckOnceError::Network(e.to_string()))?;
     parse_release_tag(&body)
         .ok_or_else(|| CheckOnceError::Parse("no stable release tag in response".to_string()))
-}
-
-/// Pull `tag_name` from the JSON payload. Strips a leading `v`, rejects
-/// any prerelease suffix.
-fn parse_release_tag(json: &str) -> Option<String> {
-    let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
-    let tag = parsed.get("tag_name")?.as_str()?;
-    let trimmed = tag.strip_prefix('v').unwrap_or(tag);
-    if trimmed.contains('-') {
-        return None;
-    }
-    if !is_stable_semver(trimmed) {
-        return None;
-    }
-    Some(trimmed.to_string())
-}
-
-fn is_stable_semver(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    parts.len() == 3
-        && parts
-            .iter()
-            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
-}
-
-fn compare_stable_versions(a: &str, b: &str) -> std::cmp::Ordering {
-    let parse = |s: &str| -> [u64; 3] {
-        let mut parts = s.split('.').map(|p| p.parse::<u64>().unwrap_or(0));
-        [
-            parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0),
-        ]
-    };
-    parse(a).cmp(&parse(b))
 }
 
 #[cfg(test)]

--- a/crates/cartog/src/commands/doctor.rs
+++ b/crates/cartog/src/commands/doctor.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 
 #[cfg(feature = "remote-s3")]
 use super::remote;
+use super::self_cmd::github_latest_url;
 use crate::config::CartogConfig;
+use cartog::semver::{compare_stable_versions, parse_release_tag};
 use cartog_db::Database;
 use cartog_rag as rag;
 
@@ -17,6 +19,24 @@ struct CheckResult {
     name: String,
     status: CheckStatus,
     message: String,
+    /// Extra lines rendered indented under `message` in human output and kept
+    /// as discrete strings in `--json` (never newline-joined into `message`,
+    /// which machine consumers would have to re-split).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    details: Vec<String>,
+}
+
+// Only the two multi-line rows (`paths`, `lsp`) carry `details`; every other
+// check omits the field and relies on this default.
+impl Default for CheckResult {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            status: CheckStatus::Ok,
+            message: String::new(),
+            details: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +79,7 @@ fn check_git_repo() -> CheckResult {
                 name: "git".into(),
                 status: CheckStatus::Ok,
                 message: format!("git repository at {}", dir.display()),
+                details: Vec::new(),
             };
         }
         if !dir.pop() {
@@ -69,6 +90,7 @@ fn check_git_repo() -> CheckResult {
         name: "git".into(),
         status: CheckStatus::Error,
         message: "not inside a git repository".into(),
+        details: Vec::new(),
     }
 }
 
@@ -83,16 +105,19 @@ fn check_config(config_path: Option<&Path>, rejected: bool) -> CheckResult {
                  reflect defaults, not your config file.",
                 p.display()
             ),
+            ..Default::default()
         },
         (Some(p), false) => CheckResult {
             name: "config".into(),
             status: CheckStatus::Ok,
             message: format!("loaded from {}", p.display()),
+            details: Vec::new(),
         },
         (None, _) => CheckResult {
             name: "config".into(),
             status: CheckStatus::Warn,
             message: "no .cartog.toml found (using defaults)".into(),
+            details: Vec::new(),
         },
     }
 }
@@ -120,6 +145,7 @@ fn check_database(
             name: "database".into(),
             status: CheckStatus::Warn,
             message: format!("database not found at {}, {hint}", db_path.display()),
+            details: Vec::new(),
         };
     }
     match Database::open(db_path, embedding_dim) {
@@ -133,6 +159,7 @@ fn check_database(
                     stats.num_symbols,
                     db_path.display()
                 ),
+                ..Default::default()
             },
             Ok(_) => CheckResult {
                 name: "database".into(),
@@ -141,17 +168,20 @@ fn check_database(
                     "database exists but is empty, run 'cartog index' ({})",
                     db_path.display()
                 ),
+                ..Default::default()
             },
             Err(e) => CheckResult {
                 name: "database".into(),
                 status: CheckStatus::Error,
                 message: format!("failed to query database at {}: {e}", db_path.display()),
+                details: Vec::new(),
             },
         },
         Err(e) => CheckResult {
             name: "database".into(),
             status: CheckStatus::Error,
             message: format!("failed to open database at {}: {e}", db_path.display()),
+            details: Vec::new(),
         },
     }
 }
@@ -178,12 +208,14 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                     name: "embedding".into(),
                     status: CheckStatus::Ok,
                     message: "local model cached".into(),
+                    details: Vec::new(),
                 }
             } else {
                 CheckResult {
                     name: "embedding".into(),
                     status: CheckStatus::Warn,
                     message: "local model not downloaded, run 'cartog rag setup'".into(),
+                    details: Vec::new(),
                 }
             }
         }
@@ -212,6 +244,7 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                                 name: "embedding".into(),
                                 status: CheckStatus::Error,
                                 message: format!("cannot resolve ollama host '{addr}': {e}"),
+                                details: Vec::new(),
                             };
                         }
                     };
@@ -221,11 +254,13 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                             name: "embedding".into(),
                             status: CheckStatus::Ok,
                             message: format!("ollama reachable at {base_url}"),
+                            details: Vec::new(),
                         },
                         Err(e) => CheckResult {
                             name: "embedding".into(),
                             status: CheckStatus::Error,
                             message: format!("cannot reach ollama at {base_url}: {e}"),
+                            details: Vec::new(),
                         },
                     }
                 }
@@ -233,6 +268,7 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                     name: "embedding".into(),
                     status: CheckStatus::Error,
                     message: format!("cannot parse ollama URL: {base_url}"),
+                    details: Vec::new(),
                 },
             }
         }
@@ -256,6 +292,7 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                         "invalid [embedding.openai].base_url {base_url:?} — expected an \
                          http(s):// URL ending in /v1"
                     ),
+                    ..Default::default()
                 };
             }
             // Report the endpoint + key presence; an unset OR empty key is
@@ -265,6 +302,7 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                     name: "embedding".into(),
                     status: CheckStatus::Ok,
                     message: format!("openai endpoint {base_url} (key from ${env})"),
+                    details: Vec::new(),
                 }
             } else {
                 CheckResult {
@@ -273,6 +311,7 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
                     message: format!(
                         "openai endpoint {base_url}; ${env} unset (ok for keyless local endpoints)"
                     ),
+                    ..Default::default()
                 }
             }
         }
@@ -280,6 +319,7 @@ fn check_embedding_provider(config: &rag::EmbeddingProviderConfig) -> CheckResul
             name: "embedding".into(),
             status: CheckStatus::Error,
             message: format!("unknown provider '{other}'"),
+            details: Vec::new(),
         },
     }
 }
@@ -292,6 +332,7 @@ fn check_reranker(config: &rag::EmbeddingProviderConfig) -> CheckResult {
             name: "reranker".into(),
             status: CheckStatus::Ok,
             message: "disabled".into(),
+            details: Vec::new(),
         },
         "local" => match rag::resolve_reranker_model(model) {
             // Unparseable model = config error, not a missing download.
@@ -299,6 +340,7 @@ fn check_reranker(config: &rag::EmbeddingProviderConfig) -> CheckResult {
                 name: "reranker".into(),
                 status: CheckStatus::Error,
                 message: format!("unknown reranker model '{name}': {e}"),
+                details: Vec::new(),
             },
             Ok(rm) => {
                 if rag::is_reranker_resolved_cached(&rm) {
@@ -306,12 +348,14 @@ fn check_reranker(config: &rag::EmbeddingProviderConfig) -> CheckResult {
                         name: "reranker".into(),
                         status: CheckStatus::Ok,
                         message: format!("{name} cached{}", orphan_bge_hint(name)),
+                        details: Vec::new(),
                     }
                 } else {
                     CheckResult {
                         name: "reranker".into(),
                         status: CheckStatus::Warn,
                         message: format!("{name} not downloaded, run 'cartog rag setup'"),
+                        details: Vec::new(),
                     }
                 }
             }
@@ -320,6 +364,7 @@ fn check_reranker(config: &rag::EmbeddingProviderConfig) -> CheckResult {
             name: "reranker".into(),
             status: CheckStatus::Error,
             message: format!("unknown provider '{other}'"),
+            details: Vec::new(),
         },
     }
 }
@@ -363,6 +408,7 @@ fn check_remote(config: &CartogConfig, config_rejected: bool) -> CheckResult {
             message: "[remote] status unknown — config file was rejected; \
                       fix the config and re-run doctor"
                 .into(),
+            ..Default::default()
         };
     }
     let remote = match config.remote.as_ref() {
@@ -372,6 +418,7 @@ fn check_remote(config: &CartogConfig, config_rejected: bool) -> CheckResult {
                 name: "remote".into(),
                 status: CheckStatus::Ok,
                 message: "not configured (local-only)".into(),
+                details: Vec::new(),
             }
         }
     };
@@ -381,6 +428,7 @@ fn check_remote(config: &CartogConfig, config_rejected: bool) -> CheckResult {
             name: "remote".into(),
             status: CheckStatus::Warn,
             message: "[remote] section present but `url` is empty".into(),
+            details: Vec::new(),
         };
     }
 
@@ -391,6 +439,7 @@ fn check_remote(config: &CartogConfig, config_rejected: bool) -> CheckResult {
             name: "remote".into(),
             status: CheckStatus::Error,
             message: "[remote] configured but cartog was built without `remote-s3` feature".into(),
+            details: Vec::new(),
         }
     }
 
@@ -400,13 +449,338 @@ fn check_remote(config: &CartogConfig, config_rejected: bool) -> CheckResult {
             name: "remote".into(),
             status: CheckStatus::Ok,
             message: format!("{} reachable", remote.url.as_deref().unwrap_or("<unset>")),
+            details: Vec::new(),
         },
         Err(e) => CheckResult {
             name: "remote".into(),
             status: CheckStatus::Warn,
             message: format!("unreachable: {e}"),
+            details: Vec::new(),
         },
     }
+}
+
+/// `CARTOG_NO_UPDATE_CHECK` (any non-empty value) skips the release probe.
+fn update_check_disabled() -> bool {
+    std::env::var_os("CARTOG_NO_UPDATE_CHECK").is_some_and(|v| !v.is_empty())
+}
+
+/// How long the release probe may block the whole report.
+///
+/// Deliberately much shorter than the 5s `cartog self update` allows: there,
+/// waiting for an answer *is* the task, whereas doctor is what you run because
+/// something is already broken, and it prints nothing until every row is in.
+/// On a blackholed network (packets dropped, no fast RST) the user waits the
+/// whole budget, so this is the one row that can make the report feel hung —
+/// measured against a ~0.02-0.3s local-only run, 800ms keeps it unnoticeable
+/// while still clearing a normal transatlantic round trip.
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_millis(800);
+
+/// Fetch the latest release tag under [`VERSION_PROBE_TIMEOUT`].
+///
+/// Mirrors `self_cmd::fetch_latest_version` but with doctor's shorter budget;
+/// the shared helper keeps the longer one because `self update` needs it.
+fn fetch_latest_version_quick(url: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!("cartog/", env!("CARGO_PKG_VERSION")))
+        // Both budgets: the total cap alone still let a dropped-SYN connect
+        // stall well past it, which is exactly the blackholed-network case.
+        .connect_timeout(VERSION_PROBE_TIMEOUT)
+        .timeout(VERSION_PROBE_TIMEOUT)
+        .build()?;
+    let response = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()?;
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("GitHub API returned status {status}");
+    }
+    parse_release_tag(&response.text()?)
+        .ok_or_else(|| anyhow::anyhow!("no stable release tag in the GitHub response"))
+}
+
+/// Compare the running version against the latest stable GitHub release.
+///
+/// A failed probe is `Ok`, not `Warn`: being offline is not a broken
+/// environment, and doctor exits 1 on any error row. Both `disabled` and
+/// `fetch` are injected rather than read here, so the function is pure and
+/// the tests cannot be flipped by a `CARTOG_NO_UPDATE_CHECK` that happens to
+/// be set in the developer's or CI runner's environment.
+fn check_version(
+    current: &str,
+    disabled: bool,
+    fetch: impl FnOnce() -> Result<String>,
+) -> CheckResult {
+    if disabled {
+        return CheckResult {
+            name: "version".into(),
+            status: CheckStatus::Ok,
+            message: format!("{current} (update check disabled)"),
+            details: Vec::new(),
+        };
+    }
+    match fetch() {
+        Ok(latest) => {
+            if compare_stable_versions(current, &latest) == std::cmp::Ordering::Less {
+                CheckResult {
+                    name: "version".into(),
+                    status: CheckStatus::Warn,
+                    message: format!(
+                        "update available: {current} -> {latest}, run 'cartog self update'"
+                    ),
+                    ..Default::default()
+                }
+            } else {
+                CheckResult {
+                    name: "version".into(),
+                    status: CheckStatus::Ok,
+                    message: format!("{current} is up to date"),
+                    details: Vec::new(),
+                }
+            }
+        }
+        Err(e) => CheckResult {
+            name: "version".into(),
+            status: CheckStatus::Ok,
+            message: format!("{current} (latest unknown: {e})"),
+            details: Vec::new(),
+        },
+    }
+}
+
+/// Inventory row: every path and identity a bug report needs, in one place.
+/// Always `Ok` — it reports where things are, not whether they are healthy.
+fn check_paths(config_path: Option<&Path>, db_path: &Path, project_root: &Path) -> CheckResult {
+    let show = |p: Option<std::path::PathBuf>| {
+        p.map_or_else(|| "unavailable".to_string(), |p| p.display().to_string())
+    };
+    let config = config_path.map_or_else(
+        || "none (using defaults)".to_string(),
+        |p| p.display().to_string(),
+    );
+    let details = vec![
+        format!("project root:  {}", project_root.display()),
+        format!("config:        {config}"),
+        format!("database:      {}", db_path.display()),
+        format!(
+            "state file:    {}",
+            show(crate::state::default_state_file())
+        ),
+        format!("model cache:   {}", rag::model_cache_dir().display()),
+        format!(
+            "install:       {} ({})",
+            super::self_cmd::effective_install_source(),
+            super::self_cmd::TARGET_TRIPLE,
+        ),
+    ];
+    CheckResult {
+        name: "paths".into(),
+        status: CheckStatus::Ok,
+        message: String::new(),
+        details,
+    }
+}
+
+/// Whether clangd can see a compile database covering `dir`. Without one it
+/// guesses bare flags and cross-file includes go unresolved — measured at ~59%
+/// of the LSP edge gain on the C++ fixture, silently.
+///
+/// clangd searches the file's own directory and every ancestor, so this walks
+/// upward from the C/C++ sources rather than testing the project root alone:
+/// in a polyglot repo (a Rust workspace with a C fixture, a vendored native
+/// dependency) the root is exactly where a compile database would be
+/// meaningless, and demanding one there is unactionable advice.
+#[cfg(feature = "lsp")]
+fn has_compile_database(dir: &Path, stop_at: &Path) -> bool {
+    let mut cur = Some(dir);
+    while let Some(d) = cur {
+        if d.join("compile_commands.json").exists() || d.join("compile_flags.txt").exists() {
+            return true;
+        }
+        if d == stop_at {
+            break;
+        }
+        cur = d.parent();
+    }
+    false
+}
+
+/// Report LSP server availability for the languages actually indexed.
+///
+/// `languages` comes from the index itself, so the row never nags about a
+/// language this project does not use. A `[lsp.<lang>] command` override counts
+/// as available without a PATH probe — the binary lives in a container.
+#[cfg(feature = "lsp")]
+fn check_lsp(
+    languages: &[(String, u32)],
+    overrides: &std::collections::HashMap<String, Vec<String>>,
+    c_family_dirs: &[std::path::PathBuf],
+    project_root: &Path,
+) -> CheckResult {
+    use cartog_lsp::servers;
+
+    let mut missing: Vec<String> = Vec::new();
+    let mut available: Vec<&str> = Vec::new();
+    let mut clangd_ready = false;
+
+    for (lang, _) in languages {
+        // Languages with no ServerSpec (markdown) are resolved by heuristics
+        // only — not a gap, so never reported as one.
+        if !servers::has_server_spec(lang) {
+            continue;
+        }
+        if overrides.contains_key(lang) {
+            available.push(lang);
+            if lang == "c" || lang == "cpp" {
+                clangd_ready = true;
+            }
+            continue;
+        }
+        let specs = servers::find_servers(lang);
+        match specs
+            .iter()
+            .find(|s| servers::is_binary_available(s.binary))
+        {
+            Some(_) => {
+                available.push(lang);
+                if lang == "c" || lang == "cpp" {
+                    clangd_ready = true;
+                }
+            }
+            None => {
+                // List every candidate: Ruby ships two servers with different
+                // minimum runtimes, so naming only the first can hand the user
+                // the one hint they cannot satisfy.
+                let candidates = specs
+                    .iter()
+                    .map(|s| format!("{}: {}", s.binary, s.install_hint))
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+                missing.push(format!("{lang} ({candidates})"));
+            }
+        }
+    }
+
+    // Only meaningful once clangd is actually reachable; otherwise the missing
+    // server is the finding and a compile-db warning would double-report it.
+    let uncovered_dirs: Vec<&std::path::PathBuf> = if clangd_ready {
+        c_family_dirs
+            .iter()
+            .filter(|d| !has_compile_database(d, project_root))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if available.is_empty() && missing.is_empty() {
+        return CheckResult {
+            name: "lsp".into(),
+            status: CheckStatus::Ok,
+            message: "no indexed language uses an LSP server".into(),
+            details: Vec::new(),
+        };
+    }
+
+    let mut notes: Vec<String> = Vec::new();
+    if !missing.is_empty() {
+        notes.push(format!("no server for {}", missing.join(", ")));
+    }
+    if !uncovered_dirs.is_empty() {
+        // Name a real directory the user can act on, not the repo root — in a
+        // polyglot repo a compile database at the root would be meaningless.
+        let shown = uncovered_dirs
+            .iter()
+            .take(3)
+            .map(|d| d.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let more = uncovered_dirs.len().saturating_sub(3);
+        let suffix = if more > 0 {
+            format!(" (+{more} more)")
+        } else {
+            String::new()
+        };
+        notes.push(format!(
+            "clangd has no compile database covering {shown}{suffix} — add a \
+             compile_commands.json or compile_flags.txt there or in a parent; \
+             without one most cross-file includes go unresolved"
+        ));
+    }
+
+    if notes.is_empty() {
+        CheckResult {
+            name: "lsp".into(),
+            status: CheckStatus::Ok,
+            message: format!("servers found for {}", available.join(", ")),
+            details: Vec::new(),
+        }
+    } else {
+        // Keep the positive half visible: a bug report needs to know which of
+        // the twelve indexed languages *did* resolve, not only the one gap.
+        if !available.is_empty() {
+            notes.push(format!("servers found for {}", available.join(", ")));
+        }
+        CheckResult {
+            name: "lsp".into(),
+            status: CheckStatus::Warn,
+            message: String::new(),
+            details: notes,
+        }
+    }
+}
+
+/// What the `lsp` row needs from the index: which languages are present, and
+/// which directories hold the C/C++ sources clangd would need a compile
+/// database for.
+#[cfg(feature = "lsp")]
+struct IndexedForLsp {
+    languages: Vec<(String, u32)>,
+    /// Deduplicated, sorted directories containing at least one C/C++ file.
+    c_family_dirs: Vec<std::path::PathBuf>,
+}
+
+/// Read the index once for everything the `lsp` row needs, or `None` when the
+/// database is absent or unreadable — the database row already reports that,
+/// so the LSP row stays silent rather than repeating it.
+#[cfg(feature = "lsp")]
+fn indexed_for_lsp(
+    db_path: &Path,
+    embedding_dim: usize,
+    project_root: &Path,
+) -> Option<IndexedForLsp> {
+    if !db_path.exists() {
+        return None;
+    }
+    let db = Database::open(db_path, embedding_dim).ok()?;
+    let languages = db.stats().ok()?.languages;
+    let has_c_family = languages.iter().any(|(l, _)| l == "c" || l == "cpp");
+    // Only pay for the file listing when a C-family language is actually
+    // indexed; every other project skips the query entirely.
+    let c_family_dirs = if has_c_family {
+        let mut dirs: Vec<std::path::PathBuf> = db
+            .all_files()
+            .unwrap_or_default()
+            .iter()
+            .filter(|p| {
+                matches!(
+                    Path::new(p).extension().and_then(|e| e.to_str()),
+                    Some("c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" | "hxx")
+                )
+            })
+            .filter_map(|p| Path::new(p).parent().map(|d| project_root.join(d)))
+            .collect();
+        dirs.sort();
+        dirs.dedup();
+        dirs
+    } else {
+        Vec::new()
+    };
+    Some(IndexedForLsp {
+        languages,
+        c_family_dirs,
+    })
 }
 
 fn build_report(checks: Vec<CheckResult>) -> DoctorReport {
@@ -439,14 +813,20 @@ fn format_report_human(report: &DoctorReport) -> String {
     let mut out = String::new();
 
     for check in &report.checks {
+        // An empty message means the row's content lives entirely in `details`
+        // (paths, lsp), so the label must not trail a space before the break.
+        let sep = if check.message.is_empty() { "" } else { " " };
         writeln!(
             out,
-            "  [{}] {}: {}",
+            "  [{}] {}:{sep}{}",
             check.status.icon(),
             check.name,
             check.message,
         )
         .unwrap();
+        for detail in &check.details {
+            writeln!(out, "      {detail}").unwrap();
+        }
     }
     writeln!(out).unwrap();
 
@@ -468,11 +848,13 @@ fn format_report_human(report: &DoctorReport) -> String {
 }
 
 /// Check that requirements are met and everything is working.
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_doctor(
     config: &CartogConfig,
     config_path: Option<&Path>,
     config_rejected: bool,
     db_path: &Path,
+    project_root: &Path,
     json: bool,
     embedding_dim: usize,
     provider_config: &rag::EmbeddingProviderConfig,
@@ -495,14 +877,32 @@ pub fn cmd_doctor(
         crate::config::IndexCreation::resolve(db_path, file_consent, config_rejected, None);
     let db_path_unknown = creation.is_db_path_unknown();
     let consent = creation.is_allowed();
-    let checks = vec![
+    let mut checks = vec![
         check_git_repo(),
         check_config(config_path, config_rejected),
+        check_paths(config_path, db_path, project_root),
         check_database(db_path, embedding_dim, consent, db_path_unknown),
-        check_embedding_provider(provider_config),
-        check_reranker(provider_config),
-        check_remote(config, config_rejected),
     ];
+    #[cfg(feature = "lsp")]
+    if let Some(indexed) = indexed_for_lsp(db_path, embedding_dim, project_root) {
+        checks.push(check_lsp(
+            &indexed.languages,
+            &crate::config::to_lsp_overrides(config),
+            &indexed.c_family_dirs,
+            project_root,
+        ));
+    }
+    checks.push(check_embedding_provider(provider_config));
+    checks.push(check_reranker(provider_config));
+    checks.push(check_remote(config, config_rejected));
+    // Last: it is the only check that can block for seconds on a blackholed
+    // network, and doctor is what you run *because* something is already
+    // broken. Every local row is computed before the probe starts.
+    checks.push(check_version(
+        env!("CARGO_PKG_VERSION"),
+        update_check_disabled(),
+        || fetch_latest_version_quick(&github_latest_url()),
+    ));
 
     let report = build_report(checks);
 
@@ -783,11 +1183,13 @@ mod tests {
                     name: "git".into(),
                     status: CheckStatus::Ok,
                     message: "git repository".into(),
+                    details: Vec::new(),
                 },
                 CheckResult {
                     name: "config".into(),
                     status: CheckStatus::Warn,
                     message: "no config".into(),
+                    details: Vec::new(),
                 },
             ],
             summary: DoctorSummary {
@@ -813,11 +1215,13 @@ mod tests {
                 name: "a".into(),
                 status: CheckStatus::Ok,
                 message: "ok".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "b".into(),
                 status: CheckStatus::Ok,
                 message: "ok".into(),
+                details: Vec::new(),
             },
         ];
         let report = build_report(checks);
@@ -834,16 +1238,19 @@ mod tests {
                 name: "a".into(),
                 status: CheckStatus::Ok,
                 message: "fine".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "b".into(),
                 status: CheckStatus::Warn,
                 message: "meh".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "c".into(),
                 status: CheckStatus::Error,
                 message: "bad".into(),
+                details: Vec::new(),
             },
         ];
         let report = build_report(checks);
@@ -871,11 +1278,13 @@ mod tests {
                 name: "git".into(),
                 status: CheckStatus::Ok,
                 message: "git repository".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "db".into(),
                 status: CheckStatus::Ok,
                 message: "42 files".into(),
+                details: Vec::new(),
             },
         ]);
         let out = format_report_human(&report);
@@ -891,11 +1300,13 @@ mod tests {
                 name: "git".into(),
                 status: CheckStatus::Ok,
                 message: "ok".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "config".into(),
                 status: CheckStatus::Warn,
                 message: "missing".into(),
+                details: Vec::new(),
             },
         ]);
         let out = format_report_human(&report);
@@ -911,16 +1322,19 @@ mod tests {
                 name: "git".into(),
                 status: CheckStatus::Ok,
                 message: "ok".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "embed".into(),
                 status: CheckStatus::Warn,
                 message: "not cached".into(),
+                details: Vec::new(),
             },
             CheckResult {
                 name: "db".into(),
                 status: CheckStatus::Error,
                 message: "broken".into(),
+                details: Vec::new(),
             },
         ]);
         let out = format_report_human(&report);
@@ -1031,5 +1445,311 @@ mod tests {
             result.status == CheckStatus::Ok || result.status == CheckStatus::Error,
             "ollama check should be Ok or Error, not Warn"
         );
+    }
+
+    // ── check_version ─────────────────────────────────────────────────────
+
+    #[test]
+    fn version_older_than_latest_warns_with_upgrade_hint() {
+        let result = check_version("0.32.0", false, || Ok("0.33.0".to_string()));
+        assert_eq!(result.status, CheckStatus::Warn);
+        assert!(
+            result.message.contains("0.32.0 -> 0.33.0"),
+            "{}",
+            result.message
+        );
+        assert!(result.message.contains("cartog self update"));
+    }
+
+    #[test]
+    fn version_equal_to_latest_is_ok() {
+        let result = check_version("0.33.0", false, || Ok("0.33.0".to_string()));
+        assert_eq!(result.status, CheckStatus::Ok);
+        assert!(result.message.contains("up to date"));
+    }
+
+    #[test]
+    fn version_ahead_of_latest_is_ok() {
+        // A dev build past the last release must not be reported as outdated.
+        let result = check_version("0.34.0", false, || Ok("0.33.0".to_string()));
+        assert_eq!(result.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn version_check_disabled_reports_current_without_probing() {
+        let result = check_version("0.33.0", true, || {
+            panic!("must not probe when the check is disabled")
+        });
+        assert_eq!(result.status, CheckStatus::Ok);
+        assert!(
+            result.message.contains("update check disabled"),
+            "{}",
+            result.message
+        );
+    }
+
+    #[test]
+    fn version_probe_failure_is_ok_not_error() {
+        // Offline is not a broken environment, and doctor exits 1 on any error.
+        let result = check_version("0.33.0", false, || anyhow::bail!("connection refused"));
+        assert_eq!(result.status, CheckStatus::Ok);
+        assert!(
+            result.message.contains("latest unknown"),
+            "{}",
+            result.message
+        );
+        assert!(result.message.contains("connection refused"));
+    }
+
+    // ── check_paths ───────────────────────────────────────────────────────
+
+    #[test]
+    fn paths_lists_every_location_as_details() {
+        let result = check_paths(
+            Some(Path::new("/proj/.cartog.toml")),
+            Path::new("/proj/.cartog/db.sqlite"),
+            Path::new("/proj"),
+        );
+        assert_eq!(result.status, CheckStatus::Ok);
+        // Content lives in `details` so `--json` consumers never re-split a blob.
+        assert!(result.message.is_empty());
+        let joined = result.details.join("\n");
+        assert!(joined.contains("/proj/.cartog.toml"), "{joined}");
+        assert!(joined.contains("/proj/.cartog/db.sqlite"), "{joined}");
+        assert!(joined.contains("project root:"), "{joined}");
+        assert!(joined.contains("install:"), "{joined}");
+    }
+
+    #[test]
+    fn paths_reports_defaults_when_no_config_file() {
+        let result = check_paths(
+            None,
+            Path::new("/proj/.cartog/db.sqlite"),
+            Path::new("/proj"),
+        );
+        assert!(
+            result
+                .details
+                .iter()
+                .any(|d| d.contains("none (using defaults)")),
+            "{:?}",
+            result.details
+        );
+    }
+
+    // ── check_lsp ─────────────────────────────────────────────────────────
+
+    #[cfg(feature = "lsp")]
+    mod lsp {
+        use super::*;
+        use std::collections::HashMap;
+
+        fn langs(pairs: &[(&str, u32)]) -> Vec<(String, u32)> {
+            pairs.iter().map(|(l, n)| ((*l).to_string(), *n)).collect()
+        }
+
+        #[test]
+        fn language_with_no_server_spec_is_never_reported_missing() {
+            // Markdown resolves by heuristics only — absence of a server is not a gap.
+            let result = check_lsp(
+                &langs(&[("markdown", 10)]),
+                &HashMap::new(),
+                &[],
+                Path::new("/proj"),
+            );
+            assert_eq!(result.status, CheckStatus::Ok);
+            assert!(result
+                .message
+                .contains("no indexed language uses an LSP server"));
+        }
+
+        /// Run `f` with an empty `PATH` so no server binary can resolve —
+        /// makes the "missing server" branch deterministic instead of
+        /// depending on what happens to be installed on the host.
+        fn with_empty_path<T>(f: impl FnOnce() -> T) -> T {
+            let saved = std::env::var_os("PATH");
+            std::env::set_var("PATH", "");
+            let out = f();
+            match saved {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+            out
+        }
+
+        #[test]
+        #[serial]
+        fn missing_server_warns_and_names_the_install_hint() {
+            let result = with_empty_path(|| {
+                check_lsp(
+                    &langs(&[("csharp", 3)]),
+                    &HashMap::new(),
+                    &[],
+                    Path::new("/proj"),
+                )
+            });
+            assert_eq!(result.status, CheckStatus::Warn);
+            let joined = result.details.join(" ");
+            assert!(joined.contains("csharp"), "{joined}");
+            assert!(joined.contains("dotnet tool install"), "{joined}");
+        }
+
+        #[test]
+        fn configured_override_counts_as_available_without_a_path_probe() {
+            // The override's binary lives in a container, so PATH says nothing.
+            let mut overrides = HashMap::new();
+            overrides.insert("csharp".to_string(), vec!["docker".to_string()]);
+            let result = check_lsp(
+                &langs(&[("csharp", 3)]),
+                &overrides,
+                &[],
+                Path::new("/proj"),
+            );
+            assert_eq!(result.status, CheckStatus::Ok);
+            assert!(result.message.contains("csharp"), "{}", result.message);
+        }
+
+        #[test]
+        fn cpp_without_a_compile_database_warns() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut overrides = HashMap::new();
+            overrides.insert("cpp".to_string(), vec!["clangd".to_string()]);
+            let result = check_lsp(
+                &langs(&[("cpp", 12)]),
+                &overrides,
+                &[dir.path().join("src")],
+                dir.path(),
+            );
+            assert_eq!(result.status, CheckStatus::Warn);
+            assert!(
+                result
+                    .details
+                    .iter()
+                    .any(|d| d.contains("compile database")),
+                "{:?}",
+                result.details
+            );
+        }
+
+        #[test]
+        fn cpp_with_compile_flags_txt_has_no_compile_database_warning() {
+            let dir = tempfile::TempDir::new().unwrap();
+            std::fs::write(dir.path().join("compile_flags.txt"), "-std=c++17\n").unwrap();
+            let mut overrides = HashMap::new();
+            overrides.insert("cpp".to_string(), vec!["clangd".to_string()]);
+            let result = check_lsp(
+                &langs(&[("cpp", 12)]),
+                &overrides,
+                &[dir.path().join("src")],
+                dir.path(),
+            );
+            assert_eq!(result.status, CheckStatus::Ok);
+        }
+
+        #[test]
+        #[serial]
+        fn compile_database_is_not_reported_when_clangd_itself_is_missing() {
+            // Otherwise a machine without clangd double-reports the same gap:
+            // the missing server is the finding, not the missing compile db.
+            let dir = tempfile::TempDir::new().unwrap();
+            let result = with_empty_path(|| {
+                check_lsp(
+                    &langs(&[("cpp", 12)]),
+                    &HashMap::new(),
+                    &[dir.path().join("src")],
+                    dir.path(),
+                )
+            });
+            assert_eq!(result.status, CheckStatus::Warn);
+            assert!(
+                result.details.iter().any(|d| d.contains("clangd")),
+                "expected the missing-server finding: {:?}",
+                result.details
+            );
+            // The install hint mentions a compile database too, so match the
+            // distinct finding, not the substring.
+            assert!(
+                !result
+                    .details
+                    .iter()
+                    .any(|d| d.starts_with("clangd has no")),
+                "{:?}",
+                result.details
+            );
+        }
+
+        #[test]
+        fn compile_database_in_the_source_directory_satisfies_the_check() {
+            // clangd searches the file's own directory first.
+            let dir = tempfile::TempDir::new().unwrap();
+            let src = dir.path().join("native");
+            std::fs::create_dir_all(&src).unwrap();
+            std::fs::write(src.join("compile_commands.json"), "[]").unwrap();
+            let mut overrides = HashMap::new();
+            overrides.insert("cpp".to_string(), vec!["clangd".to_string()]);
+            let result = check_lsp(&langs(&[("cpp", 12)]), &overrides, &[src], dir.path());
+            assert_eq!(result.status, CheckStatus::Ok);
+        }
+
+        #[test]
+        fn compile_database_warning_names_the_source_directory_not_the_repo_root() {
+            // A polyglot repo (Rust workspace + a C fixture) must not be told to
+            // put a compile database at a root where it would be meaningless.
+            let dir = tempfile::TempDir::new().unwrap();
+            let src = dir.path().join("benchmarks/fixtures/webapp_cpp");
+            std::fs::create_dir_all(&src).unwrap();
+            let mut overrides = HashMap::new();
+            overrides.insert("cpp".to_string(), vec!["clangd".to_string()]);
+            let result = check_lsp(&langs(&[("cpp", 12)]), &overrides, &[src], dir.path());
+            assert_eq!(result.status, CheckStatus::Warn);
+            let joined = result.details.join(" ");
+            assert!(joined.contains("webapp_cpp"), "{joined}");
+        }
+
+        #[test]
+        fn warn_row_still_reports_the_servers_that_were_found() {
+            // The positive half is what a bug report needs; a single gap must
+            // not hide the eleven languages that did resolve.
+            let mut overrides = HashMap::new();
+            overrides.insert("rust".to_string(), vec!["rust-analyzer".to_string()]);
+            let result = with_empty_path(|| {
+                check_lsp(
+                    &langs(&[("rust", 20), ("csharp", 3)]),
+                    &overrides,
+                    &[],
+                    Path::new("/proj"),
+                )
+            });
+            assert_eq!(result.status, CheckStatus::Warn);
+            let joined = result.details.join(" ");
+            assert!(joined.contains("servers found for rust"), "{joined}");
+            assert!(joined.contains("csharp"), "{joined}");
+        }
+
+        #[test]
+        #[serial]
+        fn missing_multi_spec_language_lists_every_candidate_server() {
+            // Ruby ships two servers with different minimum runtimes; naming
+            // only the first can hand the user the one hint they cannot meet.
+            let result = with_empty_path(|| {
+                check_lsp(
+                    &langs(&[("ruby", 5)]),
+                    &HashMap::new(),
+                    &[],
+                    Path::new("/proj"),
+                )
+            });
+            assert_eq!(result.status, CheckStatus::Warn);
+            let joined = result.details.join(" ");
+            assert!(joined.contains("ruby-lsp"), "{joined}");
+            assert!(joined.contains("solargraph"), "{joined}");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "lsp")]
+    fn indexed_for_lsp_is_none_when_database_is_absent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(indexed_for_lsp(&dir.path().join("missing.sqlite"), 384, dir.path()).is_none());
     }
 }

--- a/crates/cartog/src/commands/doctor.rs
+++ b/crates/cartog/src/commands/doctor.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Serialize;
 
 #[cfg(feature = "remote-s3")]
@@ -487,18 +487,23 @@ fn fetch_latest_version_quick(url: &str) -> Result<String> {
         // stall well past it, which is exactly the blackholed-network case.
         .connect_timeout(VERSION_PROBE_TIMEOUT)
         .timeout(VERSION_PROBE_TIMEOUT)
-        .build()?;
+        .build()
+        .context("building the HTTP client for the release probe")?;
     let response = client
         .get(url)
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
-        .send()?;
+        .send()
+        .with_context(|| format!("release probe to {url} failed"))?;
     let status = response.status();
     if !status.is_success() {
         anyhow::bail!("GitHub API returned status {status}");
     }
-    parse_release_tag(&response.text()?)
-        .ok_or_else(|| anyhow::anyhow!("no stable release tag in the GitHub response"))
+    let body = response
+        .text()
+        .with_context(|| format!("reading the release-probe response from {url}"))?;
+    parse_release_tag(&body)
+        .ok_or_else(|| anyhow::anyhow!("no stable release tag in the response from {url}"))
 }
 
 /// Compare the running version against the latest stable GitHub release.
@@ -544,7 +549,9 @@ fn check_version(
         Err(e) => CheckResult {
             name: "version".into(),
             status: CheckStatus::Ok,
-            message: format!("{current} (latest unknown: {e})"),
+            // `{:#}` so the whole context chain shows — the outer context
+            // alone names the probe but hides why it failed.
+            message: format!("{current} (latest unknown: {e:#})"),
             details: Vec::new(),
         },
     }
@@ -1707,6 +1714,7 @@ mod tests {
         }
 
         #[test]
+        #[serial]
         fn warn_row_still_reports_the_servers_that_were_found() {
             // The positive half is what a bug report needs; a single gap must
             // not hide the eleven languages that did resolve.

--- a/crates/cartog/src/commands/self_cmd/version.rs
+++ b/crates/cartog/src/commands/self_cmd/version.rs
@@ -151,6 +151,10 @@ pub fn cmd_self_version(json: bool) -> Result<()> {
     Ok(())
 }
 
+// Re-exported so the `use super::*` glob in each `self_cmd` submodule (and
+// its tests) resolves these to the one shared implementation.
+pub(crate) use cartog::semver::{compare_stable_versions, is_stable_semver, parse_release_tag};
+
 const DEFAULT_GITHUB_LATEST_URL: &str =
     "https://api.github.com/repos/jrollin/cartog/releases/latest";
 
@@ -182,32 +186,6 @@ pub(crate) fn fetch_latest_version(url: &str) -> Result<String> {
     parse_release_tag(&body).ok_or_else(|| {
         anyhow::anyhow!("could not extract a stable release tag from GitHub response")
     })
-}
-
-/// Pull `tag_name` out of the GitHub release JSON, strip a leading `v`, and
-/// return `None` for any prerelease-shaped tag. SemVer prerelease metadata
-/// is delimited by `-`, so any hyphen in the version (e.g. `0.15.0-rc.1`,
-/// `0.15.0-alpha`, `0.15.0-nightly.42`) disqualifies the tag.
-pub(crate) fn parse_release_tag(json: &str) -> Option<String> {
-    let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
-    let tag = parsed.get("tag_name")?.as_str()?;
-    let trimmed = tag.strip_prefix('v').unwrap_or(tag);
-    if trimmed.contains('-') {
-        return None;
-    }
-    if !is_stable_semver(trimmed) {
-        return None;
-    }
-    Some(trimmed.to_string())
-}
-
-/// Quick guard: accept exactly three dot-separated non-empty numeric parts.
-pub(crate) fn is_stable_semver(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    parts.len() == 3
-        && parts
-            .iter()
-            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// JSON-friendly view of an update check. A single shape covers both the
@@ -259,23 +237,6 @@ impl CheckOutcome {
             _ => "cartog: update check produced an empty outcome".to_string(),
         }
     }
-}
-
-/// Lexicographic compare on `(major, minor, patch)`.
-///
-/// Both inputs are expected to be stable `MAJOR.MINOR.PATCH` triples — any
-/// non-numeric component is treated as `0`, so the function never panics on
-/// weird input but degrades gracefully.
-pub(crate) fn compare_stable_versions(a: &str, b: &str) -> std::cmp::Ordering {
-    let parse = |s: &str| -> [u64; 3] {
-        let mut parts = s.split('.').map(|p| p.parse::<u64>().unwrap_or(0));
-        [
-            parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0),
-        ]
-    };
-    parse(a).cmp(&parse(b))
 }
 
 // ── upgrade flow ──────────────────────────────────────────────────────

--- a/crates/cartog/src/lib.rs
+++ b/crates/cartog/src/lib.rs
@@ -41,3 +41,9 @@ pub mod state;
 /// target's `commands::self_cmd` can reach it without a duplicate copy.
 #[doc(hidden)]
 pub mod time_fmt;
+
+/// Stable-release tag parsing and version comparison. Internal — exposed via
+/// the lib facade only so `auto_check` and the bin target's `self_cmd` /
+/// `doctor` share one copy instead of three.
+#[doc(hidden)]
+pub mod semver;

--- a/crates/cartog/src/main.rs
+++ b/crates/cartog/src/main.rs
@@ -378,6 +378,7 @@ fn main() -> Result<()> {
             config_path.as_deref(),
             config_rejected,
             &db_path,
+            &project_root_from_cwd(),
             cli.json,
             embedding_dim,
             &provider_config,

--- a/crates/cartog/src/semver.rs
+++ b/crates/cartog/src/semver.rs
@@ -1,0 +1,54 @@
+//! Stable-release version parsing and comparison.
+//!
+//! Shared by the background update check (`auto_check`) and the bin target's
+//! `cartog self` / `cartog doctor` commands, which all read the same GitHub
+//! releases payload and must agree on what counts as a stable release —
+//! three of them previously carried byte-identical private copies.
+
+/// Pull `tag_name` out of the GitHub release JSON, strip a leading `v`, and
+/// return `None` for any prerelease-shaped tag.
+///
+/// SemVer prerelease metadata is delimited by `-`, so any hyphen in the
+/// version (e.g. `0.15.0-rc.1`, `0.15.0-alpha`, `0.15.0-nightly.42`)
+/// disqualifies the tag.
+#[must_use]
+pub fn parse_release_tag(json: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
+    let tag = parsed.get("tag_name")?.as_str()?;
+    let trimmed = tag.strip_prefix('v').unwrap_or(tag);
+    if trimmed.contains('-') {
+        return None;
+    }
+    if !is_stable_semver(trimmed) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Quick guard: accept exactly three dot-separated non-empty numeric parts.
+#[must_use]
+pub fn is_stable_semver(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Lexicographic compare on `(major, minor, patch)`.
+///
+/// Both inputs are expected to be stable `MAJOR.MINOR.PATCH` triples — any
+/// non-numeric component is treated as `0`, so the function never panics on
+/// weird input but degrades gracefully.
+#[must_use]
+pub fn compare_stable_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse = |s: &str| -> [u64; 3] {
+        let mut parts = s.split('.').map(|p| p.parse::<u64>().unwrap_or(0));
+        [
+            parts.next().unwrap_or(0),
+            parts.next().unwrap_or(0),
+            parts.next().unwrap_or(0),
+        ]
+    };
+    parse(a).cmp(&parse(b))
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -391,6 +391,7 @@ All 9 checks passed
 | lsp | A server is available for every indexed language | A server is missing, or clangd has no compile database | — |
 | embedding | Local model cached / Ollama reachable | Local model not downloaded | Ollama unreachable / unknown provider |
 | reranker | Model cached / disabled | Model not downloaded | Unknown provider |
+| remote | Not configured, or the bucket is reachable | `url` empty, unreachable, or config rejected | `[remote]` set but built without `remote-s3` |
 | version | Up to date, or the check is disabled/unreachable | A newer stable release exists | — |
 
 Exits with code 1 if any check is an error. Supports `--json` for structured output.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -363,11 +363,21 @@ cartog doctor
 ```text
   [+] git: git repository at /home/user/project
   [+] config: loaded from /home/user/project/.cartog.toml
+  [+] paths:
+      project root:  /home/user/project
+      config:        /home/user/project/.cartog.toml
+      database:      /home/user/project/.cartog/db.sqlite
+      state file:    /home/user/.local/state/cartog/state.toml
+      model cache:   /home/user/.cache/cartog/models
+      install:       release-tarball (x86_64-unknown-linux-gnu)
   [+] database: 42 files, 387 symbols at /home/user/project/.cartog/db.sqlite
+  [+] lsp: servers found for rust, python, typescript
   [+] embedding: local model cached
   [+] reranker: jinaai/jina-reranker-v1-turbo-en cached
+  [+] remote: not configured (local-only)
+  [+] version: 0.33.0 is up to date
 
-All 5 checks passed
+All 9 checks passed
 ```
 
 **Checks performed:**
@@ -376,11 +386,42 @@ All 5 checks passed
 |-------|-----|------|-------|
 | git | Inside a git repo | — | Not a git repo |
 | config | `.cartog.toml` found and parsed | No config file (using defaults) | — |
+| paths | Always — an inventory row, not a health check | — | — |
 | database | DB exists with indexed data | DB empty or missing | DB cannot be opened |
+| lsp | A server is available for every indexed language | A server is missing, or clangd has no compile database | — |
 | embedding | Local model cached / Ollama reachable | Local model not downloaded | Ollama unreachable / unknown provider |
 | reranker | Model cached / disabled | Model not downloaded | Unknown provider |
+| version | Up to date, or the check is disabled/unreachable | A newer stable release exists | — |
 
 Exits with code 1 if any check is an error. Supports `--json` for structured output.
+
+**`version`** queries the GitHub releases API with an 800 ms timeout — much
+shorter than the 5 s `cartog self update` allows, because there waiting for an
+answer *is* the task, while doctor is what you run when something is already
+broken. A failed probe reports `latest unknown` and stays OK: being offline is
+not a broken environment. It is also the last check to run, so every local row
+is computed before the probe starts. Measured: ~0.1 s normally, ~0.8 s worst
+case on a blackholed network. Set `CARTOG_NO_UPDATE_CHECK=1` to skip the
+request entirely, or `CARTOG_GITHUB_API_URL` to point at a mirror.
+
+**`paths`** is informational: it collects every location a bug report needs
+(project root, config, database, state file, model cache, install source and
+target triple) into one block. In `--json` these are discrete strings under
+`details`, not a newline-joined message.
+
+**`lsp`** only reports languages the project has actually indexed, so it never
+nags about a language you do not use. Languages resolved by heuristics alone
+(Markdown) are skipped. A `[lsp.<lang>] command` override counts as available
+without a `PATH` probe, since the binary usually lives in a container. A language with several
+candidate servers (Ruby: `ruby-lsp`, `solargraph`) lists all of them, since they
+carry different minimum runtimes. When C or C++ is indexed and `clangd` is
+reachable, it also checks for a `compile_commands.json` or `compile_flags.txt`
+covering the directories that actually hold the C/C++ sources, walking up to the
+project root — a polyglot repo (a Rust workspace with a C fixture, a vendored
+native dependency) is never asked for a compile database at a root where one
+would be meaningless. Without a compile database clangd guesses bare flags and
+most cross-file includes go unresolved. The row is
+absent from builds compiled `--no-default-features` (no `lsp` feature).
 
 ### `cartog watch [path] [--debounce N] [--rag] [--rag-delay N] [--json]`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,7 +66,9 @@ simpler `compile_flags.txt` listing one flag per line:
 
 Without one, clangd guesses bare flags and cross-file includes go unresolved, so
 LSP adds little over the heuristic tiers. `cartog doctor` reports a missing
-compile database in its `lsp` row whenever C or C++ is indexed. A Dockerized server via `[lsp.cpp]
+compile database in its `lsp` row when C or C++ is indexed **and clangd is
+reachable**; when clangd itself is missing it reports that instead, since the
+absent server is the finding. A Dockerized server via `[lsp.cpp]
 command = [...]` (see `benchmarks/lsp-images/cpp.Dockerfile`) avoids a host
 install. Note `.h` is parsed with the C++ grammar (a superset that also parses C
 headers correctly).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,7 +65,8 @@ simpler `compile_flags.txt` listing one flag per line:
 ```
 
 Without one, clangd guesses bare flags and cross-file includes go unresolved, so
-LSP adds little over the heuristic tiers. A Dockerized server via `[lsp.cpp]
+LSP adds little over the heuristic tiers. `cartog doctor` reports a missing
+compile database in its `lsp` row whenever C or C++ is indexed. A Dockerized server via `[lsp.cpp]
 command = [...]` (see `benchmarks/lsp-images/cpp.Dockerfile`) avoids a host
 install. Note `.h` is parsed with the C++ grammar (a superset that also parses C
 headers correctly).
@@ -431,8 +432,10 @@ already-downloaded weights, no re-download).
 
 ### `cartog refs X` returns fewer hits than I expect
 
-Check whether the `lsp` feature is compiled in:
-`cartog doctor` shows "LSP: available" when it is. Heuristic-only resolution
+Check whether the `lsp` feature is compiled in and a server is actually
+reachable: `cartog doctor`'s `lsp` row lists the servers found for the
+languages you have indexed, and names the missing ones with their install
+hint. Heuristic-only resolution
 hovers around 25–37 % across languages; LSP-backed resolution is 44–81 %
 depending on language.
 
@@ -471,6 +474,8 @@ service shutdown) still work; only Ctrl-C is unavailable until restart.
 A useful issue includes:
 
 - `cartog --version`
-- `cartog doctor`
+- `cartog doctor` — its `paths` row collects the config, database, state-file
+  and model-cache locations plus the install source, which is most of what a
+  maintainer needs to reproduce
 - `cartog stats`
 - The failing command, run with `RUST_LOG=debug`.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -170,9 +170,10 @@ import { withBase } from "../lib/url";
 <span class="highlight">[+]</span> <span class="output">lsp: servers found for rust, python, typescript</span>
 <span class="highlight">[+]</span> <span class="output">embedding: local model cached</span>
 <span class="highlight">[+]</span> <span class="output">reranker: jina-reranker-v1-turbo-en cached</span>
+<span class="highlight">[+]</span> <span class="output">remote: not configured (local-only)</span>
 <span class="highlight">[+]</span> <span class="output">version: 0.33.0 is up to date</span>
 
-<span class="comment">All 8 checks passed</span></div>
+<span class="comment">All 9 checks passed</span></div>
         </div>
       </div>
     </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -165,11 +165,14 @@ import { withBase } from "../lib/url";
           <div class="terminal-body"><span class="prompt">$</span> <span class="cmd">cartog doctor</span>
 <span class="highlight">[+]</span> <span class="output">git: git repository at /your/repo</span>
 <span class="highlight">[+]</span> <span class="output">config: loaded from .cartog.toml</span>
+<span class="highlight">[+]</span> <span class="output">paths: config, database, state, model cache</span>
 <span class="highlight">[+]</span> <span class="output">database: 142 files, 3891 symbols</span>
+<span class="highlight">[+]</span> <span class="output">lsp: servers found for rust, python, typescript</span>
 <span class="highlight">[+]</span> <span class="output">embedding: local model cached</span>
 <span class="highlight">[+]</span> <span class="output">reranker: jina-reranker-v1-turbo-en cached</span>
+<span class="highlight">[+]</span> <span class="output">version: 0.33.0 is up to date</span>
 
-<span class="comment">All 5 checks passed</span></div>
+<span class="comment">All 8 checks passed</span></div>
         </div>
       </div>
     </div>

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -1046,19 +1046,31 @@ Measured across 13 benchmark scenarios (see crates/cartog/benches/queries.rs).</
         <p>Data comes from a local <code>query_log</code> table inside <code>.cartog/db.sqlite</code>. Nothing leaves the machine; no query payloads are recorded — only the tool name, call surface (<code>cli</code> / <code>mcp</code>), and a timestamp. Secondary read-only MCP attaches can't write, so multi-MCP-server setups under-report secondary traffic rather than double-counting it.</p>
 
         <h2 id="cmd-doctor"><code>cartog doctor</code></h2>
-        <p>Validate that all requirements are met and everything is working. Checks git repo, config, database, embedding provider, and reranker.</p>
+        <p>Validate that all requirements are met and everything is working. Checks the release version, git repo, config, key paths, database, LSP servers, embedding provider, and reranker.</p>
         <pre>cartog doctor                 <span class="comment"># check all requirements</span>
 cartog --json doctor          <span class="comment"># structured JSON output</span></pre>
         <p class="example-label">Example output</p>
         <pre class="example-output">  [+] git: git repository at /your/repo
   [+] config: loaded from /your/repo/.cartog.toml
+  [+] paths:
+      project root:  /your/repo
+      config:        /your/repo/.cartog.toml
+      database:      /your/repo/.cartog/db.sqlite
+      state file:    /home/you/.local/state/cartog/state.toml
+      model cache:   /home/you/.cache/cartog/models
+      install:       release-tarball (x86_64-unknown-linux-gnu)
   [+] database: 70 files, 697 symbols at .cartog/db.sqlite
+  [+] lsp: servers found for rust, python, typescript
   [+] embedding: local model cached
   [+] reranker: jinaai/jina-reranker-v1-turbo-en cached
   [+] remote: not configured (local-only)
+  [+] version: 0.33.0 is up to date
 
-All 6 checks passed</pre>
+All 9 checks passed</pre>
         <p>Each check reports <strong>OK</strong>, <strong>Warn</strong>, or <strong>Error</strong>. Exits with code 1 if any check is an error. Run this when commands fail unexpectedly or after first setup.</p>
+        <p><strong>version</strong> queries the GitHub releases API with an 800&nbsp;ms timeout — much shorter than the 5&nbsp;s <code>cartog self update</code> allows, because there waiting for an answer <em>is</em> the task, while doctor is what you run when something is already broken. A failed probe reports <code>latest unknown</code> and stays OK: being offline is not a broken environment. Measured: ~0.1&nbsp;s normally, ~0.8&nbsp;s worst case on a blackholed network. Set <code>CARTOG_NO_UPDATE_CHECK=1</code> to skip the request entirely.</p>
+        <p><strong>paths</strong> is an inventory row, not a health check: it collects every location a bug report needs into one block. In <code>--json</code> these are discrete strings under <code>details</code>.</p>
+        <p><strong>lsp</strong> reports only the languages you have actually indexed, so it never nags about a language you do not use. A <code>[lsp.&lt;lang&gt;] command</code> override counts as available without a <code>PATH</code> probe. A language with several candidate servers (Ruby: <code>ruby-lsp</code>, <code>solargraph</code>) lists all of them, since they carry different minimum runtimes. When C or C++ is indexed and <code>clangd</code> is reachable, it also checks for a <code>compile_commands.json</code> or <code>compile_flags.txt</code> covering the directories that actually hold the C/C++ sources, walking up to the project root — a polyglot repo is never asked for a compile database at a root where one would be meaningless. Without one clangd guesses bare flags and most cross-file includes go unresolved.</p>
 
         <h2 id="cmd-map"><code>cartog map</code></h2>
         <p>Token-budget-aware codebase summary — file tree + top symbols ranked by reference count. Add <code>--mermaid</code> for a <code>graph TD</code> rooted at "Repo"; the token budget still applies (renderer stops adding nodes before it overflows).</p>

--- a/site/src/pages/usage.astro
+++ b/site/src/pages/usage.astro
@@ -1046,7 +1046,7 @@ Measured across 13 benchmark scenarios (see crates/cartog/benches/queries.rs).</
         <p>Data comes from a local <code>query_log</code> table inside <code>.cartog/db.sqlite</code>. Nothing leaves the machine; no query payloads are recorded — only the tool name, call surface (<code>cli</code> / <code>mcp</code>), and a timestamp. Secondary read-only MCP attaches can't write, so multi-MCP-server setups under-report secondary traffic rather than double-counting it.</p>
 
         <h2 id="cmd-doctor"><code>cartog doctor</code></h2>
-        <p>Validate that all requirements are met and everything is working. Checks the release version, git repo, config, key paths, database, LSP servers, embedding provider, and reranker.</p>
+        <p>Validate that all requirements are met and everything is working. Checks the git repo, config, key paths, database, LSP servers, embedding provider, reranker, remote, and the release version.</p>
         <pre>cartog doctor                 <span class="comment"># check all requirements</span>
 cartog --json doctor          <span class="comment"># structured JSON output</span></pre>
         <p class="example-label">Example output</p>

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -350,7 +350,7 @@ The primary tool for "how does X work?" and understanding an area: one call retu
 cartog doctor                            # check all requirements
 cartog --json doctor                     # structured JSON output
 ```
-Validates git repo, config, key paths, database, LSP servers, embedding provider, reranker, and the release version. Returns OK / Warn / Error per check and exits with code 1 if any error. Run this when commands fail unexpectedly or after first setup to verify everything is working.
+Validates git repo, config, key paths, database, LSP servers, embedding provider, reranker, the remote, and the release version. Returns OK / Warn / Error per check and exits with code 1 if any error. Run this when commands fail unexpectedly or after first setup to verify everything is working.
 
 ### Stats (index summary, savings retention hook)
 ```bash

--- a/skills/cartog/SKILL.md
+++ b/skills/cartog/SKILL.md
@@ -350,7 +350,7 @@ The primary tool for "how does X work?" and understanding an area: one call retu
 cartog doctor                            # check all requirements
 cartog --json doctor                     # structured JSON output
 ```
-Validates git repo, config, database, embedding provider, and reranker. Returns OK / Warn / Error per check and exits with code 1 if any error. Run this when commands fail unexpectedly or after first setup to verify everything is working.
+Validates git repo, config, key paths, database, LSP servers, embedding provider, reranker, and the release version. Returns OK / Warn / Error per check and exits with code 1 if any error. Run this when commands fail unexpectedly or after first setup to verify everything is working.
 
 ### Stats (index summary, savings retention hook)
 ```bash


### PR DESCRIPTION
## Summary

`cartog doctor` gains three rows — `version`, `paths`, and `lsp` — turning it
from a four-subsystem check into something you can paste into a bug report.

The `lsp` row closes a real, measured gap: a missing clangd compile database
costs **~59% of the LSP edge gain** on the C++ fixture (17 → 7 resolved edges),
silently, with no signal to the user. `doctor` had zero LSP awareness before
this — despite `docs/troubleshooting.md` telling users it showed an
`LSP: available` line it never had.

Run against this repo, the new row immediately found two genuine gaps
(a missing `csharp-ls`, and the compile-database check now covering the C/C++
fixtures).

## Changes

**`version`** — compares the running build against the latest stable GitHub
release, reusing the shared semver helpers.

- A failed probe is **OK, not Warn**: being offline is not a broken
  environment, and `doctor` exits 1 on any error row.
- Runs **last**, on an **800 ms** budget (vs the 5 s `self update` allows) —
  `doctor` is what you run *because* something is already broken. Measured
  **~0.1 s** normally, **~0.8 s** worst case on a blackholed network.
- `CARTOG_NO_UPDATE_CHECK=1` skips the probe; `CARTOG_GITHUB_API_URL` retargets it.

**`paths`** — an inventory row, not a health check: project root, config,
database, state file, model cache, install source + target triple. Carried as
discrete `details` strings so `--json` consumers never have to re-split a
newline-joined blob.

**`lsp`** — server availability for the languages **actually indexed**, so it
never nags about a language the project does not use.

- Heuristic-only languages (Markdown) are skipped — not a gap.
- A `[lsp.<lang>] command` override counts as available without a `PATH` probe
  (the binary lives in a container).
- A language with several candidate servers lists **all** of them: Ruby's two
  carry different minimum runtimes, so naming only the first can hand the user
  the one hint they cannot satisfy.
- For C/C++, checks for a compile database by walking up **from the directories
  that hold the sources**, not the project root — a polyglot repo (a Rust
  workspace with a C fixture, a vendored native dep) must never be told to add
  one where it would be meaningless.
- Skipped when clangd itself is absent, since that is the finding.
- Gated on the `lsp` feature; absent from `--no-default-features` builds.

**Refactor (separate commit, move-only).** `parse_release_tag`,
`is_stable_semver` and `compare_stable_versions` existed as two byte-identical
private copies (lib `auto_check`, bin `self_cmd::version`) — an artifact of the
lib/bin split. Extracted into `cartog::semver`, following the `time_fmt`
precedent. `self_cmd::version` re-exports the names so every sibling's
`use super::*` keeps resolving. Net **−13 lines**, no behaviour change.

The refactor is committed **first**: `doctor.rs` imports `cartog::semver`, so
the reverse order would leave a commit that does not compile. Verified by
building `6b48aaf` standalone.

**Docs + site synced** — `docs/reference/cli.md`, `docs/troubleshooting.md`
(including the stale `LSP: available` claim), both site pages, `README.md`, and
`skills/cartog/SKILL.md`. Every example block's row count was verified against
its own "All N checks passed" line.

## Testing

- 14 new tests in `doctor.rs` (55 total in the module, green on both feature sets).
- Two LSP tests initially self-skipped when a binary happened to be installed —
  made deterministic by emptying `PATH`, at which point one immediately caught a
  bad assertion of mine (clangd's install hint itself contains "compile database").
- The `version` tests take `disabled` as a parameter rather than reading the env,
  so a developer or CI runner with `CARTOG_NO_UPDATE_CHECK` set cannot silently
  flip them. Verified: the suite passes with that var set.

## Checklist

- [x] `make check` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for new behavior
- [x] Documentation updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded `cartog doctor` with path, LSP, and release-version checks.
  - Added detailed diagnostic information in human-readable and JSON output.
  - Version checks support offline environments and configurable update-check behavior.

- **Documentation**
  - Updated CLI reference, troubleshooting guidance, website examples, and usage documentation to reflect the expanded diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->