### PR TITLE
docs(readme): index the two docs missing from the Diataxis tree

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This documentation is organized by the [Diataxis](https://diataxis.fr) framework
 - [how-to/set-up-s3-sync.md](how-to/set-up-s3-sync.md) — remote push/pull via S3-compatible storage
 - [how-to/update-cartog.md](how-to/update-cartog.md) — upgrade, rollback, deferred updates
 - [how-to/wire-editors.md](how-to/wire-editors.md) — `cartog ide` and manual MCP config
+- [how-to/publish-vscode-extension.md](how-to/publish-vscode-extension.md) — maintainer runbook: publish the VS Code extension to the Marketplace + Open VSX
 
 ## Reference
 
@@ -37,6 +38,7 @@ This documentation is organized by the [Diataxis](https://diataxis.fr) framework
 
 ## Background docs
 
+- [usage.md](usage.md) — hub: search commands, plugin, agent skill, MCP server, agents
 - [product.md](product.md) — vision, target users, positioning
 - [tech.md](tech.md) — technology stack, dependencies, benchmarks
 - [structure.md](structure.md) — workspace layout and per-crate links


### PR DESCRIPTION
## What

Adds two existing docs to `docs/README.md`, the Diataxis index:

- `usage.md` — the hub doc, under Background docs
- `how-to/publish-vscode-extension.md` — the maintainer runbook, under How-to

## Why

Both files existed on disk but were absent from the index. `publish-vscode-extension.md`
was listed only in `how-to/README.md`; `usage.md` was in no index at all despite being
the hub the docs convention designates.

Beyond navigation, this had a machine-readable consequence: `site/src/lib/docs.ts`
generates `/llms-full.txt` by parsing `docs/README.md`'s bullet lists, so both pages
were invisible to coding agents fetching the index endpoint. Verified both now emit
with correctly rewritten GitHub `blob/` links.

Placement follows the existing scheme rather than reorganizing anything.

## Audit context

Found while auditing doc/code sync across the surfaces the contributor guide flags.
Everything else verified in sync against source (not against other docs): 28 CLI
commands, 5/3/4 subcommands, 16+2 MCP tools, 10 config sections across
`config.md`/`usage.astro`/`init.rs`, 18 languages, and the `~`-expansion prose
against `expand_tilde`.

## Checks

| Gate | Result |
|---|---|
| `make check` | pass |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | pass |
| `cargo test --no-default-features` | pass |
| `cargo test --doc --workspace` | pass |
| `npm run build` (site + `verify-machine-pages.mjs`) | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to the VS Code extension publishing runbook.
  * Added a link to the usage overview hub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->