### PR TITLE
fix(registry): README parsing, quarantine scope, and duplicate-row merge

### DIFF
--- a/crates/cartog-registry/src/corrupt.rs
+++ b/crates/cartog-registry/src/corrupt.rs
@@ -16,10 +16,18 @@ use crate::open::open_read_only;
 /// particular this does nothing for an absent file, an unreadable-by-permission
 /// file, or a busy one — none of those is corruption.
 ///
-/// The corrupt file is preserved, never truncated: it still holds every row
-/// the user accumulated, and its bytes are the only evidence of what went
-/// wrong. The unix-timestamp suffix means a second corruption cannot clobber
-/// the first quarantine.
+/// The corrupt main file is preserved, never truncated: its bytes are the
+/// evidence of what went wrong. The unix-timestamp suffix means a second
+/// corruption cannot clobber the first quarantine.
+///
+/// Its `-wal`/`-shm` sidecars are **discarded**, not moved aside, so rows that
+/// were committed but not yet checkpointed are lost — the quarantined file is
+/// evidence, not a complete backup. That is the deliberate cost of the ordering
+/// documented on `rename_aside`: a stale WAL left next to a freed path would be
+/// recovered against whatever new registry appears there.
+///
+/// Called from the write path only. A read degrades to "no projects" instead,
+/// since renaming a user's file is not a predictable side effect of a listing.
 pub(crate) fn quarantine_if_corrupt(path: &Path) {
     if !path.exists() {
         return;

--- a/crates/cartog-registry/src/describe.rs
+++ b/crates/cartog-registry/src/describe.rs
@@ -216,10 +216,15 @@ fn is_markup_only_html_line(trimmed: &str) -> bool {
 /// Counts opening against closing and self-closing tags rather than pattern
 /// matching a tag list: `<br>`, `<img …/>` and `<p …><img/></p>` all balance,
 /// while `<div>` does not. A void element written without a slash (`<br>`,
-/// `<img …>`, `<hr>`) has no closer, so it is listed — that set is fixed by
-/// the HTML spec and short.
+/// `<img …>`, `<hr>`) has no closer, so all of them are listed — the set is
+/// closed by the HTML spec, and an omission makes the element look unclosed,
+/// which suppresses the paragraph beneath it.
 fn is_balanced_html_line(trimmed: &str) -> bool {
-    const VOID: [&str; 8] = ["br", "img", "hr", "input", "meta", "link", "source", "col"];
+    /// Every HTML void element, per the spec's fixed list.
+    const VOID: [&str; 14] = [
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+        "source", "track", "wbr",
+    ];
     let mut depth = 0i32;
     let mut rest = trimmed;
     while let Some(open) = rest.find('<') {
@@ -1006,6 +1011,26 @@ The real summary.
     /// HTML syntax lost the very thing it was describing — `` `<div>` ``
     /// vanished outright. This text becomes a project description an agent
     /// reads, so silently eating it is worse than leaving markup in.
+    /// Every HTML void element must leave the paragraph beneath it alone.
+    ///
+    /// The list started at 8 of the spec's 14, and each omission made the tag
+    /// look unclosed, so the block ran to the next blank line and ate the
+    /// tagline — the same failure the centered-logo fix addressed, just with a
+    /// rarer tag. Enumerated rather than spot-checked because the set is
+    /// closed: a future edit that drops one fails here.
+    #[test]
+    fn no_void_element_swallows_the_paragraph_beneath_it() {
+        for tag in [
+            "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+            "source", "track", "wbr",
+        ] {
+            let body = format!("<{tag}>\nA fast thing.\n");
+            let d = describe("README.md", &body)
+                .unwrap_or_else(|| panic!("<{tag}> must not suppress the tagline"));
+            assert_eq!(d.text, "A fast thing.", "tag: <{tag}>");
+        }
+    }
+
     /// An indented code block is code, not prose.
     ///
     /// `first_prose_paragraph` trims each line before testing, so a 4-space

--- a/crates/cartog-registry/src/describe.rs
+++ b/crates/cartog-registry/src/describe.rs
@@ -120,6 +120,13 @@ fn first_prose_paragraph(text: &str) -> Option<String> {
             }
         }
 
+        // A 4-space indent starts a code block, but only where a paragraph
+        // could start: inside one, an indented line is a wrapped continuation
+        // (or a list's), and treating it as code would truncate the sentence.
+        // Tested before the trim-based checks below, which cannot see indent.
+        if paragraph.is_empty() && is_indented_code(line) {
+            continue;
+        }
         if trimmed.is_empty() || is_structural(trimmed) {
             if !paragraph.is_empty() {
                 break;
@@ -151,16 +158,22 @@ enum HtmlBlock {
 }
 
 impl HtmlBlock {
-    /// The block a `<`-leading line opens.
+    /// The block a `<`-leading line opens, or `None` when the line is already
+    /// complete on its own.
     ///
     /// An `Element` block runs to the next blank line, which is CommonMark's
-    /// rule and also why a self-contained `<p>text</p>` needs no special case:
-    /// the line after it is blank, so the block ends there either way.
+    /// rule for a multi-line block. A line that closes everything it opened is
+    /// *not* such a block: the centered-logo README puts a complete `<img>` or
+    /// `<p>…</p>` on its own line with the tagline directly beneath and no
+    /// blank between, and treating that as an open block ate the tagline.
     fn opened_by(trimmed: &str) -> Option<Self> {
         if let Some(rest) = trimmed.strip_prefix("<!--") {
             return (!rest.contains("-->")).then_some(Self::Comment);
         }
-        trimmed.starts_with('<').then_some(Self::Element)
+        if !trimmed.starts_with('<') {
+            return None;
+        }
+        (!is_markup_only_html_line(trimmed)).then_some(Self::Element)
     }
 
     /// True when `trimmed` is the block's last line.
@@ -170,6 +183,81 @@ impl HtmlBlock {
             Self::Element => trimmed.is_empty(),
         }
     }
+}
+
+/// Whether a `<`-leading line is complete *and* carries no prose of its own.
+///
+/// Both halves matter. Complete, so `<div>` still opens a block that runs to
+/// the blank line. Prose-free, so `<p>ignored</p>` stays a block whose text is
+/// markup rather than a description — only the decorative shapes (`<br>`,
+/// `<img>`, `<p align="center"><img/></p>`) end on their own line, which is
+/// what stops them swallowing the tagline beneath.
+fn is_markup_only_html_line(trimmed: &str) -> bool {
+    if !is_balanced_html_line(trimmed) {
+        return false;
+    }
+    // Text outside the tags is prose the block rule should still consume.
+    let mut rest = trimmed;
+    while let Some(open) = rest.find('<') {
+        if !rest[..open].trim().is_empty() {
+            return false;
+        }
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('>') else {
+            return false;
+        };
+        rest = &after[close + 1..];
+    }
+    rest.trim().is_empty()
+}
+
+/// Whether a `<`-leading line leaves no element open.
+///
+/// Counts opening against closing and self-closing tags rather than pattern
+/// matching a tag list: `<br>`, `<img …/>` and `<p …><img/></p>` all balance,
+/// while `<div>` does not. A void element written without a slash (`<br>`,
+/// `<img …>`, `<hr>`) has no closer, so it is listed — that set is fixed by
+/// the HTML spec and short.
+fn is_balanced_html_line(trimmed: &str) -> bool {
+    const VOID: [&str; 8] = ["br", "img", "hr", "input", "meta", "link", "source", "col"];
+    let mut depth = 0i32;
+    let mut rest = trimmed;
+    while let Some(open) = rest.find('<') {
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('>') else {
+            // An unterminated tag spills onto the next line: a real block.
+            return false;
+        };
+        let inner = &after[..close];
+        rest = &after[close + 1..];
+
+        if inner.starts_with('/') {
+            depth -= 1;
+        } else if inner.ends_with('/') {
+            // Self-closing, contributes nothing.
+        } else {
+            let name = inner
+                .split([' ', '\t', '\n'])
+                .next()
+                .unwrap_or("")
+                .trim_end_matches('/')
+                .to_ascii_lowercase();
+            if !VOID.contains(&name.as_str()) {
+                depth += 1;
+            }
+        }
+    }
+    depth <= 0
+}
+
+/// A line indented enough to be a code block (4 spaces, or a tab).
+///
+/// Only meaningful where a paragraph could begin — see the call site.
+fn is_indented_code(line: &str) -> bool {
+    if line.trim().is_empty() {
+        return false;
+    }
+    line.starts_with("    ") || line.starts_with('\t')
 }
 
 /// The fence character of a code-fence line (``` or ~~~), if any.
@@ -323,7 +411,7 @@ fn remove_images(text: &str) -> String {
     while let Some(start) = rest.find("![") {
         out.push_str(&rest[..start]);
         let after = &rest[start + 2..];
-        let Some(close) = after.find(']') else {
+        let Some(close) = matching_bracket(after) else {
             // Unterminated: keep the literal so nothing is silently eaten.
             out.push_str(&rest[start..]);
             return out;
@@ -336,6 +424,24 @@ fn remove_images(text: &str) -> String {
     }
     out.push_str(rest);
     out
+}
+
+/// Offset of the `]` closing a bracket span, honouring nesting.
+///
+/// The first `]` is the wrong one when the label itself holds a link, as in
+/// `![img in [link](u)](v)`: taking it consumed `(u)` as the image target and
+/// left `](v)` in the description.
+fn matching_bracket(after_open: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    for (i, c) in after_open.char_indices() {
+        match c {
+            '[' => depth += 1,
+            ']' if depth == 0 => return Some(i),
+            ']' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Rewrite `[text](url)` / `[text][ref]` / `[text]` to `text`.
@@ -900,6 +1006,68 @@ The real summary.
     /// HTML syntax lost the very thing it was describing — `` `<div>` ``
     /// vanished outright. This text becomes a project description an agent
     /// reads, so silently eating it is worse than leaving markup in.
+    /// An indented code block is code, not prose.
+    ///
+    /// `first_prose_paragraph` trims each line before testing, so a 4-space
+    /// block looked like ordinary text; a README opening with an install
+    /// snippet stored the snippet as its description. Fenced blocks were
+    /// already handled — this was the one code-block form that leaked.
+    #[test]
+    fn an_indented_code_block_is_not_prose() {
+        let body = "# T\n\n    cargo install thing\n\nThe real summary.\n";
+        let d = describe("README.md", body).expect("must find prose");
+        assert_eq!(d.text, "The real summary.");
+    }
+
+    /// A list's continuation lines are indented too, so indentation alone must
+    /// not be read as code once a paragraph is under way.
+    #[test]
+    fn an_indented_continuation_line_stays_part_of_its_paragraph() {
+        let body = "# T\n\nA summary that wraps\n    onto an indented line.\n";
+        let d = describe("README.md", body).expect("must find prose");
+        assert_eq!(d.text, "A summary that wraps onto an indented line.");
+    }
+
+    /// A link nested in image alt text must not leak markup.
+    ///
+    /// `remove_images` found the first `]` — the inner link's — and consumed
+    /// the wrong `(…)` as the image target, leaving the remainder behind.
+    #[test]
+    fn a_link_nested_in_image_alt_text_is_removed_whole() {
+        let body = "Nested ![img in [link](u)](v) prose.\n";
+        let d = describe("README.md", body).expect("must find prose");
+        assert_eq!(d.text, "Nested prose.");
+    }
+
+    /// A self-contained HTML line must not swallow the paragraph under it.
+    ///
+    /// CommonMark runs an HTML *block* to the next blank line, which is right
+    /// for a multi-line block. But the centered-logo README shape puts a
+    /// complete `<img>` or `<br>` on its own line with the tagline directly
+    /// beneath and no blank between — so the block rule ate exactly the prose
+    /// the description exists to surface.
+    #[test]
+    fn a_self_contained_html_line_does_not_swallow_the_next_paragraph() {
+        for body in [
+            "# proj\n\n<br>\nA fast thing.\n",
+            "<img src=\"logo.png\">\nA fast thing.\n",
+            "<p align=\"center\"><img src=\"logo.png\" /></p>\nA fast thing.\n",
+        ] {
+            let d = describe("README.md", body)
+                .unwrap_or_else(|| panic!("must find prose, body: {body:?}"));
+            assert_eq!(d.text, "A fast thing.", "body: {body:?}");
+        }
+    }
+
+    /// A genuinely multi-line HTML block still runs to the blank line, or the
+    /// fix above would leak raw markup into the description.
+    #[test]
+    fn a_multi_line_html_block_still_runs_to_the_blank_line() {
+        let body = "<div>\n  <img src=\"logo.png\">\n</div>\n\nA fast thing.\n";
+        let d = describe("README.md", body).expect("must find prose");
+        assert_eq!(d.text, "A fast thing.");
+    }
+
     #[test]
     fn markup_inside_a_code_span_is_literal() {
         for (body, want) in [

--- a/crates/cartog-registry/src/read.rs
+++ b/crates/cartog-registry/src/read.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 
 use rusqlite::Connection;
 
-use crate::corrupt::quarantine_if_corrupt;
 use crate::model::{Description, DescriptionSource, Listing, Markers, ProjectRow};
 use crate::open::open_read_only;
 use crate::slot::slot_for_db;
@@ -43,8 +42,12 @@ pub fn list_projects_at(
     if !registry.exists() {
         return Listing::unavailable();
     }
-    quarantine_if_corrupt(registry);
-
+    // Deliberately does NOT quarantine. A listing is a read: renaming the
+    // user's registry as a side effect of `cartog projects list` is not
+    // predictable from the command, and the reader gains nothing from it —
+    // the failed open below already degrades to "no projects". Quarantine
+    // stays on the write path, which is the caller that needs the path
+    // cleared before it can make progress.
     let conn = match open_read_only(registry) {
         Ok(c) => c,
         Err(e) => {
@@ -733,8 +736,14 @@ mod tests {
         assert_eq!(row.file_count, Some(412), "the sane columns survive");
     }
 
+    /// A corrupt registry degrades the listing and leaves the file alone.
+    ///
+    /// The reader needs the first half only. Renaming the user's registry is
+    /// not a predictable side effect of `cartog projects list`, so quarantine
+    /// belongs to the write path — which is also the only caller that cannot
+    /// make progress until the path is cleared.
     #[test]
-    fn a_corrupt_registry_lists_as_unavailable_and_is_quarantined() {
+    fn a_corrupt_registry_lists_as_unavailable_without_renaming_it() {
         let f = Fixture::new();
         std::fs::write(&f.registry, b"not a database").unwrap();
 
@@ -742,10 +751,14 @@ mod tests {
 
         assert!(!listing.available);
         assert!(listing.projects.is_empty());
+        assert!(
+            f.registry.exists(),
+            "a read must not rename the user's registry"
+        );
         let quarantined = std::fs::read_dir(f._dir.path())
             .unwrap()
             .any(|e| e.unwrap().path().to_string_lossy().contains(".corrupt."));
-        assert!(quarantined, "the corrupt file must be preserved aside");
+        assert!(!quarantined, "quarantine is the write path's job");
     }
 
     #[test]

--- a/crates/cartog-registry/src/write.rs
+++ b/crates/cartog-registry/src/write.rs
@@ -125,7 +125,12 @@ fn retire_drifted_rows(conn: &Connection, keep_id: &str, db_path: &Path) {
             continue;
         }
         // Still on the old id? It lost the UPDATE to an existing `keep_id` row,
-        // which is authoritative — so this one is a true duplicate.
+        // which is authoritative — so this one is a true duplicate. Merge what
+        // it knows and the winner does not before dropping it: both rows
+        // describe the same physical project, and the upsert's `COALESCE` can
+        // only preserve values the *winner* already holds, so a bare canonical
+        // row would otherwise lose the drifted row's counts outright.
+        merge_into_survivor(conn, keep_id, &id, db_path);
         if let Err(e) = conn.execute(
             "DELETE FROM projects WHERE id = ?1 AND ?1 != ?2",
             rusqlite::params![id, keep_id],
@@ -136,6 +141,58 @@ fn retire_drifted_rows(conn: &Connection, keep_id: &str, db_path: &Path) {
                 "could not drop a duplicate registry row; the project may list twice"
             );
         }
+    }
+}
+
+/// Columns a losing duplicate can contribute to the row that outranks it.
+///
+/// Measurements and embedding state only. `db_path`/`root`/`name` belong to the
+/// canonical row by definition, `last_seen` is about to be refreshed, and the
+/// three declared columns are the config's to set — a stale row must not
+/// resurrect a name or description a later config cleared.
+const MERGEABLE_COLUMNS: [&str; 12] = [
+    "languages",
+    "schema_version",
+    "file_count",
+    "symbol_count",
+    "edge_count",
+    "resolved_count",
+    "embedding_count",
+    "embed_provider",
+    "embed_model",
+    "embed_dim",
+    "source_fingerprint",
+    "last_indexed",
+];
+
+/// Fill any [`MERGEABLE_COLUMNS`] the survivor left NULL from the loser.
+///
+/// `COALESCE(survivor, loser)` per column, so a value the survivor already
+/// holds always wins: this recovers lost history without ever overwriting the
+/// canonical row's own measurements. Failure is logged and ignored, like every
+/// other step here — a row missing its counts is untidy, not incorrect, and
+/// must never fail the caller's index.
+fn merge_into_survivor(conn: &Connection, keep_id: &str, loser_id: &str, db_path: &Path) {
+    let assignments = MERGEABLE_COLUMNS
+        .iter()
+        .map(|c| format!("{c} = COALESCE(survivor.{c}, loser.{c})"))
+        .collect::<Vec<_>>()
+        .join(",\n             ");
+    // Only the column *names* are interpolated, and they are compile-time
+    // literals; both ids are bound.
+    let sql = format!(
+        "UPDATE projects AS survivor SET
+             {assignments}
+         FROM (SELECT * FROM projects WHERE id = ?2) AS loser
+         WHERE survivor.id = ?1"
+    );
+    if let Err(e) = conn.execute(&sql, rusqlite::params![keep_id, loser_id]) {
+        tracing::warn!(
+            project = %db_path.display(),
+            error = %e,
+            "could not merge a duplicate registry row's counts; the project may \
+             list with unknown counts until its next index"
+        );
     }
 }
 
@@ -716,6 +773,90 @@ mod tests {
             .unwrap()
             .any(|e| e.unwrap().path().to_string_lossy().contains(".corrupt."));
         assert!(quarantined, "the corrupt bytes must be preserved aside");
+    }
+
+    /// A collision must merge the drifted row's counts, not drop them.
+    ///
+    /// `UPDATE OR IGNORE` cannot re-key onto an occupied id, so the drifted row
+    /// was deleted outright. When the canonical row holds no counts and the
+    /// drifted one does, the upsert's `COALESCE` has nothing to preserve and
+    /// the project reads `? symbols` until something re-indexes it.
+    #[test]
+    #[serial]
+    fn a_collision_merges_the_drifted_row_rather_than_dropping_its_counts() {
+        let f = WriteFixture::new();
+        let (root, db) = f.project("a");
+        let canonical = db.to_string_lossy().into_owned();
+        let non_canonical = canonical.replace("/private/var/", "/var/");
+        if non_canonical == canonical {
+            // Not macOS, or no such prefix: the drift under test cannot arise.
+            return;
+        }
+        {
+            let conn = crate::open::open_read_write(&f.registry).unwrap();
+            let stale = ProjectFacts {
+                // Bypass `absolutize` to reproduce a DB-absent write.
+                db_path: std::path::PathBuf::from(&non_canonical),
+                ..counted(&db, &root, 8134)
+            };
+            upsert(&conn, "serve-stale0000000000", &stale, Some("fp-stale")).unwrap();
+            // The canonical row exists already, and knows no counts.
+            let bare = ProjectFacts::identity_only(&db, &root);
+            upsert(&conn, &slot_for_db("serve", &db), &bare, Some("fp-bare")).unwrap();
+        }
+
+        f.record(&ProjectFacts::identity_only(&db, &root));
+
+        let rows = crate::read::list_projects_at(&f.registry, None, 8).projects;
+        assert_eq!(rows.len(), 1, "one database, one row");
+        assert_eq!(
+            rows[0].symbol_count,
+            Some(8134),
+            "the surviving row must inherit the counts the drifted row held"
+        );
+    }
+
+    /// The merge fills gaps; it never overwrites the canonical row.
+    ///
+    /// Without this the recovery above could regress into "last writer wins",
+    /// letting a stale duplicate replace the measurements the canonical row
+    /// obtained from a real index.
+    #[test]
+    #[serial]
+    fn a_collision_never_overwrites_the_survivors_own_counts() {
+        let f = WriteFixture::new();
+        let (root, db) = f.project("a");
+        let canonical = db.to_string_lossy().into_owned();
+        let non_canonical = canonical.replace("/private/var/", "/var/");
+        if non_canonical == canonical {
+            return;
+        }
+        {
+            let conn = crate::open::open_read_write(&f.registry).unwrap();
+            let stale = ProjectFacts {
+                db_path: std::path::PathBuf::from(&non_canonical),
+                ..counted(&db, &root, 1)
+            };
+            upsert(&conn, "serve-stale0000000000", &stale, Some("fp-stale")).unwrap();
+            // The canonical row already knows a real, larger count.
+            upsert(
+                &conn,
+                &slot_for_db("serve", &db),
+                &counted(&db, &root, 9999),
+                Some("fp-real"),
+            )
+            .unwrap();
+        }
+
+        f.record(&ProjectFacts::identity_only(&db, &root));
+
+        let rows = crate::read::list_projects_at(&f.registry, None, 8).projects;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].symbol_count,
+            Some(9999),
+            "the survivor's own count must win over the duplicate's"
+        );
     }
 
     #[test]

--- a/crates/cartog-registry/src/write.rs
+++ b/crates/cartog-registry/src/write.rs
@@ -696,6 +696,28 @@ mod tests {
         );
     }
 
+    /// The write path is the only caller that quarantines, so a corrupt
+    /// registry must recover here or it never recovers at all: reads
+    /// deliberately leave the file alone (see `read::list_projects_at`).
+    #[test]
+    #[serial]
+    fn a_corrupt_registry_is_quarantined_and_rebuilt_by_the_next_write() {
+        let f = WriteFixture::new();
+        let (root, db) = f.project("a");
+        std::fs::write(&f.registry, b"not a database").unwrap();
+
+        f.record(&ProjectFacts::identity_only(&db, &root));
+
+        assert!(
+            f.row(&db).is_some(),
+            "the write must land in a rebuilt registry"
+        );
+        let quarantined = std::fs::read_dir(f.dir.path())
+            .unwrap()
+            .any(|e| e.unwrap().path().to_string_lossy().contains(".corrupt."));
+        assert!(quarantined, "the corrupt bytes must be preserved aside");
+    }
+
     #[test]
     fn re_keying_a_drifted_row_preserves_the_counts_it_accumulated() {
         // It is the same project, so its history must survive: a path that

--- a/crates/cartog-registry/src/write.rs
+++ b/crates/cartog-registry/src/write.rs
@@ -487,6 +487,31 @@ mod tests {
             (root, db)
         }
 
+        /// A textually different spelling of `db` that resolves to the same
+        /// file, and the same slot, on every platform.
+        ///
+        /// A `.` component does that portably. The earlier spelling swapped a
+        /// macOS-only `/private/var` prefix, so on Linux the drift tests
+        /// returned before their first assertion and covered nothing.
+        fn drifted_spelling(&self, root: &Path, db: &Path) -> std::path::PathBuf {
+            let drifted = root.join(".").join("db.sqlite");
+            // Compare the strings, not the paths: `PathBuf` equality treats a
+            // `.` component as insignificant, so `assert_ne!` on the values
+            // fails even though the stored bytes differ — and the bytes are
+            // what a drifted registry row actually holds.
+            assert_ne!(
+                drifted.to_string_lossy(),
+                db.to_string_lossy(),
+                "the stored spelling must differ textually"
+            );
+            assert_eq!(
+                slot_for_db("serve", &drifted),
+                slot_for_db("serve", db),
+                "both spellings must resolve to one slot"
+            );
+            drifted
+        }
+
         /// Drive the real fallible core, so the env-dependent wrapper is the
         /// only thing these tests do not exercise.
         fn record(&self, facts: &ProjectFacts) {
@@ -720,17 +745,12 @@ mod tests {
         // `db_path` byte-identical, so it cannot catch this.
         let f = WriteFixture::new();
         let (root, db) = f.project("a");
-        let canonical = db.to_string_lossy().into_owned();
-        let non_canonical = canonical.replace("/private/var/", "/var/");
-        if non_canonical == canonical {
-            // Not macOS, or no such prefix: the case under test cannot arise.
-            return;
-        }
+        let non_canonical = f.drifted_spelling(&root, &db);
         {
             let conn = crate::open::open_read_write(&f.registry).unwrap();
             let stale = ProjectFacts {
                 // Bypass `absolutize` to reproduce what a DB-absent write stored.
-                db_path: std::path::PathBuf::from(&non_canonical),
+                db_path: non_canonical.clone(),
                 ..counted(&db, &root, 8134)
             };
             upsert(&conn, "serve-stale0000000000", &stale, Some("stale-fp")).unwrap();
@@ -786,17 +806,12 @@ mod tests {
     fn a_collision_merges_the_drifted_row_rather_than_dropping_its_counts() {
         let f = WriteFixture::new();
         let (root, db) = f.project("a");
-        let canonical = db.to_string_lossy().into_owned();
-        let non_canonical = canonical.replace("/private/var/", "/var/");
-        if non_canonical == canonical {
-            // Not macOS, or no such prefix: the drift under test cannot arise.
-            return;
-        }
+        let non_canonical = f.drifted_spelling(&root, &db);
         {
             let conn = crate::open::open_read_write(&f.registry).unwrap();
             let stale = ProjectFacts {
                 // Bypass `absolutize` to reproduce a DB-absent write.
-                db_path: std::path::PathBuf::from(&non_canonical),
+                db_path: non_canonical.clone(),
                 ..counted(&db, &root, 8134)
             };
             upsert(&conn, "serve-stale0000000000", &stale, Some("fp-stale")).unwrap();
@@ -826,15 +841,11 @@ mod tests {
     fn a_collision_never_overwrites_the_survivors_own_counts() {
         let f = WriteFixture::new();
         let (root, db) = f.project("a");
-        let canonical = db.to_string_lossy().into_owned();
-        let non_canonical = canonical.replace("/private/var/", "/var/");
-        if non_canonical == canonical {
-            return;
-        }
+        let non_canonical = f.drifted_spelling(&root, &db);
         {
             let conn = crate::open::open_read_write(&f.registry).unwrap();
             let stale = ProjectFacts {
-                db_path: std::path::PathBuf::from(&non_canonical),
+                db_path: non_canonical.clone(),
                 ..counted(&db, &root, 1)
             };
             upsert(&conn, "serve-stale0000000000", &stale, Some("fp-stale")).unwrap();

--- a/crates/cartog/tests/projects_test.rs
+++ b/crates/cartog/tests/projects_test.rs
@@ -436,7 +436,7 @@ fn projects_list_works_from_a_directory_with_no_git_and_no_config() {
 // ── corruption ──
 
 #[test]
-fn a_corrupt_registry_is_renamed_aside_rather_than_truncated() {
+fn a_corrupt_registry_survives_a_read_and_is_quarantined_by_the_next_write() {
     let sb = Sandbox::new();
     assert!(sb.index().status.success());
 
@@ -448,8 +448,24 @@ fn a_corrupt_registry_is_renamed_aside_rather_than_truncated() {
     let dir = registry.parent().unwrap().to_path_buf();
     fs::write(&registry, b"this is not a database").unwrap();
 
+    // A read must not rename the user's file, so it reports no projects and
+    // leaves the corruption in place for the write path to handle.
     let out = sb.cmd(&["projects", "list"]);
     assert!(out.status.success(), "a corrupt registry is not fatal");
+    assert!(
+        registry.exists(),
+        "a listing must not rename the registry out from under the user"
+    );
+
+    // The write path is the quarantiner: indexing recovers and preserves the
+    // corrupt bytes aside.
+    // `--force`: a second no-op pass changes nothing, and the registry hook
+    // deliberately skips a write that has nothing new to record.
+    let reindex = sb.cmd_env(
+        &["index", "--no-lsp", "--force", "."],
+        &[("CARTOG_AUTO_INIT", "1")],
+    );
+    assert!(reindex.status.success(), "the index must recover");
 
     let quarantined: Vec<_> = fs::read_dir(&dir)
         .unwrap()

--- a/crates/cartog/tests/self_update_test.rs
+++ b/crates/cartog/tests/self_update_test.rs
@@ -1321,15 +1321,18 @@ fn apply_pending_does_not_wait_on_a_foreign_peer_without_the_test_seam() {
     // can be named from an integration test.
     //
     // Measured on a warm spawn, 4+ runs each:
-    //   correct   (0 s budget) -> 260-272 ms
+    //   correct   (0 s budget) -> 260-272 ms isolated, up to ~1.07 s under a
+    //                             full-workspace run (process spawn contends)
     //   regressed (2 s tier)   -> ~2075 ms
-    // 1 s is half the 2 s tier: ~3.7x above the correct cluster and ~2x below
-    // the regressed one, so neither load jitter nor the regression sits near
-    // the line.
-    let bound = std::time::Duration::from_secs(1);
+    // 1.5 s sits above the loaded correct cluster and still ~1.4x below the
+    // regressed one. An earlier 1 s bound was derived from the isolated
+    // numbers only and flaked at 1.07 s in `cargo test --workspace`; measuring
+    // a wall-clock bound outside the load it will run under is the mistake
+    // that produced it.
+    let bound = std::time::Duration::from_millis(1500);
     assert!(
         elapsed < bound,
-        "took {elapsed:?} (bound {bound:?}, half the 2 s own-peer grace); an unclearable \
+        "took {elapsed:?} (bound {bound:?}, below the 2 s own-peer grace); an unclearable \
          foreign lock must wait out no peer budget at all"
     );
     let text = std::fs::read_to_string(&state_path).unwrap();


### PR DESCRIPTION
Closes #181, #182, #184. (#183's CI half landed on main as `2f76bac`.)

Each fix reproduced first, and every new guard mutation-tested.

## #182 — three README-parsing bugs (`df2cd96`)

**A self-contained HTML line swallowed the paragraph under it.** CommonMark runs an HTML block to the next blank line, which is right for a multi-line block, but the centered-logo README puts a complete `<img>` or `<br>` on its own line with the tagline directly beneath. The block rule ate exactly the prose the description exists to surface.

A line now ends its own block when it is both balanced and prose-free. Both halves matter: `<div>` still opens a block, and `<p>ignored</p>` stays one so its markup cannot become a description. My first attempt checked only balance and broke an existing test that pins that.

**An indented code block read as prose**, so a README opening with an install snippet stored the snippet. The indent check runs only where a paragraph could start, since inside one an indented line is a wrapped continuation.

**A link nested in image alt text leaked markup**: `![img in [link](u)](v)` left `](v)` behind.

## #184 — quarantine scope and an overselling doc (`7001c9f`)

`cartog projects list`, `cartog_list_projects` and `search --all` could all rename the user's `projects.sqlite`. Unpredictable for a read, and the reader gains nothing: the failed open already degrades to "no projects". Quarantine now belongs to the write path alone.

That left the write path as the only quarantiner with no test covering recovery there, so a corrupt registry could have stopped recovering entirely without a failure. Added one.

The module doc claimed the quarantined file "still holds every row the user accumulated". Under WAL it may not, since the sidecars are discarded. That discard is the deliberate cost of an ordering already documented on `rename_aside`, but the completeness promise was wrong.

## #181 — duplicate-row merge (`2052a6a`)

Reproduced first, which I had not managed when filing: a surviving row with `symbol_count = None` against a drifted row holding 8,134. `UPDATE OR IGNORE` cannot re-key onto an occupied id, and the upsert's `COALESCE` preserves only what the winner already holds.

The merge is per-column `COALESCE(survivor, loser)` over measurements and embedding state. Paths and the declared name/description are excluded: a stale row must not resurrect a description a later config cleared. A second test pins that the survivor's own values always win.

## Verification

| Gate | Result |
|---|---|
| `cargo test --workspace` | exit 0 |
| `cargo test --workspace --no-default-features` | exit 0 |
| `cargo test --doc --workspace` | exit 0 |
| clippy, both feature sets | exit 0 |
| `cargo fmt --check` | pass |

One cross-crate catch worth noting: an integration test in `cartog` asserted that `projects list` quarantines. Only the full workspace suite caught it, not the registry crate's own tests. Its valuable halves now run against a read (must leave the file alone) and a forced re-index (must recover).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Registry reads now leave corrupt files in place and report them as unavailable instead of renaming them.
  - Forced reindexing can recover from corrupt registry data while preserving the original bytes in a timestamped backup.
  - Duplicate registry records now retain available measurements and embedding counts during cleanup.
  - Project descriptions are parsed more accurately, including indented code, standalone HTML, and nested image alt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->